### PR TITLE
docs: Add Docker setup instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,59 @@ Add this to your Claude Desktop `claude_desktop_config.json` file. See [Claude D
 }
 ```
 
+### Using Docker
+
+If you prefer to run the MCP server in a Docker container:
+
+1.  **Build the Docker Image:**
+
+    First, create a `Dockerfile` in the project root (or anywhere you prefer):
+
+    <details>
+    <summary>Click to see Dockerfile content</summary>
+
+    ```Dockerfile
+    FROM node:18-alpine
+
+    WORKDIR /app
+
+    # Install the latest version globally
+    RUN npm install -g @upstash/context7-mcp@latest
+
+    # Expose default port if needed (optional, depends on MCP client interaction)
+    # EXPOSE 3000
+
+    # Default command to run the server
+    CMD ["context7-mcp"]
+    ```
+
+    </details>
+
+    Then, build the image using a tag (e.g., `context7-mcp`). **Make sure Docker Desktop (or the Docker daemon) is running.** Run the following command in the same directory where you saved the `Dockerfile`:
+
+    ```bash
+    docker build -t context7-mcp .
+    ```
+
+2.  **Configure Your MCP Client:**
+
+    Update your MCP client's configuration to use the Docker command.
+
+    *Example for a cline_mcp_settings.json:*
+
+    ```json
+    {
+      "mcpServers": {
+        "Сontext7": {
+          "command": "docker",
+          "args": ["run", "-i", "--rm", "context7-mcp"],
+          "transportType": "stdio"
+        }
+      }
+    }
+    ```
+    *Note: This is an example configuration. Please refer to the specific examples for your MCP client (like Cursor, VS Code, etc.) earlier in this README to adapt the structure (e.g., `mcpServers` vs `servers`) and server name (`context7` vs `Context7`). Also, ensure the image name in `args` matches the tag used during the `docker build` command.*
+
 ### Available Tools
 
 - `resolve-library-id`: Resolves a general library name into a Context7-compatible library ID.

--- a/README.md
+++ b/README.md
@@ -199,6 +199,9 @@ If you prefer to run the MCP server in a Docker container:
     {
       "mcpServers": {
         "Сontext7": {
+        "autoApprove": [],
+        "disabled": false,
+        "timeout": 60,
           "command": "docker",
           "args": ["run", "-i", "--rm", "context7-mcp"],
           "transportType": "stdio"
@@ -206,7 +209,7 @@ If you prefer to run the MCP server in a Docker container:
       }
     }
     ```
-    *Note: This is an example configuration. Please refer to the specific examples for your MCP client (like Cursor, VS Code, etc.) earlier in this README to adapt the structure (e.g., `mcpServers` vs `servers`) and server name (`context7` vs `Context7`). Also, ensure the image name in `args` matches the tag used during the `docker build` command.*
+    *Note: This is an example configuration. Please refer to the specific examples for your MCP client (like Cursor, VS Code, etc.) earlier in this README to adapt the structure (e.g., `mcpServers` vs `servers`). Also, ensure the image name in `args` matches the tag used during the `docker build` command.*
 
 ### Available Tools
 


### PR DESCRIPTION
Hi @enesgules (and team)!

As requested in issue #19, this PR adds instructions for setting up and running the Context7 MCP server using Docker.

I initially shared these instructions in the issue thread after they helped me run the server, and you suggested creating a PR to add them to the official documentation.

**Changes:**

*   Added a new section `### Using Docker` under `## Getting Started` in `README.md`.
*   Included a sample `Dockerfile`.
*   Provided the `docker build` command (with notes about running Docker and using the correct directory).
*   Added an example configuration for MCP clients (like Cline) using `docker run`.
*   Included a note reminding users to adapt the configuration for their specific client based on existing examples.

This should provide users with a clear alternative method for running the server in an isolated environment.

Hope this is helpful! Let me know if any changes are needed.