### PR TITLE
docs: Add Zed installation instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,24 @@ Add this to your VS Code MCP config file. See [VS Code MCP docs](https://code.vi
 }
 ```
 
+### Install in Zed
+
+It can be installed via [Zed Extensions](https://zed.dev/extensions?query=Context7) or you can add this to your Zed `settings.json`. See [Zed Context Server docs](https://zed.dev/docs/assistant/context-servers) for more info.
+
+```json
+{
+  "context_servers": {
+    "Context7": {
+      "command": {
+        "path": "npx",
+        "args": ["-y", "@upstash/context7-mcp@latest"]
+      }
+      "settings": {}
+    }
+  }
+}
+```
+
 ### Install in Claude Code
 
 Run this command. See [Claude Code MCP docs](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/tutorials#set-up-model-context-protocol-mcp) for more info.


### PR DESCRIPTION
This PR updates the `README.md` file to include installation instructions for Zed. The changes provide clarity on how to configure Zed to use the Context7 context server.

