### PR TITLE
feat: Add environment variable support for minimum token configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,25 @@ If you prefer to run the MCP server in a Docker container:
     ```
     *Note: This is an example configuration. Please refer to the specific examples for your MCP client (like Cursor, VS Code, etc.) earlier in this README to adapt the structure (e.g., `mcpServers` vs `servers`). Also, ensure the image name in `args` matches the tag used during the `docker build` command.*
 
+### Environment Variables
+
+- `DEFAULT_MINIMUM_TOKENS`: Set the minimum token count for documentation retrieval (default: 5000).
+
+Examples:
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp@latest"],
+      "env": {
+        "DEFAULT_MINIMUM_TOKENS": "10000"
+      }
+    }
+  }
+}
+```
+
 ### Available Tools
 
 - `resolve-library-id`: Resolves a general library name into a Context7-compatible library ID.
@@ -236,7 +255,7 @@ If you prefer to run the MCP server in a Docker container:
 - `get-library-docs`: Fetches documentation for a library using a Context7-compatible library ID.
   - `context7CompatibleLibraryID` (required)
   - `topic` (optional): Focus the docs on a specific topic (e.g., "routing", "hooks")
-  - `tokens` (optional, default 5000): Max number of tokens to return. Values less than 5000 are automatically increased to 5000.
+  - `tokens` (optional, default 5000): Max number of tokens to return. Values less than the configured `DEFAULT_MINIMUM_TOKENS` value are automatically increased to that value.
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "homepage": "https://github.com/upstash/context7#readme",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.8.0",
+    "dotenv": "^16.5.0",
     "zod": "^3.24.2"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,8 +5,23 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod";
 import { searchLibraries, fetchLibraryDocumentation } from "./lib/api.js";
 import { formatSearchResults } from "./lib/utils.js";
+import dotenv from "dotenv";
 
-const DEFAULT_MINIMUM_TOKENS = 5000;
+// Load environment variables from .env file if present
+dotenv.config();
+
+// Get DEFAULT_MINIMUM_TOKENS from environment variable or use default
+let DEFAULT_MINIMUM_TOKENS = 5000;
+if (process.env.DEFAULT_MINIMUM_TOKENS) {
+  const parsedValue = parseInt(process.env.DEFAULT_MINIMUM_TOKENS, 10);
+  if (!isNaN(parsedValue) && parsedValue > 0) {
+    DEFAULT_MINIMUM_TOKENS = parsedValue;
+  } else {
+    console.error(
+      `Warning: Invalid DEFAULT_MINIMUM_TOKENS value provided in environment variable. Using default value of 5000`
+    );
+  }
+}
 
 // Create server instance
 const server = new McpServer({


### PR DESCRIPTION
closes #130 

This PR introduces support for configuring the `DEFAULT_MINIMUM_TOKENS` value via environment variables. The primary changes updating the logic for determining the default token count, and improving the README with examples and explanations.

before:
<img width="412" alt="Screenshot 2025-05-01 at 21 45 07" src="https://github.com/user-attachments/assets/4bb86c4d-ee60-437e-b577-4ca0030e5b24" />

after:
<img width="417" alt="Screenshot 2025-05-01 at 21 43 31" src="https://github.com/user-attachments/assets/791f536b-ab44-4fc3-aaf2-8903bdc3f1d1" />

