### PR TITLE
Docs: Add BoltAI Installation and Usage Instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,23 @@ Add this to your Claude Desktop `claude_desktop_config.json` file. See [Claude D
 }
 ```
 
+### Install in BoltAI
+
+Open the "Settings" page of the app, navigate to "Plugins," and enter the following JSON:
+
+```json
+{
+	"mcpServers": {
+		"context7": {
+			"args": ["-y", "@upstash/context7-mcp@latest"],
+			"command": "npx"
+		}
+	}
+}
+```
+
+Once saved, enter in the chat `get-library-docs` followed by your Context7 documentation ID (e.g., `get-library-docs /nuxt/ui`). More information is available on [BoltAI's Documentation site](https://docs.boltai.com/docs/plugins/mcp-servers). For BoltAI on iOS, [see this guide](https://docs.boltai.com/docs/boltai-mobile/mcp-servers).
+
 ### Using Docker
 
 If you prefer to run the MCP server in a Docker container:


### PR DESCRIPTION
This pull request adds a new section to the `README.md` detailing installing and using Context7 as an MCP server with BoltAI.

**Changes:**

*   A new "Install in BoltAI" section has been added to `README.md`.
*   This section includes:
    *   JSON configuration for setting up Context7 in BoltAI's plugin settings.
    *   A brief example of how to use the `get-library-docs` command.
    *   Links to relevant BoltAI documentation for desktop and iOS.

This addition aims to make it easier for BoltAI users to integrate and utilize Context7 to access library documentation.

Please review the changes.

Thank you,

@thaikolja