### PR TITLE
feat: upgrade to http on smithery

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,12 @@ COPY package.json ./
 # Install only production dependencies
 RUN npm install --production --ignore-scripts
 
-# Expose no ports (stdio only)
+# Set default environment variables for HTTP mode
+ENV MCP_TRANSPORT=http
+ENV PORT=8080
+
+# Expose HTTP port
+EXPOSE 8080
 
 # Default command
 CMD ["node", "dist/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,10 +27,10 @@ RUN npm install --production --ignore-scripts
 
 # Set default environment variables for HTTP mode
 ENV MCP_TRANSPORT=http
-ENV PORT=8080
+ENV PORT=3000
 
 # Expose HTTP port
-EXPOSE 8080
+EXPOSE 3000
 
 # Default command
 CMD ["node", "dist/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,10 +27,10 @@ RUN npm install --production --ignore-scripts
 
 # Set default environment variables for HTTP mode
 ENV MCP_TRANSPORT=http
-ENV PORT=3000
+ENV PORT=8080
 
 # Expose HTTP port
-EXPOSE 3000
+EXPOSE 8080
 
 # Default command
 CMD ["node", "dist/index.js"]

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "tsc && chmod 755 dist/index.js",
     "format": "prettier --write .",
-    "lint": "eslint \"**/*.{js,ts,tsx}\" --fix"
+    "lint": "eslint \"**/*.{js,ts,tsx}\" --fix",
+    "start": "MCP_TRANSPORT=http node dist/index.js"
   },
   "repository": {
     "type": "git",

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,13 +1,9 @@
 # Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
 
 startCommand:
-  type: stdio
+  type: http
   configSchema:
     # JSON Schema defining the configuration options for the MCP.
     type: object
-    description: Empty configuration
-  commandFunction:
-    # A JS function that produces the CLI command based on the given config to start the MCP on stdio.
-    |-
-    (config) => ({ command: 'node', args: ['dist/index.js'] })
+    description: No configuration required
   exampleConfig: {}


### PR DESCRIPTION
PR upgrades the context7 server hosted in smithery to run natively on HTTP, allowing it to scale and provide a better user experience. Here is a working test deployment: https://smithery.ai/server/@arjunkmrm/context7

Deployment should automatically start once you merge this PR (you can also turn this feature off at the settings page).