### PR TITLE
docs: change VS Code usage snippet for context7 mcp server

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,8 +153,8 @@ Add this to your VS Code MCP config file. See [VS Code MCP docs](https://code.vi
 #### VS Code Remote Server Connection
 
 ```json
-{
-  "mcpServers": {
+"mcp": {
+  "servers": {
     "context7": {
       "type": "http",
       "url": "https://mcp.context7.com/mcp"
@@ -166,9 +166,9 @@ Add this to your VS Code MCP config file. See [VS Code MCP docs](https://code.vi
 #### VS Code Local Server Connection
 
 ```json
-{
+"mcp": {
   "servers": {
-    "Context7": {
+    "context7": {
       "type": "stdio",
       "command": "npx",
       "args": ["-y", "@upstash/context7-mcp"]


### PR DESCRIPTION
According to VSCode mcp Docs, I changed some snippets for that.