### PR TITLE
feat: Add repository accept/reject list filtering to search API

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,26 @@ Add this to your Roo Code MCP configuration file. See [Roo Code MCP docs](https:
 The Context7 MCP server supports the following environment variables:
 
 - `DEFAULT_MINIMUM_TOKENS`: Set the minimum token count for documentation retrieval (default: 10000)
+- `REPO_ACCEPT_LIST`: Comma-separated list of repository patterns to include (whitelist). Supports glob patterns with `*` and `?`
+- `REPO_REJECT_LIST`: Comma-separated list of repository patterns to exclude (blacklist). Supports glob patterns with `*` and `?`
+
+### Repository Filtering
+
+You can filter which repositories are included in search results using accept and reject lists:
+
+- **Accept List**: Only repositories matching these patterns will be included
+- **Reject List**: Repositories matching these patterns will be excluded
+- **Pattern Matching**: Supports glob-style patterns:
+  - `*` matches any characters
+  - `?` matches single character
+  - Patterns are case-insensitive
+
+Examples:
+
+- `github.com/vercel/next.js` - exact match
+- `github.com/vercel/*` - all Vercel repositories
+- `*.js` - all repositories ending with .js
+- `github.com/microsoft/*` - all Microsoft repositories
 
 Example configuration with environment variables:
 
@@ -435,7 +455,25 @@ Example configuration with environment variables:
       "command": "npx",
       "args": ["-y", "@upstash/context7-mcp"],
       "env": {
-        "DEFAULT_MINIMUM_TOKENS": "6000"
+        "DEFAULT_MINIMUM_TOKENS": "6000",
+        "REPO_ACCEPT_LIST": "github.com/vercel/next.js,github.com/facebook/react",
+        "REPO_REJECT_LIST": "*/legacy-*,*/deprecated-*"
+      }
+    }
+  }
+}
+```
+
+Or to only allow Next.js documentation:
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp"],
+      "env": {
+        "REPO_ACCEPT_LIST": "github.com/vercel/next.js"
       }
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,17 @@ if (process.env.DEFAULT_MINIMUM_TOKENS) {
   }
 }
 
+// Log repository filtering configuration if present
+if (process.env.REPO_ACCEPT_LIST || process.env.REPO_REJECT_LIST) {
+  console.warn("Repository filtering enabled:");
+  if (process.env.REPO_ACCEPT_LIST) {
+    console.warn(`  Accept list: ${process.env.REPO_ACCEPT_LIST}`);
+  }
+  if (process.env.REPO_REJECT_LIST) {
+    console.warn(`  Reject list: ${process.env.REPO_REJECT_LIST}`);
+  }
+}
+
 // Store SSE transports by session ID
 const sseTransports: Record<string, SSEServerTransport> = {};
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,7 +1,77 @@
-import { SearchResponse } from "./types.js";
+import { SearchResponse, SearchResult } from "./types.js";
 
 const CONTEXT7_API_BASE_URL = "https://context7.com/api";
 const DEFAULT_TYPE = "txt";
+
+/**
+ * Parse repository filter lists from environment variables
+ * @returns Object containing acceptList and rejectList arrays
+ */
+function parseRepositoryFilters(): { acceptList: string[]; rejectList: string[] } {
+  const acceptList = process.env.REPO_ACCEPT_LIST
+    ? process.env.REPO_ACCEPT_LIST.split(",")
+        .map((repo) => repo.trim())
+        .filter(Boolean)
+    : [];
+
+  const rejectList = process.env.REPO_REJECT_LIST
+    ? process.env.REPO_REJECT_LIST.split(",")
+        .map((repo) => repo.trim())
+        .filter(Boolean)
+    : [];
+
+  return { acceptList, rejectList };
+}
+
+/**
+ * Check if a repository matches any pattern in a list
+ * @param repoId - The repository ID to test
+ * @param patterns - Array of glob-like patterns to match against
+ * @returns True if the repository ID matches any pattern
+ */
+function matchesPattern(repoId: string, patterns: string[]): boolean {
+  return patterns.some((pattern) => {
+    let normalizedPattern = pattern;
+    if (pattern.includes("github.com/")) {
+      normalizedPattern = pattern.replace("github.com/", "");
+    }
+
+    const regexPattern = normalizedPattern
+      .replace(/\./g, "\\.")
+      .replace(/\*/g, ".*")
+      .replace(/\?/g, ".");
+
+    const regex = new RegExp(`^${regexPattern}$`, "i");
+    return regex.test(repoId);
+  });
+}
+
+/**
+ * Filter search results based on repository accept/reject lists
+ * @param results - Array of search results to filter
+ * @returns Filtered array of search results
+ */
+function filterRepositories(results: SearchResult[]): SearchResult[] {
+  const { acceptList, rejectList } = parseRepositoryFilters();
+
+  if (acceptList.length === 0 && rejectList.length === 0) {
+    return results;
+  }
+
+  return results.filter((result) => {
+    const repoId = result.id.startsWith("/") ? result.id.slice(1) : result.id;
+
+    if (rejectList.length > 0 && matchesPattern(repoId, rejectList)) {
+      return false;
+    }
+
+    if (acceptList.length > 0) {
+      return matchesPattern(repoId, acceptList);
+    }
+
+    return true;
+  });
+}
 
 /**
  * Searches for libraries matching the given query
@@ -28,7 +98,13 @@ export async function searchLibraries(query: string): Promise<SearchResponse> {
         error: `Failed to search libraries. Please try again later. Error code: ${errorCode}`,
       } as SearchResponse;
     }
-    return await response.json();
+    const searchResponse = await response.json();
+
+    if (searchResponse.results) {
+      searchResponse.results = filterRepositories(searchResponse.results);
+    }
+
+    return searchResponse;
   } catch (error) {
     console.error("Error searching libraries:", error);
     return { results: [], error: `Error searching libraries: ${error}` } as SearchResponse;


### PR DESCRIPTION
closes #247 

This PR introduces a repository filtering feature to the Context7 MCP server, allowing users to include or exclude repositories from search results based on specified patterns.

| Before | After |
|---|---|
| <img width="542" alt="Screenshot 2025-06-09 at 11 41 35" src="https://github.com/user-attachments/assets/60f609c9-c5cf-4236-b628-0e9c64884d49" /> | <img width="544" alt="Screenshot 2025-06-09 at 11 42 19" src="https://github.com/user-attachments/assets/3f65081f-48a7-4527-913d-94e3cd0d248d" /> |

