### PR TITLE
fix: InitializeResult schema mismatch in Context7 server response

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,15 +48,16 @@ const sseTransports: Record<string, SSEServerTransport> = {};
 
 // Function to create a new server instance with all tools registered
 function createServerInstance() {
-  const server = new McpServer({
-    name: "Context7",
-    description: "Retrieves up-to-date documentation and code examples for any library.",
-    version: "1.0.13",
-    capabilities: {
-      resources: {},
-      tools: {},
+  const server = new McpServer(
+    {
+      name: "Context7",
+      version: "1.0.13",
     },
-  });
+    {
+      instructions:
+        "Use this server to retrieve up-to-date documentation and code examples for any library.",
+    }
+  );
 
   // Register Context7 tools
   server.tool(


### PR DESCRIPTION
The response from the server was not matching the expected `InitializeResult` schema [^1].

1. The `serverInfo` field contained a `description` that was not part of the schema.
2. The `capabilities` field was incorrectly nested in `serverInfo`.
3. The `capabilities` field in the response included `resources`, even though this server does not support resources.

This change also adds an `instructions` field to the response, which provides guidance on how to use the server.

The SDK takes care of registering capabilities [^2], so we don't need to add this when instantiating the `server` object.

Response does not match `InitializeResult` schema:

```json
{
  "capabilities": {
    "tools": {
      "listChanged": true
    }
  },
  "serverInfo": {
    "name": "Context7",
    "version": "1.0.13",
    "description": "Retrieves up-to-date documentation and code examples for any library.",
    "capabilities": {
      "resources": {},
      "tools": {}
    }
  }
}
```

Response matches `InitializeResult` schema:

```json
{
  "capabilities": {
    "tools": {
      "listChanged": true
    }
  },
  "serverInfo": {
    "name": "Context7",
    "version": "1.0.13"
  },
  "instructions": "Use this server to retrieve up-to-date documentation and code examples for any library."
}
```

[^1]: https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/schema/2025-03-26/schema.ts#L179-L193

[^2]: https://github.com/modelcontextprotocol/typescript-sdk/blob/2cf4f0ca86ff841aca53ac8ef5f3227ba3789386/src/server/mcp.ts#L101

Fixes #282