### PR TITLE
chore: update deno readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Pasting the following configuration into your Cursor `~/.cursor/mcp.json` file i
   "mcpServers": {
     "context7": {
       "command": "deno",
-      "args": ["run", "--allow-env", "--allow-net", "npm:@upstash/context7-mcp"]
+      "args": ["run", "--allow-env=NO_DEPRECATION,TRACE_DEPRECATION", "--allow-net", "npm:@upstash/context7-mcp"]
     }
   }
 }


### PR DESCRIPTION
There's no reason to allow broad based access to all environment variables. As of right now, there is only the downstream dependency depd (https://github.com/dougwilson/nodejs-depd) which require the NO_DEPRECATION, TRACE_DEPRECATION. Lets limit the env variables to just this alone.

Also it advisible to setup some sort of CI to ensure these always work.