### PR TITLE
feat: Add accept-list and reject-list repo filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,11 +539,64 @@ bun run dist/index.js
 
 - `--transport <stdio|http|sse>` – Transport to use (`stdio` by default).
 - `--port <number>` – Port to listen on when using `http` or `sse` transport (default `3000`).
+- `--accept-list <repos...>` – Only include repositories matching these patterns (supports wildcards: `*` and `?`).
+- `--reject-list <repos...>` – Exclude repositories matching these patterns (supports wildcards: `*` and `?`).
 
-Example with http transport and port 8080:
+#### Examples
 
+Basic usage with http transport and port 8080:
 ```bash
 bun run dist/index.js --transport http --port 8080
+```
+
+Only include Next.js repository:
+```bash
+bun run dist/index.js --accept-list vercel/next.js
+```
+
+Include only repositories from Vercel and TanStack:
+```bash
+bun run dist/index.js --accept-list vercel/* tanstack/*
+```
+
+Exclude deprecated repositories:
+```bash
+bun run dist/index.js --reject-list */deprecated-*
+```
+
+Combine accept and reject lists:
+```bash
+bun run dist/index.js --accept-list vercel/* --reject-list */legacy-* --transport http
+```
+
+For JSON configuration files, use single-string format:
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "command": "npx",
+      "args": [
+        "@upstash/context7-mcp",
+        "--accept-list vercel/next.js"
+      ]
+    }
+  }
+}
+```
+
+Multiple repositories in JSON configuration:
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "command": "npx",
+      "args": [
+        "@upstash/context7-mcp",
+        "--accept-list vercel/* tanstack/*"
+      ]
+    }
+  }
+}
 ```
 
 <details>


### PR DESCRIPTION
Closes #247 

This PR introduces new filtering capabilities to the CLI tool for repository selection and updates the documentation accordingly. It adds support for `--accept-list` and `--reject-list` options, enabling users to include or exclude repositories based on patterns. Additionally, it integrates these filters into the search results processing logic and enhances the user experience with detailed feedback about applied filters.

| Before | After |
|---|---|
| <img width="480" alt="Screenshot 2025-06-13 at 22 08 49" src="https://github.com/user-attachments/assets/14c69aad-f03a-4d0b-8638-4f0fad9f66f6" /> | <img width="484" alt="Screenshot 2025-06-13 at 22 04 42" src="https://github.com/user-attachments/assets/d537c2f5-90fb-4541-a777-84b2136680ed" /> |
