### PR TITLE
Add MCP Linker badge to README.md allow user add context7-mcp to any clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,17 @@ You can find your Smithery key in the [Smithery.ai webpage](https://smithery.ai/
 </details>
 
 <details>
+<summary><b>Installing via MCP Linker</b></summary>
+
+#### Add to local mcp clients
+
+Built-in support for Claude Code, Desktop, Cursor, VS Code, Cline, Roo Code, Windsurf, and custom mcp.json.
+
+[![mcp-linker-add](https://img.shields.io/badge/mcp--linker-add-blue?logo=link&style=for-the-badge)](https://www.mcp-linker.store/install-app?name=context7&autoSubmit=true&config=eyJjb250ZXh0NyI6eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsIkB1cHN0YXNoL2NvbnRleHQ3LW1jcCJdfX0=)
+
+</details>
+
+<details>
 <summary><b>Install in Cursor</b></summary>
 
 Go to: `Settings` -> `Cursor Settings` -> `MCP` -> `Add new global MCP server`


### PR DESCRIPTION
… detailing support for various local mcp clients.

This badge allow user use [mcp-linker](http://github.com/milisp/mcp-linker) to add context7-mcp to any clients with config

> `autoSubmit=true` will auto add to selected client

[![mcp-linker-add](https://img.shields.io/badge/mcp--linker-add-blue?logo=link&style=for-the-badge)](https://www.mcp-linker.store/install-app?name=context7&autoSubmit=true&config=eyJjb250ZXh0NyI6eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsIkB1cHN0YXNoL2NvbnRleHQ3LW1jcCJdfX0=)

```json
{
  "context7": {
    "command": "npx",
    "args": ["-y", "@upstash/context7-mcp"]
  }
}
```

Built-in support for Claude Code, Desktop, Cursor, VS Code, Cline, Roo Code, Windsurf, and custom mcp.json.