### PR TITLE
docs: add remote server install instructions for Gemini CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,18 @@ See [Gemini CLI Configuration](https://github.com/google-gemini/gemini-cli/blob/
 {
   "mcpServers": {
     "context7": {
+      "httpUrl": "https://mcp.context7.com/mcp"
+    }
+  }
+}
+```
+
+Or, for a local server:
+
+```json
+{
+  "mcpServers": {
+    "context7": {
       "command": "npx",
       "args": ["-y", "@upstash/context7-mcp"]
     }


### PR DESCRIPTION
Gemini CLI added support for remote MCP servers via Custom HTTP headers in version 0.1.8 with commit #2477, but usage instructions are not updated on their MCP server tutorial page yet, neither on here as well. 

I've tested and remote MCP server for context7 works with Gemini CLI.