### PR TITLE
docs: Add installation instructions for Copilot Coding Agent across multiple language README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -706,6 +706,32 @@ Add this to your Opencode configuration file. See [Opencode MCP docs](https://op
 
 </details>
 
+<details>
+<summary><b>Install in Copilot Coding Agent</b></summary>
+
+## Using Context7 with Copilot Coding Agent
+
+Add the following configuration to the `mcp` section of your Copilot Coding Agent configuration file Repository->Settings->Copilot->Coding agent->MCP configuration:
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp",
+      "tools": [
+        "get-library-docs",
+        "resolve-library-id"
+      ]
+    }
+  }
+}
+```
+
+For more information, see the [official GitHub documentation](https://docs.github.com/en/enterprise-cloud@latest/copilot/how-tos/agents/copilot-coding-agent/extending-copilot-coding-agent-with-mcp).
+
+</details>
+
 ## 🔨 Available Tools
 
 Context7 MCP provides the following tools that LLMs can use:

--- a/docs/README.ar.md
+++ b/docs/README.ar.md
@@ -165,6 +165,27 @@ claude mcp add context7 -- npx -y @upstash/context7-mcp@latest
 }
 ```
 
+### التثبيت في Copilot Coding Agent
+
+أضف التكوين التالي إلى قسم `mcp` في ملف إعدادات Copilot Coding Agent الخاص بك Repository->Settings->Copilot->Coding agent->MCP configuration:
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp",
+      "tools": [
+        "get-library-docs",
+        "resolve-library-id"
+      ]
+    }
+  }
+}
+```
+
+لمزيد من المعلومات، راجع [التوثيق الرسمي على GitHub](https://docs.github.com/en/enterprise-cloud@latest/copilot/how-tos/agents/copilot-coding-agent/extending-copilot-coding-agent-with-mcp).
+
 ### باستخدام Docker
 
 **Dockerfile:**

--- a/docs/README.de.md
+++ b/docs/README.de.md
@@ -171,6 +171,28 @@ Füge dies zu deiner Claude Desktop `claude_desktop_config.json` Datei hinzu. Si
 }
 ```
 
+
+### Installation im Copilot Coding Agent
+
+Füge die folgende Konfiguration zum Abschnitt `mcp` deiner Copilot Coding Agent-Konfigurationsdatei hinzu (Repository->Settings->Copilot->Coding agent->MCP configuration):
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp",
+      "tools": [
+        "get-library-docs",
+        "resolve-library-id"
+      ]
+    }
+  }
+}
+```
+
+Weitere Informationen findest du in der [offiziellen GitHub-Dokumentation](https://docs.github.com/en/enterprise-cloud@latest/copilot/how-tos/agents/copilot-coding-agent/extending-copilot-coding-agent-with-mcp).
+
 ### Docker verwenden
 
 Wenn du den MCP-Server lieber in einem Docker-Container ausführen möchtest:

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -153,6 +153,28 @@ Añade esto a tu archivo `claude_desktop_config.json` de Claude Desktop. Consult
 }
 ```
 
+### Instalar en Copilot Coding Agent
+
+Agrega la siguiente configuración a la sección `mcp` de tu archivo de configuración de Copilot Coding Agent (Repository->Settings->Copilot->Coding agent->MCP configuration):
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp",
+      "tools": [
+        "get-library-docs",
+        "resolve-library-id"
+      ]
+    }
+  }
+}
+```
+
+Para más información, consulta la [documentación oficial de GitHub](https://docs.github.com/en/enterprise-cloud@latest/copilot/how-tos/agents/copilot-coding-agent/extending-copilot-coding-agent-with-mcp).
+
+
 ### Herramientas Disponibles
 
 - `resolve-library-id`: Resuelve un nombre de una biblioteca general en un ID de biblioteca compatible con Context7.

--- a/docs/README.fr.md
+++ b/docs/README.fr.md
@@ -156,6 +156,8 @@ Exécutez cette commande. Voir la [documentation Claude Code MCP](https://docs.a
 claude mcp add context7 -- npx -y @upstash/context7-mcp@latest
 ```
 
+
+
 ### Installation dans Claude Desktop
 
 Ajoutez ceci à votre fichier `claude_desktop_config.json`. Voir la [documentation Claude Desktop MCP](https://modelcontextprotocol.io/quickstart/user).
@@ -187,6 +189,27 @@ Ouvrez la page "Settings" de l'application, naviguez jusqu'à "Plugins", et entr
 ```
 
 Une fois enregistré, saisissez dans le chat `get-library-docs` suivi de votre ID de documentation Context7 (par exemple, `get-library-docs /nuxt/ui`). Plus d'informations sont disponibles sur le [site de documentation BoltAI](https://docs.boltai.com/docs/plugins/mcp-servers). Pour BoltAI sur iOS, [consultez ce guide](https://docs.boltai.com/docs/boltai-mobile/mcp-servers).
+
+### Installation dans Copilot Coding Agent
+
+Ajoutez la configuration suivante à la section `mcp` de votre fichier de configuration Copilot Coding Agent (Repository->Settings->Copilot->Coding agent->MCP configuration) :
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp",
+      "tools": [
+        "get-library-docs",
+        "resolve-library-id"
+      ]
+    }
+  }
+}
+```
+
+Pour plus d'informations, consultez la [documentation officielle GitHub](https://docs.github.com/en/enterprise-cloud@latest/copilot/how-tos/agents/copilot-coding-agent/extending-copilot-coding-agent-with-mcp).
 
 ### Utilisation avec Docker
 

--- a/docs/README.id-ID.md
+++ b/docs/README.id-ID.md
@@ -175,6 +175,27 @@ Tambahkan ini ke file `claude_desktop_config.json` Claude Desktop Anda. Lihat [D
 }
 ```
 
+### Instalasi di Copilot Coding Agent
+
+Tambahkan konfigurasi berikut ke bagian `mcp` pada file konfigurasi Copilot Coding Agent Anda (Repository->Settings->Copilot->Coding agent->MCP configuration):
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp",
+      "tools": [
+        "get-library-docs",
+        "resolve-library-id"
+      ]
+    }
+  }
+}
+```
+
+Untuk informasi lebih lanjut, lihat [dokumentasi resmi GitHub](https://docs.github.com/en/enterprise-cloud@latest/copilot/how-tos/agents/copilot-coding-agent/extending-copilot-coding-agent-with-mcp).
+
 ### Menggunakan Docker
 
 Jika Anda lebih suka menjalankan server MCP dalam kontainer Docker:

--- a/docs/README.it.md
+++ b/docs/README.it.md
@@ -173,6 +173,27 @@ Aggiungi questo al tuo file `claude_desktop_config.json` di Claude Desktop. Vedi
 }
 ```
 
+### Installazione in Copilot Coding Agent
+
+Aggiungi la seguente configurazione alla sezione `mcp` del file di configurazione di Copilot Coding Agent (Repository->Settings->Copilot->Coding agent->MCP configuration):
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp",
+      "tools": [
+        "get-library-docs",
+        "resolve-library-id"
+      ]
+    }
+  }
+}
+```
+
+Per maggiori informazioni, consulta la [documentazione ufficiale GitHub](https://docs.github.com/en/enterprise-cloud@latest/copilot/how-tos/agents/copilot-coding-agent/extending-copilot-coding-agent-with-mcp).
+
 ### Utilizzo di Docker
 
 Se preferisci eseguire il server MCP in un contenitore Docker:

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -321,6 +321,30 @@ claude mcp add context7 -- npx -y @upstash/context7-mcp
 </details>
 
 <details>
+<summary><b>Copilot Coding Agent へのインストール</b></summary>
+
+以下の設定を Copilot Coding Agent の `mcp` セクション（Repository->Settings->Copilot->Coding agent->MCP configuration）に追加してください：
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp",
+      "tools": [
+        "get-library-docs",
+        "resolve-library-id"
+      ]
+    }
+  }
+}
+```
+
+詳細は [公式 GitHub ドキュメント](https://docs.github.com/en/enterprise-cloud@latest/copilot/how-tos/agents/copilot-coding-agent/extending-copilot-coding-agent-with-mcp) をご覧ください。
+
+</details>
+
+<details>
 <summary><b>Docker を使用</b></summary>
 
 MCP サーバーを Docker コンテナで実行したい場合：

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -400,6 +400,30 @@ Claude Desktop의 `claude_desktop_config.json` 파일에 다음을 추가하세�
 </details>
 
 <details>
+<summary><b>Copilot Coding Agent 설치</b></summary>
+
+아래 설정을 Copilot Coding Agent의 `mcp` 섹션(Repository->Settings->Copilot->Coding agent->MCP configuration)에 추가하세요:
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp",
+      "tools": [
+        "get-library-docs",
+        "resolve-library-id"
+      ]
+    }
+  }
+}
+```
+
+자세한 내용은 [공식 GitHub 문서](https://docs.github.com/en/enterprise-cloud@latest/copilot/how-tos/agents/copilot-coding-agent/extending-copilot-coding-agent-with-mcp)를 참고하세요.
+
+</details>
+
+<details>
 <summary><b>Docker 사용하기</b></summary>
 
 MCP 서버를 Docker 컨테이너에서 실행하려면:

--- a/docs/README.pt-BR.md
+++ b/docs/README.pt-BR.md
@@ -173,6 +173,27 @@ Adicione isto ao seu arquivo `claude_desktop_config.json` do Claude Desktop. Vej
 }
 ```
 
+### Instalação no Copilot Coding Agent
+
+Adicione a seguinte configuração à seção `mcp` do seu arquivo de configuração do Copilot Coding Agent (Repository->Settings->Copilot->Coding agent->MCP configuration):
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp",
+      "tools": [
+        "get-library-docs",
+        "resolve-library-id"
+      ]
+    }
+  }
+}
+```
+
+Para mais informações, consulte a [documentação oficial do GitHub](https://docs.github.com/en/enterprise-cloud@latest/copilot/how-tos/agents/copilot-coding-agent/extending-copilot-coding-agent-with-mcp).
+
 ### Usando Docker
 
 Se você preferir executar o servidor MCP em um contêiner Docker:

--- a/docs/README.ru.md
+++ b/docs/README.ru.md
@@ -186,6 +186,27 @@ claude mcp add context7 -- npx -y @upstash/context7-mcp
 }
 ```
 
+### Установка в Copilot Coding Agent
+
+Добавьте следующую конфигурацию в секцию `mcp` вашего файла настроек Copilot Coding Agent (Repository->Settings->Copilot->Coding agent->MCP configuration):
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp",
+      "tools": [
+        "get-library-docs",
+        "resolve-library-id"
+      ]
+    }
+  }
+}
+```
+
+Подробнее см. в [официальной документации GitHub](https://docs.github.com/en/enterprise-cloud@latest/copilot/how-tos/agents/copilot-coding-agent/extending-copilot-coding-agent-with-mcp).
+
 ### Используя Docker
 
 Если вы предпочитаете запускать MCP сервер в Docker контейнере:

--- a/docs/README.tr.md
+++ b/docs/README.tr.md
@@ -173,6 +173,27 @@ Bunu Claude Desktop `claude_desktop_config.json` dosyanıza ekleyin. Daha fazla 
 }
 ```
 
+### Copilot Coding Agent Kurulumu
+
+Aşağıdaki yapılandırmayı Copilot Coding Agent'ın `mcp` bölümüne ekleyin (Repository->Settings->Copilot->Coding agent->MCP configuration):
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp",
+      "tools": [
+        "get-library-docs",
+        "resolve-library-id"
+      ]
+    }
+  }
+}
+```
+
+Daha fazla bilgi için [resmi GitHub dokümantasyonuna](https://docs.github.com/en/enterprise-cloud@latest/copilot/how-tos/agents/copilot-coding-agent/extending-copilot-coding-agent-with-mcp) bakabilirsiniz.
+
 ### Docker Kullanımı
 
 MCP sunucusunu bir Docker konteynerinde çalıştırmayı tercih ederseniz:

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -171,6 +171,27 @@ claude mcp add context7 -- npx -y @upstash/context7-mcp@latest
 }
 ```
 
+### 在 Copilot Coding Agent 中安装
+
+将以下配置添加到 Copilot Coding Agent 的 `mcp` 配置部分（Repository->Settings->Copilot->Coding agent->MCP configuration）：
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp",
+      "tools": [
+        "get-library-docs",
+        "resolve-library-id"
+      ]
+    }
+  }
+}
+```
+
+更多信息请参见[官方GitHub文档](https://docs.github.com/en/enterprise-cloud@latest/copilot/how-tos/agents/copilot-coding-agent/extending-copilot-coding-agent-with-mcp)。
+
 ### 使用Docker（容器部署）
 
 如果你希望使用Docker容器运行MCP服务器：

--- a/docs/README.zh-TW.md
+++ b/docs/README.zh-TW.md
@@ -270,6 +270,30 @@ claude mcp add context7 -- npx -y @upstash/context7-mcp
 </details>
 
 <details>
+<summary><b>在 Copilot Coding Agent 安裝</b></summary>
+
+請將以下設定加入 Copilot Coding Agent 的 `mcp` 設定區塊（Repository->Settings->Copilot->Coding agent->MCP configuration）：
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp",
+      "tools": [
+        "get-library-docs",
+        "resolve-library-id"
+      ]
+    }
+  }
+}
+```
+
+更多資訊請參見[官方 GitHub 文件](https://docs.github.com/en/enterprise-cloud@latest/copilot/how-tos/agents/copilot-coding-agent/extending-copilot-coding-agent-with-mcp)。
+
+</details>
+
+<details>
 <summary><b>使用 Docker</b></summary>
 
 若你偏好在 Docker 容器中執行 MCP 伺服器：


### PR DESCRIPTION
This pull request updates the documentation to include instructions for integrating Context7 MCP with the Copilot Coding Agent. The changes add configuration examples and references to the official GitHub documentation across multiple language-specific README files.

### Documentation Updates for Context7 MCP Integration:

* **English Documentation**:
  - Added a section in `README.md` with detailed steps to configure Context7 MCP in the Copilot Coding Agent, including an example JSON configuration and a link to the official GitHub documentation.

* **Localized Documentation**:
  - Added similar configuration instructions for Context7 MCP integration in the following language-specific files:
    - Arabic (`docs/README.ar.md`)
    - German (`docs/README.de.md`)
    - Spanish (`docs/README.es.md`)
    - French (`docs/README.fr.md`)
    - Indonesian (`docs/README.id-ID.md`)
    - Italian (`docs/README.it.md`)
    - Japanese (`docs/README.ja.md`)
    - Korean (`docs/README.ko.md`)
    - Portuguese (Brazil) (`docs/README.pt-BR.md`)
    - Russian (`docs/README.ru.md`)
    - Turkish (`docs/README.tr.md`)
    - Simplified Chinese (`docs/README.zh-CN.md`)
    - Traditional Chinese (`docs/README.zh-TW.md`)