### PR TITLE
Honor https_proxy environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -965,6 +965,10 @@ Context7 MCP provides the following tools that LLMs can use:
 >
 > The slash syntax tells the MCP tool exactly which library to load docs for.
 
+### HTTPS Proxy
+
+For users behind a http proxy, context7 should honor the standard https_proxy/HTTPS_PROXY environment variables.
+
 ## 💻 Development
 
 Clone the project and install dependencies:

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",
         "commander": "^14.0.0",
+        "undici": "^6.6.3",
         "zod": "^3.24.2",
       },
       "devDependencies": {
@@ -395,6 +396,8 @@
     "typescript": ["typescript@5.8.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ=="],
 
     "typescript-eslint": ["typescript-eslint@8.28.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.28.0", "@typescript-eslint/parser": "8.28.0", "@typescript-eslint/utils": "8.28.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <5.9.0" } }, "sha512-jfZtxJoHm59bvoCMYCe2BM0/baMswRhMmYhy+w6VfcyHrjxZ0OJe0tGasydCpIpA+A/WIJhTyZfb3EtwNC/kHQ=="],
+
+    "undici": ["undici@6.21.3", "", {}, "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw=="],
 
     "undici-types": ["undici-types@6.20.0", "", {}, "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="],
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "homepage": "https://github.com/upstash/context7#readme",
   "dependencies": {
+    "undici": "^6.6.3",
     "@modelcontextprotocol/sdk": "^1.12.0",
     "commander": "^14.0.0",
     "zod": "^3.24.2"

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,8 +1,33 @@
 import { SearchResponse } from "./types.js";
 import { generateHeaders } from "./encryption.js";
+import { ProxyAgent, setGlobalDispatcher } from "undici";
 
 const CONTEXT7_API_BASE_URL = "https://context7.com/api";
 const DEFAULT_TYPE = "txt";
+
+// Pick up proxy configuration in a variety of common env var names.
+let PROXY_URL: string | null =
+  process.env.HTTPS_PROXY ??
+  process.env.https_proxy ??
+  process.env.HTTP_PROXY ??
+  process.env.http_proxy ??
+  null;
+
+if (PROXY_URL && !PROXY_URL.startsWith("$") && /^(http|https):\/\//i.test(PROXY_URL)) {
+  try {
+    // Configure a global proxy agent once at startup. Subsequent fetch calls will
+    // automatically use this dispatcher.
+    // Using `any` cast because ProxyAgent implements the Dispatcher interface but
+    // TS may not infer it correctly in some versions.
+    setGlobalDispatcher(new ProxyAgent(PROXY_URL) as any);
+  } catch (error) {
+    // Don't crash the app if proxy initialisation fails – just log a warning.
+    console.error(
+      `[Context7] Failed to configure proxy agent for provided proxy URL: ${PROXY_URL}:`,
+      error
+    );
+  }
+}
 
 /**
  * Searches for libraries matching the given query


### PR DESCRIPTION
This should allow the mcp server to operate behind http proxy servers. If the standard https_proxy environment variable is defined, it should be used for requests to https://context7.com/api