### PR TITLE
docs: fix numbering in Cline installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,9 +385,9 @@ Add this to your Claude Desktop `claude_desktop_config.json` file. See [Claude D
 You can easily install Context7 through the [Cline MCP Server Marketplace](https://cline.bot/mcp-marketplace) by following these instructions:
 
 1. Open **Cline**.
-1. Click the hamburger menu icon (☰) to enter the **MCP Servers** section.
-2. Use the search bar within the **Marketplace** tab to find *Context7*.
-3. Click the **Install** button.
+2. Click the hamburger menu icon (☰) to enter the **MCP Servers** section.
+3. Use the search bar within the **Marketplace** tab to find *Context7*.
+4. Click the **Install** button.
 
 </details>
 


### PR DESCRIPTION
Corrects the list numbering for the Cline installation steps in the main README file.