### PR TITLE
Add Crush MCP installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,56 @@ Add this to your Claude Desktop `claude_desktop_config.json` file. See [Claude D
 </details>
 
 <details>
+<summary><b>Install in Crush</b></summary>
+
+Add this to your Crush configuration file. See [Crush MCP docs](https://github.com/charmbracelet/crush#mcps) for more info.
+
+#### Crush Remote Server Connection (HTTP)
+
+```json
+{
+  "$schema": "https://charm.land/crush.json",
+  "mcp": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp"
+    }
+  }
+}
+```
+
+#### Crush Remote Server Connection (SSE)
+
+```json
+{
+  "$schema": "https://charm.land/crush.json",
+  "mcp": {
+    "context7": {
+      "type": "sse",
+      "url": "https://mcp.context7.com/sse"
+    }
+  }
+}
+```
+
+#### Crush Local Server Connection
+
+```json
+{
+  "$schema": "https://charm.land/crush.json",
+  "mcp": {
+    "context7": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp"]
+    }
+  }
+}
+```
+
+</details>
+
+<details>
 <summary>
 <b>Install in Cline</b>
 </summary>


### PR DESCRIPTION
## Summary
Add comprehensive installation guide for using Context7 MCP with Charm's Crush CLI tool, including HTTP, SSE, and local server connection options.

## Changes
- [x] Added Crush installation section to README.md
- [x] Included HTTP remote server connection configuration
- [x] Included SSE remote server connection configuration  
- [x] Included local server connection configuration
- [x] Added proper links to Crush MCP documentation

## Details
This addition follows the existing pattern of other MCP client installations in the README and provides users with all necessary configuration options for integrating Context7 with Crush.