### PR TITLE
docs: Update Windsurf MCP URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Pasting the following configuration into your Cursor `~/.cursor/mcp.json` file i
 <details>
 <summary><b>Install in Windsurf</b></summary>
 
-Add this to your Windsurf MCP config file. See [Windsurf MCP docs](https://docs.windsurf.com/windsurf/mcp) for more info.
+Add this to your Windsurf MCP config file. See [Windsurf MCP docs](https://docs.windsurf.com/windsurf/cascade/mcp) for more info.
 
 #### Windsurf Remote Server Connection
 


### PR DESCRIPTION
This updates the outdated URL for Windsurf MCP in the docs