### PR TITLE
Fix Cline Config Instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,28 @@ You can easily install Context7 through the [Cline MCP Server Marketplace](https
 3. Use the search bar within the **Marketplace** tab to find _Context7_.
 4. Click the **Install** button.
 
+Or you can directly edit MCP servers configuration:
+
+1. Open **Cline**.
+2. Click the hamburger menu icon (☰) to enter the **MCP Servers** section.
+3. Choose **Remote Servers** tab.
+4. Click the **Edit Configuration** button.
+5. Add context7 to `mcpServers`:
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "url": "https://mcp.context7.com/mcp",
+      "type": "streamableHttp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
 </details>
 
 <details>

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -209,6 +209,32 @@ Smithery キーは [Smithery.ai Web ページ](https://smithery.ai/server/@upsta
 </details>
 
 <details>
+<summary>
+<b>Cline でのインストール</b>
+</summary>
+
+1. **Cline** を開きます。
+2. メニューアイコン (☰) をクリックし、**MCP サーバー**セクションに移動します。
+3. **リモートサーバー** タブを選択します。
+4. **設定を編集** ボタンをクリックします。
+5. context7 に関連する設定を `mcpServers` に追加します：
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "url": "https://mcp.context7.com/mcp",
+      "type": "streamableHttp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+</details>
+<details>
 <summary><b>Visual Studio 2022 へのインストール</b></summary>
 
 [Visual Studio MCP サーバードキュメント](https://learn.microsoft.com/visualstudio/ide/mcp-servers?view=vs-2022) に従って、Visual Studio 2022 で Context7 MCP を設定できます。

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -214,9 +214,31 @@ claude mcp add context7 -- npx -y @upstash/context7-mcp --api-key YOUR_API_KEY
 您可以通过以下步骤轻松地通过 [Cline MCP Server 市场](https://cline.bot/mcp-marketplace) 安装 Context7：
 
 1. 打开 **Cline**。
-2. 点击汉堡菜单图标 (☰)，进入 **MCP 服务器** 部分。
+2. 点击菜单图标 (☰)，进入 **MCP 服务器** 部分。
 3. 在 **市场** 标签页中的搜索栏搜索 _Context7_。
 4. 点击 **安装** 按钮。
+
+您也可以直接修改MCP servers设置文件：
+
+1. 打开**Cline**。
+2. 点击菜单图标 (☰)，进入 **MCP 服务器** 部分。
+3. 选择 **远程服务器** 标签。
+4. 点击 **编辑配置** 按钮。
+5. 将 context7 相关设置添加到 `mcpServers`:
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "url": "https://mcp.context7.com/mcp",
+      "type": "streamableHttp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
 
 </details>
 

--- a/docs/README.zh-TW.md
+++ b/docs/README.zh-TW.md
@@ -377,9 +377,31 @@ claude mcp add context7 -- npx -y @upstash/context7-mcp
 您可以按照以下說明，透過 [Cline MCP 伺服器市集](https://cline.bot/mcp-marketplace) 輕鬆安裝 Context7：
 
 1. 開啟 **Cline**。
-2. 點擊漢堡選單圖示（☰）進入 **MCP 伺服器** 區段。
+2. 點擊選單圖示（☰）進入 **MCP 伺服器** 區段。
 3. 在 **市集** 分頁的搜尋欄中尋找 _Context7_。
 4. 點擊 **安裝** 按鈕。
+
+您也可以直接修改 MCP servers 設定檔案：
+
+1. 開啟 Cline。
+2. 點擊選單圖示 (☰)，進入 MCP 伺服器部分。
+3. 選擇遠端伺服器標籤。
+4. 點擊編輯設定按鈕。
+5. 將 context7 相關設定新增至 mcpServers：
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "url": "https://mcp.context7.com/mcp",
+      "type": "streamableHttp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
 
 </details>
 


### PR DESCRIPTION
Improve README.md to fix cline configuration problem (https://github.com/upstash/context7/issues/184#issuecomment-3258307936)

@enesgules I modified README.md. As for other languages, I only know zh-TW/CN & ja.
- Is there any way to sync these docs?
- Otherwise, should I use LLM-translated content to modify doc for all languages?
- Or wait for native speakers to fix them?