### PR TITLE
Update Context7 MCP documentation to use standard Authorization header

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Run this command. See [Claude Code MCP docs](https://docs.anthropic.com/en/docs/
 #### Claude Code Remote Server Connection
 
 ```sh
-claude mcp add --transport http context7 https://mcp.context7.com/mcp --header "CONTEXT7_API_KEY: YOUR_API_KEY"
+claude mcp add --transport http context7 https://mcp.context7.com/mcp --header "Authorization: Bearer YOUR_CONTEXT7_API_KEY"
 ```
 
 #### Claude Code Local Server Connection


### PR DESCRIPTION
 ## Summary
  - Updates the MCP add command documentation to use the standard `Authorization: Bearer` header format
  - Changes from custom `CONTEXT7_API_KEY` header to OAuth 2.0 standard format

  ## Changes
  - Modified the `claude mcp add` command example in README
  - Updated header format from `"CONTEXT7_API_KEY: YOUR_API_KEY"` to `"Authorization: Bearer YOUR_CONTEXT7_API_KEY"`

  ## Rationale
  The `Authorization: Bearer` format is the industry standard for API authentication and provides:
  - Better compatibility with existing tools and libraries
  - Immediate recognition by developers familiar with OAuth 2.0
  - Consistency with HTTP authorization best practices
  - Clear indication that this is an authentication header