### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,8 +496,13 @@ See [Kiro Model Context Protocol Documentation](https://kiro.dev/docs/mcp/config
   "mcpServers": {
     "Context7": {
       "command": "npx",
-      "args": ["-y", "@upstash/context7-mcp", "--api-key", "YOUR_API_KEY"],
-      "env": {},
+      "args": [
+        "-y",
+        "@upstash/context7-mcp"
+      ],
+      "env": {
+        "CONTEXT7_API_KEY": "YOUR_API_KEY"
+      },
       "disabled": false,
       "autoApprove": []
     }


### PR DESCRIPTION
fix Kiro documentation, the original causes the issue below:

```
2025-09-21 10:42:28.932 [info] [Context7] Reconnecting to server
2025-09-21 10:42:28.936 [info] [Context7] Registering MCP server and starting connection
2025-09-21 10:42:30.428 [warning] [Context7] Log from MCP Server: error: too many arguments. Expected 0 arguments but got 2.
```