### PR TITLE
Add MacOS configuration notes for timeout issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,9 +493,27 @@ startup_timeout_ms = 20_000
 
 This ensures Codex CLI works reliably on Windows.
 
+⚠️ MacOS Notes
+
+On MacOS, some users may encounter the same request timed out errors like Windows,
+it also can be solved tith the full path to Node.js and the installed package:
+
+```toml
+[mcp_servers.context7]
+command = "/Users/yourname/.nvm/versions/node/v22.14.0/bin/node"  # Node.js full path
+args = ["/Users/yourname/.nvm/versions/node/v22.14.0/lib/node_modules/@upstash/context7-mcp/dist/index.js",  
+  "--transport",
+  "stdio",
+  "--api-key",
+  "YOUR_API_KEY"
+]
+```
+This ensures Codex CLI works reliably on MacOS.
+
 </details>
 
 <details>
+
 <summary><b>Install in JetBrains AI Assistant</b></summary>
 
 See [JetBrains AI Assistant Documentation](https://www.jetbrains.com/help/ai-assistant/configure-an-mcp-server.html) for more details.


### PR DESCRIPTION
## Problem
I encountered request timeout errors on macOS when using Context7 MCP with Claude Desktop (Codex CLI). The issue occurs when Context7 needs to be re-downloaded due to version changes or updates, and the download time exceeds Codex's default timeout settings.

## Root Cause
- When Context7 package version changes or needs to be reinstalled
- The download/installation process takes longer than Codex's default timeout limit
- This results in "request timed out" errors, preventing the MCP server from initializing properly

## Solution
Similar to the existing Windows solution, the fix involves specifying the full paths to both Node.js and the installed Context7 package in the configuration. This bypasses the initialization timeout by directly pointing to the already-installed resources.
