### PR TITLE
chore: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,127 @@
+name: Bug Report
+description: Report a bug or issue with Context7 MCP
+title: "[Bug]: "
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report this issue! Please fill out the form below to help us investigate.
+
+  - type: dropdown
+    id: client
+    attributes:
+      label: MCP Client
+      description: Which MCP client are you using?
+      options:
+        - Cursor
+        - Claude Desktop
+        - Claude Code
+        - Windsurf
+        - VS Code
+        - Cline
+        - Zed
+        - Other (specify in description)
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Context7 MCP Version
+      description: Which version of Context7 MCP are you using? (Check package.json or npm list)
+      placeholder: e.g., 1.0.21
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: A clear description of what the bug is
+      placeholder: When I try to...
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Steps to reproduce the behavior
+      placeholder: |
+        1. Install Context7 MCP via...
+        2. Run the command...
+        3. See error...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What you expected to happen
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Error Messages / Logs
+      description: Please copy and paste any relevant error messages or logs
+      render: shell
+
+  - type: dropdown
+    id: transport
+    attributes:
+      label: Transport Method
+      description: Which transport method are you using?
+      options:
+        - stdio (default)
+        - http
+        - SSE (deprecated)
+    validations:
+      required: true
+
+  - type: input
+    id: node-version
+    attributes:
+      label: Node.js Version
+      description: Output of `node --version`
+      placeholder: e.g., v20.10.0
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating System
+      description: Which OS are you running?
+      placeholder: e.g., macOS 14.2, Windows 11, Ubuntu 22.04
+
+  - type: textarea
+    id: config
+    attributes:
+      label: Configuration
+      description: Your Context7 MCP configuration (remove any API keys!)
+      render: json
+      placeholder: |
+        {
+          "mcpServers": {
+            "context7": {
+              "command": "npx",
+              "args": ["-y", "@upstash/context7-mcp"]
+            }
+          }
+        }
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other context about the problem (proxy settings, firewalls, etc.)

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,50 @@
+name: Documentation Issue
+description: Report incorrect or missing documentation
+title: "[Docs]: "
+labels: ["documentation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Found an issue with Context7 documentation? Let us know!
+
+  - type: dropdown
+    id: doc-type
+    attributes:
+      label: Documentation Type
+      description: Where is the issue?
+      options:
+        - README
+        - Installation instructions
+        - API documentation
+        - Library-specific docs
+        - Configuration examples
+    validations:
+      required: true
+
+  - type: textarea
+    id: issue
+    attributes:
+      label: Issue Description
+      description: What's wrong or missing?
+    validations:
+      required: true
+
+  - type: input
+    id: location
+    attributes:
+      label: Documentation Location
+      description: Link or section name where the issue exists
+      placeholder: e.g., README.md line 45, or "Installation via Smithery" section
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested Fix
+      description: How should it be corrected or what should be added?
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other relevant information

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,51 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature! We appreciate your input.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Description
+      description: Is your feature request related to a problem? Please describe.
+      placeholder: I'm frustrated when...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the solution you'd like
+      placeholder: I would like Context7 to...
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Describe any alternative solutions or features you've considered
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: How important is this feature to you?
+      options:
+        - Nice to have
+        - Would improve my workflow
+        - Blocking my usage
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Add any other context, screenshots, or examples about the feature request


### PR DESCRIPTION
This PR adds the issue templates that guides the users on how to create the issues. You can see the preview of the UI that shows up when creating the issues.
<img width="1271" height="438" alt="Screenshot 2025-10-11 at 15 25 05" src="https://github.com/user-attachments/assets/d0e95313-00e9-4638-bc37-5737285a3625" />
