### PR TITLE
docs: Added missing docker run to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -689,6 +689,7 @@ If you prefer to run the MCP server in a Docker container:
 
    ```bash
    docker build -t context7-mcp .
+   docker run context7-mcp:latest
    ```
 
 2. **Configure Your MCP Client:**


### PR DESCRIPTION
The README has you run `docker build` and then add the MCP server, but it skips the `docker run` step, so I added it.

Edit: Looks like I was wrong, I'm closing the issue