### PR TITLE
docs: Add Qwen Coder installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,45 @@ If the `mcpServers` object does not exist, create it.
 </details>
 
 <details>
+<summary><b>Install in Qwen Coder</b></summary>
+
+See [Qwen Coder MCP Configuration](https://qwenlm.github.io/qwen-code-docs/en/tools/mcp-server/#how-to-set-up-your-mcp-server) for details.
+
+1.  Open the Qwen Coder settings file. The location is `~/.qwen/settings.json` (where `~` is your home directory).
+2.  Add the following to the `mcpServers` object in your `settings.json` file:
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "httpUrl": "https://mcp.context7.com/mcp",
+      "headers": {
+        "CONTEXT7_API_KEY": "YOUR_API_KEY",
+        "Accept": "application/json, text/event-stream"
+      }
+    }
+  }
+}
+```
+
+Or, for a local server:
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp", "--api-key", "YOUR_API_KEY"]
+    }
+  }
+}
+```
+
+If the `mcpServers` object does not exist, create it.
+
+</details>
+
+<details>
 <summary><b>Install in Claude Desktop</b></summary>
 
 #### Remote Server Connection


### PR DESCRIPTION
Added installation instructions for Qwen Coder MCP configuration.

- Context7 now works with Qwen Coder after following the instructions now provided.

<img width="1742" height="974" alt="paint" src="https://github.com/user-attachments/assets/33f0588a-b17f-4190-9798-0d4f13507240" />

