### PR TITLE
feat: add remote server connection for OpenAI Codex across all docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,11 +514,21 @@ See [OpenAI Codex](https://github.com/openai/codex) for more information.
 
 Add the following configuration to your OpenAI Codex MCP server settings:
 
+#### Local Server Connection
+
 ```toml
 [mcp_servers.context7]
 args = ["-y", "@upstash/context7-mcp", "--api-key", "YOUR_API_KEY"]
 command = "npx"
 startup_timeout_ms = 20_000
+```
+
+#### Remote Server Connection
+
+```toml
+[mcp_servers.context7]
+url = "https://mcp.context7.com/mcp"
+http_headers = { "CONTEXT7_API_KEY" = "YOUR_API_KEY" }
 ```
 
 > Optional troubleshooting — only if you see startup "request timed out" or "not found program". Most users can ignore this.

--- a/docs/README.id-ID.md
+++ b/docs/README.id-ID.md
@@ -673,10 +673,21 @@ Lihat [Dokumentasi Protokol Konteks Model Kiro](https://kiro.dev/docs/mcp/config
 <summary><b>Instal di OpenAI Codex</b></summary>
 Lihat [OpenAI Codex](https://github.com/openai/codex) untuk informasi lebih lanjut.
 Tambahkan konfigurasi berikut ke pengaturan server MCP OpenAI Codex Anda:
+
+#### Koneksi Server Lokal
+
 ```toml
 [mcp_servers.context7]
 args = ["-y", "@upstash/context7-mcp"]
 command = "npx"
+```
+
+#### Koneksi Server Jarak Jauh
+
+```toml
+[mcp_servers.context7]
+url = "https://mcp.context7.com/mcp"
+http_headers = { "CONTEXT7_API_KEY" = "YOUR_API_KEY" }
 ```
 </details>
 

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -770,10 +770,20 @@ Opencode 설정 파일에 다음을 추가하세요. 자세한 내용은 [Openco
 
 OpenAI Codex MCP 서버 설정에 다음 설정을 추가하세요:
 
+#### 로컬 서버 연결
+
 ```toml
 [mcp_servers.context7]
 args = ["-y", "@upstash/context7-mcp"]
 command = "npx"
+```
+
+#### 원격 서버 연결
+
+```toml
+[mcp_servers.context7]
+url = "https://mcp.context7.com/mcp"
+http_headers = { "CONTEXT7_API_KEY" = "YOUR_API_KEY" }
 ```
 
 </details>

--- a/docs/README.pt-BR.md
+++ b/docs/README.pt-BR.md
@@ -412,10 +412,20 @@ Veja mais em [OpenAI Codex](https://github.com/openai/codex).
 
 Adicione a seguinte configuração às definições do servidor MCP do OpenAI Codex:
 
+#### Conexão de Servidor Local
+
 ```toml
 [mcp_servers.context7]
 args = ["-y", "@upstash/context7-mcp"]
 command = "npx"
+```
+
+#### Conexão de Servidor Remoto
+
+```toml
+[mcp_servers.context7]
+url = "https://mcp.context7.com/mcp"
+http_headers = { "CONTEXT7_API_KEY" = "YOUR_API_KEY" }
 ```
 
 </details>

--- a/docs/README.vi.md
+++ b/docs/README.vi.md
@@ -775,10 +775,20 @@ Xem [OpenAI Codex](https://github.com/openai/codex) để biết thêm thông ti
 
 Thêm cấu hình sau vào cài đặt OpenAI Codex MCP server của bạn:
 
+#### Kết nối Server Cục bộ
+
 ```toml
 [mcp_servers.context7]
 args = ["-y", "@upstash/context7-mcp"]
 command = "npx"
+```
+
+#### Kết nối Server Từ xa
+
+```toml
+[mcp_servers.context7]
+url = "https://mcp.context7.com/mcp"
+http_headers = { "CONTEXT7_API_KEY" = "YOUR_API_KEY" }
 ```
 
 </details>

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -447,10 +447,20 @@ claude mcp add context7 -- npx -y @upstash/context7-mcp --api-key YOUR_API_KEY
 
 将以下配置添加到您的 OpenAI Codex MCP 服务器设置中：
 
+#### 本地服务器连接
+
 ```toml
 [mcp_servers.context7]
 args = ["-y", "@upstash/context7-mcp", "--api-key", "YOUR_API_KEY"]
 command = "npx"
+```
+
+#### 远程服务器连接
+
+```toml
+[mcp_servers.context7]
+url = "https://mcp.context7.com/mcp"
+http_headers = { "CONTEXT7_API_KEY" = "YOUR_API_KEY" }
 ```
 
 </details>

--- a/docs/README.zh-TW.md
+++ b/docs/README.zh-TW.md
@@ -766,10 +766,20 @@ Windows 的設定與 Linux 或 macOS 略有不同（_範例以 Cline 為例_）�
 
 將下列設定加入你的 OpenAI Codex MCP 伺服器設定：
 
+#### 本地伺服器連接
+
 ```toml
 [mcp_servers.context7]
 args = ["-y", "@upstash/context7-mcp"]
 command = "npx"
+```
+
+#### 遠端伺服器連接
+
+```toml
+[mcp_servers.context7]
+url = "https://mcp.context7.com/mcp"
+http_headers = { "CONTEXT7_API_KEY" = "YOUR_API_KEY" }
 ```
 
 </details>


### PR DESCRIPTION
Add a remote server configuration example for `Codex` so that users who fail to execute npx commands in their local environment can access it via HTTP.