### PR TITLE
docs: Add Copilot CLI installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -841,6 +841,57 @@ For more information, see the [official GitHub documentation](https://docs.githu
 </details>
 
 <details>
+<summary><b>Install in Copilot CLI</b></summary>
+
+1.  Open the Copilot CLI MCP config file. The location is `~/.copilot/mcp-config.json` (where `~` is your home directory).
+2.  Add the following to the `mcpServers` object in your `settings.json` file:
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp",
+      "headers": {
+        "CONTEXT7_API_KEY": "YOUR_API_KEY"
+      },
+      "tools": [
+        "get-library-docs", 
+        "resolve-library-id"
+      ]
+    }
+  }
+}
+```
+
+Or, for a local server:
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "type": "local",
+      "command": "npx",
+      "tools": [
+        "get-library-docs", 
+        "resolve-library-id"
+      ],
+      "args": [
+        "-y",
+        "@upstash/context7-mcp",
+        "--api-key",
+        "YOUR_API_KEY"
+      ]
+    }
+  }
+}
+```
+
+If the `mcp-config.json` file does not exist, create it.
+
+</details>
+
+<details>
 <summary><b>Install in LM Studio</b></summary>
 
 See [LM Studio MCP Support](https://lmstudio.ai/blog/lmstudio-v0.3.17) for more information.

--- a/README.md
+++ b/README.md
@@ -844,7 +844,7 @@ For more information, see the [official GitHub documentation](https://docs.githu
 <summary><b>Install in Copilot CLI</b></summary>
 
 1.  Open the Copilot CLI MCP config file. The location is `~/.copilot/mcp-config.json` (where `~` is your home directory).
-2.  Add the following to the `mcpServers` object in your `settings.json` file:
+2.  Add the following to the `mcpServers` object in your `mcp-config.json` file:
 
 ```json
 {

--- a/docs/README.de.md
+++ b/docs/README.de.md
@@ -189,6 +189,54 @@ Füge die folgende Konfiguration zum Abschnitt `mcp` deiner Copilot Coding Agent
 
 Weitere Informationen findest du in der [offiziellen GitHub-Dokumentation](https://docs.github.com/en/enterprise-cloud@latest/copilot/how-tos/agents/copilot-coding-agent/extending-copilot-coding-agent-with-mcp).
 
+### Installation im Copilot CLI
+
+1.  Öffne die MCP-Konfigurationsdatei von Copilot CLI. Der Ort ist `~/.copilot/mcp-config.json` (wobei `~` dein Home-Verzeichnis ist).
+2.  Füge Folgendes zum `mcpServers`-Objekt in deiner `mcp-config.json`-Datei hinzu:
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp",
+      "headers": {
+        "CONTEXT7_API_KEY": "YOUR_API_KEY"
+      },
+      "tools": [
+        "get-library-docs", 
+        "resolve-library-id"
+      ]
+    }
+  }
+}
+```
+
+Oder für einen lokalen Server:
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "type": "local",
+      "command": "npx",
+      "tools": [
+        "get-library-docs", 
+        "resolve-library-id"
+      ],
+      "args": [
+        "-y",
+        "@upstash/context7-mcp",
+        "--api-key",
+        "YOUR_API_KEY"
+      ]
+    }
+  }
+}
+```
+
+Falls die `mcp-config.json`-Datei nicht existiert, erstelle sie.
+
 ### Docker verwenden
 
 Wenn du den MCP-Server lieber in einem Docker-Container ausführen möchtest:

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -171,6 +171,54 @@ Agrega la siguiente configuración a la sección `mcp` de tu archivo de configur
 
 Para más información, consulta la [documentación oficial de GitHub](https://docs.github.com/en/enterprise-cloud@latest/copilot/how-tos/agents/copilot-coding-agent/extending-copilot-coding-agent-with-mcp).
 
+### Instalar en Copilot CLI
+
+1.  Abre el archivo de configuración MCP de Copilot CLI. La ubicación es `~/.copilot/mcp-config.json` (donde `~` es tu directorio home).
+2.  Agrega lo siguiente al objeto `mcpServers` en tu archivo `mcp-config.json`:
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp",
+      "headers": {
+        "CONTEXT7_API_KEY": "YOUR_API_KEY"
+      },
+      "tools": [
+        "get-library-docs", 
+        "resolve-library-id"
+      ]
+    }
+  }
+}
+```
+
+O, para un servidor local:
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "type": "local",
+      "command": "npx",
+      "tools": [
+        "get-library-docs", 
+        "resolve-library-id"
+      ],
+      "args": [
+        "-y",
+        "@upstash/context7-mcp",
+        "--api-key",
+        "YOUR_API_KEY"
+      ]
+    }
+  }
+}
+```
+
+Si el archivo `mcp-config.json` no existe, créalo.
+
 ### Herramientas Disponibles
 
 - `resolve-library-id`: Resuelve un nombre de una biblioteca general en un ID de biblioteca compatible con Context7.

--- a/docs/README.fr.md
+++ b/docs/README.fr.md
@@ -206,6 +206,54 @@ Ajoutez la configuration suivante à la section `mcp` de votre fichier de config
 
 Pour plus d'informations, consultez la [documentation officielle GitHub](https://docs.github.com/en/enterprise-cloud@latest/copilot/how-tos/agents/copilot-coding-agent/extending-copilot-coding-agent-with-mcp).
 
+### Installation dans Copilot CLI
+
+1.  Ouvrez le fichier de configuration MCP de Copilot CLI. L'emplacement est `~/.copilot/mcp-config.json` (où `~` est votre répertoire personnel).
+2.  Ajoutez ce qui suit à l'objet `mcpServers` dans votre fichier `mcp-config.json` :
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp",
+      "headers": {
+        "CONTEXT7_API_KEY": "YOUR_API_KEY"
+      },
+      "tools": [
+        "get-library-docs", 
+        "resolve-library-id"
+      ]
+    }
+  }
+}
+```
+
+Ou, pour un serveur local :
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "type": "local",
+      "command": "npx",
+      "tools": [
+        "get-library-docs", 
+        "resolve-library-id"
+      ],
+      "args": [
+        "-y",
+        "@upstash/context7-mcp",
+        "--api-key",
+        "YOUR_API_KEY"
+      ]
+    }
+  }
+}
+```
+
+Si le fichier `mcp-config.json` n'existe pas, créez-le.
+
 ### Utilisation avec Docker
 
 Si vous préférez exécuter le serveur MCP dans un conteneur Docker :

--- a/docs/README.id-ID.md
+++ b/docs/README.id-ID.md
@@ -639,6 +639,57 @@ Untuk informasi lebih lanjut, lihat [dokumentasi resmi GitHub](https://docs.gith
 </details>
 
 <details>
+<summary><b>Instal di Copilot CLI</b></summary>
+
+1.  Buka file konfigurasi MCP Copilot CLI. Lokasinya adalah `~/.copilot/mcp-config.json` (di mana `~` adalah direktori home Anda).
+2.  Tambahkan yang berikut ke objek `mcpServers` di file `mcp-config.json` Anda:
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp",
+      "headers": {
+        "CONTEXT7_API_KEY": "YOUR_API_KEY"
+      },
+      "tools": [
+        "get-library-docs", 
+        "resolve-library-id"
+      ]
+    }
+  }
+}
+```
+
+Atau, untuk server lokal:
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "type": "local",
+      "command": "npx",
+      "tools": [
+        "get-library-docs", 
+        "resolve-library-id"
+      ],
+      "args": [
+        "-y",
+        "@upstash/context7-mcp",
+        "--api-key",
+        "YOUR_API_KEY"
+      ]
+    }
+  }
+}
+```
+
+Jika file `mcp-config.json` tidak ada, buatlah.
+
+</details>
+
+<details>
 <summary><b>Instal di Kiro</b></summary>
 Lihat [Dokumentasi Protokol Konteks Model Kiro](https://kiro.dev/docs/mcp/configuration/) untuk detail.
 1. Navigasikan `Kiro` > `Server MCP`

--- a/docs/README.it.md
+++ b/docs/README.it.md
@@ -191,6 +191,54 @@ Aggiungi la seguente configurazione alla sezione `mcp` del file di configurazion
 
 Per maggiori informazioni, consulta la [documentazione ufficiale GitHub](https://docs.github.com/en/enterprise-cloud@latest/copilot/how-tos/agents/copilot-coding-agent/extending-copilot-coding-agent-with-mcp).
 
+### Installazione in Copilot CLI
+
+1.  Apri il file di configurazione MCP di Copilot CLI. La posizione è `~/.copilot/mcp-config.json` (dove `~` è la tua home directory).
+2.  Aggiungi quanto segue all'oggetto `mcpServers` nel tuo file `mcp-config.json`:
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp",
+      "headers": {
+        "CONTEXT7_API_KEY": "YOUR_API_KEY"
+      },
+      "tools": [
+        "get-library-docs", 
+        "resolve-library-id"
+      ]
+    }
+  }
+}
+```
+
+Oppure, per un server locale:
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "type": "local",
+      "command": "npx",
+      "tools": [
+        "get-library-docs", 
+        "resolve-library-id"
+      ],
+      "args": [
+        "-y",
+        "@upstash/context7-mcp",
+        "--api-key",
+        "YOUR_API_KEY"
+      ]
+    }
+  }
+}
+```
+
+Se il file `mcp-config.json` non esiste, crealo.
+
 ### Utilizzo di Docker
 
 Se preferisci eseguire il server MCP in un contenitore Docker:

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -374,6 +374,57 @@ claude mcp add context7 -- npx -y @upstash/context7-mcp
 </details>
 
 <details>
+<summary><b>Copilot CLI へのインストール</b></summary>
+
+1.  Copilot CLI MCP 設定ファイルを開きます。ファイルの場所は `~/.copilot/mcp-config.json`（`~` はホームディレクトリ）です。
+2.  `mcp-config.json` ファイルの `mcpServers` オブジェクトに以下を追加します：
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp",
+      "headers": {
+        "CONTEXT7_API_KEY": "YOUR_API_KEY"
+      },
+      "tools": [
+        "get-library-docs", 
+        "resolve-library-id"
+      ]
+    }
+  }
+}
+```
+
+または、ローカルサーバーの場合：
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "type": "local",
+      "command": "npx",
+      "tools": [
+        "get-library-docs", 
+        "resolve-library-id"
+      ],
+      "args": [
+        "-y",
+        "@upstash/context7-mcp",
+        "--api-key",
+        "YOUR_API_KEY"
+      ]
+    }
+  }
+}
+```
+
+`mcp-config.json` ファイルが存在しない場合は、作成してください。
+
+</details>
+
+<details>
 <summary><b>Docker を使用</b></summary>
 
 MCP サーバーを Docker コンテナで実行したい場合：

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -430,6 +430,57 @@ Claude Desktop의 `claude_desktop_config.json` 파일에 다음을 추가하세�
 </details>
 
 <details>
+<summary><b>Copilot CLI 설치</b></summary>
+
+1.  Copilot CLI MCP 구성 파일을 엽니다. 파일 위치는 `~/.copilot/mcp-config.json`입니다(`~`는 홈 디렉토리).
+2.  `mcp-config.json` 파일의 `mcpServers` 객체에 다음을 추가하세요:
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp",
+      "headers": {
+        "CONTEXT7_API_KEY": "YOUR_API_KEY"
+      },
+      "tools": [
+        "get-library-docs", 
+        "resolve-library-id"
+      ]
+    }
+  }
+}
+```
+
+또는 로컬 서버의 경우:
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "type": "local",
+      "command": "npx",
+      "tools": [
+        "get-library-docs", 
+        "resolve-library-id"
+      ],
+      "args": [
+        "-y",
+        "@upstash/context7-mcp",
+        "--api-key",
+        "YOUR_API_KEY"
+      ]
+    }
+  }
+}
+```
+
+`mcp-config.json` 파일이 없으면 생성하세요.
+
+</details>
+
+<details>
 <summary><b>Docker 사용하기</b></summary>
 
 MCP 서버를 Docker 컨테이너에서 실행하려면:

--- a/docs/README.pt-BR.md
+++ b/docs/README.pt-BR.md
@@ -704,6 +704,57 @@ Para mais informações, veja a [documentação oficial do GitHub](https://docs.
 </details>
 
 <details>
+<summary><b>Instalar no Copilot CLI</b></summary>
+
+1.  Abra o arquivo de configuração MCP do Copilot CLI. A localização é `~/.copilot/mcp-config.json` (onde `~` é o seu diretório home).
+2.  Adicione o seguinte ao objeto `mcpServers` no seu arquivo `mcp-config.json`:
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp",
+      "headers": {
+        "CONTEXT7_API_KEY": "YOUR_API_KEY"
+      },
+      "tools": [
+        "get-library-docs", 
+        "resolve-library-id"
+      ]
+    }
+  }
+}
+```
+
+Ou, para um servidor local:
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "type": "local",
+      "command": "npx",
+      "tools": [
+        "get-library-docs", 
+        "resolve-library-id"
+      ],
+      "args": [
+        "-y",
+        "@upstash/context7-mcp",
+        "--api-key",
+        "YOUR_API_KEY"
+      ]
+    }
+  }
+}
+```
+
+Se o arquivo `mcp-config.json` não existir, crie-o.
+
+</details>
+
+<details>
 <summary><b>Instalar no LM Studio</b></summary>
 
 Veja mais em [Suporte a MCP no LM Studio](https://lmstudio.ai/blog/lmstudio-v0.3.17).

--- a/docs/README.ru.md
+++ b/docs/README.ru.md
@@ -204,6 +204,54 @@ claude mcp add context7 -- npx -y @upstash/context7-mcp
 
 Подробнее см. в [официальной документации GitHub](https://docs.github.com/en/enterprise-cloud@latest/copilot/how-tos/agents/copilot-coding-agent/extending-copilot-coding-agent-with-mcp).
 
+### Установка в Copilot CLI
+
+1.  Откройте файл конфигурации MCP Copilot CLI. Расположение: `~/.copilot/mcp-config.json` (где `~` — ваша домашняя папка).
+2.  Добавьте следующее к объекту `mcpServers` в вашем файле `mcp-config.json`:
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp",
+      "headers": {
+        "CONTEXT7_API_KEY": "YOUR_API_KEY"
+      },
+      "tools": [
+        "get-library-docs", 
+        "resolve-library-id"
+      ]
+    }
+  }
+}
+```
+
+Или для локального сервера:
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "type": "local",
+      "command": "npx",
+      "tools": [
+        "get-library-docs", 
+        "resolve-library-id"
+      ],
+      "args": [
+        "-y",
+        "@upstash/context7-mcp",
+        "--api-key",
+        "YOUR_API_KEY"
+      ]
+    }
+  }
+}
+```
+
+Если файл `mcp-config.json` не существует, создайте его.
+
 ### Используя Docker
 
 Если вы предпочитаете запускать MCP сервер в Docker контейнере:

--- a/docs/README.uk.md
+++ b/docs/README.uk.md
@@ -301,6 +301,83 @@ npx -y @smithery/cli@latest install @upstash/context7-mcp --client <CLIENT_NAME>
 </details>
 
 <details>
+<summary><b>Встановлення в Copilot Coding Agent</b></summary>
+
+## Використання Context7 з Copilot Coding Agent
+
+Додайте наступну конфігурацію до розділу `mcp` вашого файла настроек Copilot Coding Agent Repository->Settings->Copilot->Coding agent->MCP configuration:
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp",
+      "headers": {
+        "CONTEXT7_API_KEY": "YOUR_API_KEY"
+      },
+      "tools": ["get-library-docs", "resolve-library-id"]
+    }
+  }
+}
+```
+
+Детальніше див. в [офіційній документації GitHub](https://docs.github.com/en/enterprise-cloud@latest/copilot/how-tos/agents/copilot-coding-agent/extending-copilot-coding-agent-with-mcp).
+
+</details>
+
+<details>
+<summary><b>Встановлення в Copilot CLI</b></summary>
+
+1.  Відкрийте файл конфігурації MCP Copilot CLI. Розташування: `~/.copilot/mcp-config.json` (де `~` — ваша домашня папка).
+2.  Додайте наступне до об'єкта `mcpServers` у вашому файлі `mcp-config.json`:
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp",
+      "headers": {
+        "CONTEXT7_API_KEY": "YOUR_API_KEY"
+      },
+      "tools": [
+        "get-library-docs", 
+        "resolve-library-id"
+      ]
+    }
+  }
+}
+```
+
+Або для локального сервера:
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "type": "local",
+      "command": "npx",
+      "tools": [
+        "get-library-docs", 
+        "resolve-library-id"
+      ],
+      "args": [
+        "-y",
+        "@upstash/context7-mcp",
+        "--api-key",
+        "YOUR_API_KEY"
+      ]
+    }
+  }
+}
+```
+
+Якщо файл `mcp-config.json` не існує, створіть його.
+
+</details>
+
+<details>
 <summary><b>Встановлення в Gemini CLI</b></summary>
 
 Детальніше див. у [конфігурації Gemini CLI](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/configuration.md).

--- a/docs/README.vi.md
+++ b/docs/README.vi.md
@@ -734,6 +734,57 @@ Thêm cấu hình sau vào phần `mcp` trong file cấu hình Copilot Coding Ag
 Để biết thêm thông tin, xem [tài liệu GitHub chính thức](https://docs.github.com/en/enterprise-cloud@latest/copilot/how-tos/agents/copilot-coding-agent/extending-copilot-coding-agent-with-mcp).
 
 </details>
+
+<details>
+<summary><b>Cài đặt trong Copilot CLI</b></summary>
+
+1.  Mở file cấu hình MCP của Copilot CLI. Vị trí là `~/.copilot/mcp-config.json` (trong đó `~` là thư mục home của bạn).
+2.  Thêm nội dung sau vào đối tượng `mcpServers` trong file `mcp-config.json` của bạn:
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp",
+      "headers": {
+        "CONTEXT7_API_KEY": "YOUR_API_KEY"
+      },
+      "tools": [
+        "get-library-docs", 
+        "resolve-library-id"
+      ]
+    }
+  }
+}
+```
+
+Hoặc, đối với server cục bộ:
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "type": "local",
+      "command": "npx",
+      "tools": [
+        "get-library-docs", 
+        "resolve-library-id"
+      ],
+      "args": [
+        "-y",
+        "@upstash/context7-mcp",
+        "--api-key",
+        "YOUR_API_KEY"
+      ]
+    }
+  }
+}
+```
+
+Nếu file `mcp-config.json` không tồn tại, hãy tạo nó.
+
+</details>
   
 <details>
   

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -740,6 +740,57 @@ http_headers = { "CONTEXT7_API_KEY" = "YOUR_API_KEY" }
 </details>
 
 <details>
+<summary><b>在 Copilot CLI 中安装</b></summary>
+
+1.  打开 Copilot CLI MCP 配置文件。文件位置是 `~/.copilot/mcp-config.json`（其中 `~` 是你的主目录）。
+2.  将以下内容添加到 `mcp-config.json` 文件中的 `mcpServers` 对象：
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp",
+      "headers": {
+        "CONTEXT7_API_KEY": "YOUR_API_KEY"
+      },
+      "tools": [
+        "get-library-docs", 
+        "resolve-library-id"
+      ]
+    }
+  }
+}
+```
+
+或者，对于本地服务器：
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "type": "local",
+      "command": "npx",
+      "tools": [
+        "get-library-docs", 
+        "resolve-library-id"
+      ],
+      "args": [
+        "-y",
+        "@upstash/context7-mcp",
+        "--api-key",
+        "YOUR_API_KEY"
+      ]
+    }
+  }
+}
+```
+
+如果 `mcp-config.json` 文件不存在，请创建它。
+
+</details>
+
+<details>
 <summary><b>在 LM Studio 中安装</b></summary>
 
 更多详情请参见 [LM Studio MCP 支持](https://lmstudio.ai/blog/lmstudio-v0.3.17)。

--- a/docs/README.zh-TW.md
+++ b/docs/README.zh-TW.md
@@ -443,6 +443,57 @@ claude mcp add context7 -- npx -y @upstash/context7-mcp
 </details>
 
 <details>
+<summary><b>在 Copilot CLI 中安裝</b></summary>
+
+1.  打開 Copilot CLI MCP 設定檔。位置為 `~/.copilot/mcp-config.json`（其中 `~` 是您的主目錄）。
+2.  在 `mcp-config.json` 檔案中的 `mcpServers` 物件新增下列内容：
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp",
+      "headers": {
+        "CONTEXT7_API_KEY": "YOUR_API_KEY"
+      },
+      "tools": [
+        "get-library-docs", 
+        "resolve-library-id"
+      ]
+    }
+  }
+}
+```
+
+或者，對於本地伺服器：
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "type": "local",
+      "command": "npx",
+      "tools": [
+        "get-library-docs", 
+        "resolve-library-id"
+      ],
+      "args": [
+        "-y",
+        "@upstash/context7-mcp",
+        "--api-key",
+        "YOUR_API_KEY"
+      ]
+    }
+  }
+}
+```
+
+如果 `mcp-config.json` 檔案不存在，請建立它。
+
+</details>
+
+<details>
 <summary><b>使用 Docker</b></summary>
 
 若你偏好在 Docker 容器中執行 MCP 伺服器：


### PR DESCRIPTION
Added a new section with step-by-step instructions for configuring Copilot CLI with a remote or local MCP server in the README. This helps users set up the required configuration for using context7 tools with Copilot CLI.