### PR TITLE
docs: add Factory installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1141,6 +1141,37 @@ See [Local and Remote MCPs for Perplexity](https://www.perplexity.ai/help-center
 7. Click `Save`.
 </details>
 
+<details>
+<summary><b>Install in Factory</b></summary>
+
+Factory's droid supports MCP servers through its CLI. See [Factory MCP docs](https://docs.factory.ai/cli/configuration/mcp) for more info.
+
+#### Factory Remote Server Connection (HTTP)
+
+Run this command in your terminal:
+
+```sh
+droid mcp add context7 https://mcp.context7.com/mcp --type http --header "CONTEXT7_API_KEY: YOUR_API_KEY"
+```
+
+Or without an API key (basic usage with rate limits):
+
+```sh
+droid mcp add context7 https://mcp.context7.com/mcp --type http
+```
+
+#### Factory Local Server Connection (Stdio)
+
+Run this command in your terminal:
+
+```sh
+droid mcp add context7 "npx -y @upstash/context7-mcp" --env CONTEXT7_API_KEY=YOUR_API_KEY
+```
+
+Once configured, Context7 tools will be available in your droid sessions. Type `/mcp` within droid to manage servers, authenticate, and view available tools.
+
+</details>
+
 ## 🔨 Available Tools
 
 Context7 MCP provides the following tools that LLMs can use:


### PR DESCRIPTION
## Summary

This PR adds Factory as one of the supported MCP client installation options in the Context7 README.

## What's Changed

Added a new installation section for **Factory**, an AI coding tool with a CLI-based agent called droid. The section includes:
- HTTP (remote) server connection instructions
- Stdio (local) server connection instructions  
- Link to Factory's official MCP documentation

## Context

Factory's droid supports MCP servers through its `droid mcp add` CLI command, which allows users to easily add Context7 as an MCP server. This makes Context7 accessible to Factory users following the same pattern as other supported clients like Cursor, Claude Code, Windsurf, etc.

Factory Documentation: https://docs.factory.ai/cli/configuration/mcp

## Testing

- ✅ Verified syntax matches other installation sections
- ✅ Confirmed Factory documentation link is correct
- ✅ Both HTTP and stdio configurations follow Factory's documented patterns