### PR TITLE
Add warnings against mistaking context7 as part of the question

### DIFF
--- a/README.md
+++ b/README.md
@@ -1301,7 +1301,8 @@ CONTEXT7_API_KEY=your_api_key_here
   "mcpServers": {
     "context7": {
       "command": "npx",
-      "args": ["tsx", "/path/to/folder/context7/src/index.ts", "--api-key", "YOUR_API_KEY"]
+      "args": ["path/context7/dist/index.js"],
+      "env": { "CONTEXT7_API_KEY": "[API_KEY]" }
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,6 +115,7 @@ server.registerTool(
     description: `Resolves a package/product name to a Context7-compatible library ID and returns a list of matching libraries.
 
 You MUST call this function before 'get-library-docs' to obtain a valid Context7-compatible library ID UNLESS the user explicitly provides a library ID in the format '/org/project' or '/org/project/version' in their query.
+- ⚠️ IMPORTANT: When the user says "use context7", they want documentation for OTHER libraries (like React, Next.js, MongoDB, etc.), NOT about Context7 itself unless they explicitly ask about Context7 documentation.
 
 Selection Process:
 1. Analyze the query to understand what library/package the user is looking for
@@ -169,6 +170,7 @@ Each result includes:
 - Code Snippets: Number of available code examples
 - Trust Score: Authority indicator
 - Versions: List of versions if available. Use one of those versions if the user provides a version in their query. The format of the version is /org/project/version.
+- ⚠️ IMPORTANT: When the user says "use context7", they want documentation for OTHER libraries (like React, Next.js, MongoDB, etc.), NOT about Context7 itself unless they explicitly ask about Context7 documentation.
 
 For best results, select libraries based on name match, trust score, snippet coverage, and relevance to your use case.
 


### PR DESCRIPTION
Previously llm was mistaking context7 as part of the question for prompts like this: `use context7 TypeScript Node.js MCP general request failed error`
This PR adds warnings against this situation in the description and response of resolve-library-id. After the changes llm doesn't mistake context7 as part of the question anymore. Happy to share the output if needed.

Update readme for local mcp setup as the previous instructions were not working.