### PR TITLE
Update readme with specific package version usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1301,7 +1301,8 @@ CONTEXT7_API_KEY=your_api_key_here
   "mcpServers": {
     "context7": {
       "command": "npx",
-      "args": ["tsx", "/path/to/folder/context7/src/index.ts", "--api-key", "YOUR_API_KEY"]
+      "args": ["path/context7/dist/index.js"],
+      "env": { "CONTEXT7_API_KEY": "[API_KEY]" }
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -26,8 +26,10 @@ Add `use context7` to your prompt in Cursor:
 Create a Next.js middleware that checks for a valid JWT in cookies and redirects unauthenticated users to `/login`. use context7
 ```
 
+Get answers tailored to the exact package versions in your project
+
 ```txt
-Configure a Cloudflare Worker script to cache JSON API responses for five minutes. use context7
+Configure a Cloudflare Worker script to cache JSON API responses for five minutes. Use the package versions specified in the repository. use context7
 ```
 
 Context7 fetches up-to-date code examples and documentation right into your LLM's context.

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,6 +115,7 @@ server.registerTool(
     description: `Resolves a package/product name to a Context7-compatible library ID and returns a list of matching libraries.
 
 You MUST call this function before 'get-library-docs' to obtain a valid Context7-compatible library ID UNLESS the user explicitly provides a library ID in the format '/org/project' or '/org/project/version' in their query.
+- ⚠️ IMPORTANT: When the user says "use context7", they want documentation for OTHER libraries (like React, Next.js, MongoDB, etc.), NOT about Context7 itself unless they explicitly ask about Context7 documentation.
 
 Selection Process:
 1. Analyze the query to understand what library/package the user is looking for
@@ -169,6 +170,7 @@ Each result includes:
 - Code Snippets: Number of available code examples
 - Trust Score: Authority indicator
 - Versions: List of versions if available. Use one of those versions if the user provides a version in their query. The format of the version is /org/project/version.
+- ⚠️ IMPORTANT: When the user says "use context7", they want documentation for OTHER libraries (like React, Next.js, MongoDB, etc.), NOT about Context7 itself unless they explicitly ask about Context7 documentation.
 
 For best results, select libraries based on name match, trust score, snippet coverage, and relevance to your use case.
 


### PR DESCRIPTION
Improve readme.

Working prompt example:

<img width="832" height="629" alt="image" src="https://github.com/user-attachments/assets/7f0d1973-5041-4b09-8e8e-6e9014c66f31" />


There is only one problem, for each package, the number of versions available on context7 is very limited. If that version doesn't exist in context7 it'll default to no version.