### PR TITLE
docs: update the Zed configuration file format

### DIFF
--- a/docs/README.ar.md
+++ b/docs/README.ar.md
@@ -123,11 +123,9 @@ npx -y @smithery/cli install @upstash/context7-mcp --client claude
 {
   "context_servers": {
     "Context7": {
-      "command": {
-        "path": "npx",
-        "args": ["-y", "@upstash/context7-mcp@latest"]
-      },
-      "settings": {}
+      "source": "custom",
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp", "--api-key", "YOUR_API_KEY"]
     }
   }
 }

--- a/docs/README.de.md
+++ b/docs/README.de.md
@@ -138,11 +138,9 @@ Es kann über [Zed Extensions](https://zed.dev/extensions?query=Context7) instal
 {
   "context_servers": {
     "Context7": {
-      "command": {
-        "path": "npx",
-        "args": ["-y", "@upstash/context7-mcp@latest"]
-      },
-      "settings": {}
+      "source": "custom",
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp", "--api-key", "YOUR_API_KEY"]
     }
   }
 }
@@ -204,7 +202,7 @@ Weitere Informationen findest du in der [offiziellen GitHub-Dokumentation](https
         "CONTEXT7_API_KEY": "YOUR_API_KEY"
       },
       "tools": [
-        "get-library-docs", 
+        "get-library-docs",
         "resolve-library-id"
       ]
     }
@@ -221,7 +219,7 @@ Oder für einen lokalen Server:
       "type": "local",
       "command": "npx",
       "tools": [
-        "get-library-docs", 
+        "get-library-docs",
         "resolve-library-id"
       ],
       "args": [

--- a/docs/README.fr.md
+++ b/docs/README.fr.md
@@ -138,11 +138,9 @@ Peut être installé via [Zed Extensions](https://zed.dev/extensions?query=Conte
 {
   "context_servers": {
     "Context7": {
-      "command": {
-        "path": "npx",
-        "args": ["-y", "@upstash/context7-mcp@latest"]
-      },
-      "settings": {}
+      "source": "custom",
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp", "--api-key", "YOUR_API_KEY"]
     }
   }
 }
@@ -221,7 +219,7 @@ Pour plus d'informations, consultez la [documentation officielle GitHub](https:/
         "CONTEXT7_API_KEY": "YOUR_API_KEY"
       },
       "tools": [
-        "get-library-docs", 
+        "get-library-docs",
         "resolve-library-id"
       ]
     }
@@ -238,7 +236,7 @@ Ou, pour un serveur local :
       "type": "local",
       "command": "npx",
       "tools": [
-        "get-library-docs", 
+        "get-library-docs",
         "resolve-library-id"
       ],
       "args": [

--- a/docs/README.id-ID.md
+++ b/docs/README.id-ID.md
@@ -256,11 +256,9 @@ Dapat diinstal melalui [Ekstensi Zed](https://zed.dev/extensions?query=Context7)
 {
   "context_servers": {
     "Context7": {
-      "command": {
-        "path": "npx",
-        "args": ["-y", "@upstash/context7-mcp"]
-      },
-      "settings": {}
+      "source": "custom",
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp", "--api-key", "YOUR_API_KEY"]
     }
   }
 }
@@ -654,7 +652,7 @@ Untuk informasi lebih lanjut, lihat [dokumentasi resmi GitHub](https://docs.gith
         "CONTEXT7_API_KEY": "YOUR_API_KEY"
       },
       "tools": [
-        "get-library-docs", 
+        "get-library-docs",
         "resolve-library-id"
       ]
     }
@@ -671,7 +669,7 @@ Atau, untuk server lokal:
       "type": "local",
       "command": "npx",
       "tools": [
-        "get-library-docs", 
+        "get-library-docs",
         "resolve-library-id"
       ],
       "args": [

--- a/docs/README.it.md
+++ b/docs/README.it.md
@@ -140,11 +140,9 @@ Può essere installato tramite [Zed Extensions](https://zed.dev/extensions?query
 {
   "context_servers": {
     "Context7": {
-      "command": {
-        "path": "npx",
-        "args": ["-y", "@upstash/context7-mcp@latest"]
-      },
-      "settings": {}
+      "source": "custom",
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp", "--api-key", "YOUR_API_KEY"]
     }
   }
 }
@@ -206,7 +204,7 @@ Per maggiori informazioni, consulta la [documentazione ufficiale GitHub](https:/
         "CONTEXT7_API_KEY": "YOUR_API_KEY"
       },
       "tools": [
-        "get-library-docs", 
+        "get-library-docs",
         "resolve-library-id"
       ]
     }
@@ -223,7 +221,7 @@ Oppure, per un server locale:
       "type": "local",
       "command": "npx",
       "tools": [
-        "get-library-docs", 
+        "get-library-docs",
         "resolve-library-id"
       ],
       "args": [

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -283,11 +283,9 @@ Smithery キーは [Smithery.ai Web ページ](https://smithery.ai/server/@upsta
 {
   "context_servers": {
     "Context7": {
-      "command": {
-        "path": "npx",
-        "args": ["-y", "@upstash/context7-mcp"]
-      },
-      "settings": {}
+      "source": "custom",
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp", "--api-key", "YOUR_API_KEY"]
     }
   }
 }
@@ -389,7 +387,7 @@ claude mcp add context7 -- npx -y @upstash/context7-mcp
         "CONTEXT7_API_KEY": "YOUR_API_KEY"
       },
       "tools": [
-        "get-library-docs", 
+        "get-library-docs",
         "resolve-library-id"
       ]
     }
@@ -406,7 +404,7 @@ claude mcp add context7 -- npx -y @upstash/context7-mcp
       "type": "local",
       "command": "npx",
       "tools": [
-        "get-library-docs", 
+        "get-library-docs",
         "resolve-library-id"
       ],
       "args": [

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -290,11 +290,9 @@ Visual Studio MCP 설정 파일에 다음을 추가하세요(자세한 내용은
 {
   "context_servers": {
     "Context7": {
-      "command": {
-        "path": "npx",
-        "args": ["-y", "@upstash/context7-mcp"]
-      },
-      "settings": {}
+      "source": "custom",
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp", "--api-key", "YOUR_API_KEY"]
     }
   }
 }
@@ -445,7 +443,7 @@ Claude Desktop의 `claude_desktop_config.json` 파일에 다음을 추가하세�
         "CONTEXT7_API_KEY": "YOUR_API_KEY"
       },
       "tools": [
-        "get-library-docs", 
+        "get-library-docs",
         "resolve-library-id"
       ]
     }
@@ -462,7 +460,7 @@ Claude Desktop의 `claude_desktop_config.json` 파일에 다음을 추가하세�
       "type": "local",
       "command": "npx",
       "tools": [
-        "get-library-docs", 
+        "get-library-docs",
         "resolve-library-id"
       ],
       "args": [

--- a/docs/README.pt-BR.md
+++ b/docs/README.pt-BR.md
@@ -211,11 +211,9 @@ Pode ser instalado via [Zed Extensions](https://zed.dev/extensions?query=Context
 {
   "context_servers": {
     "Context7": {
-      "command": {
-        "path": "npx",
-        "args": ["-y", "@upstash/context7-mcp"]
-      },
-      "settings": {}
+      "source": "custom",
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp", "--api-key", "YOUR_API_KEY"]
     }
   }
 }
@@ -719,7 +717,7 @@ Para mais informações, veja a [documentação oficial do GitHub](https://docs.
         "CONTEXT7_API_KEY": "YOUR_API_KEY"
       },
       "tools": [
-        "get-library-docs", 
+        "get-library-docs",
         "resolve-library-id"
       ]
     }
@@ -736,7 +734,7 @@ Ou, para um servidor local:
       "type": "local",
       "command": "npx",
       "tools": [
-        "get-library-docs", 
+        "get-library-docs",
         "resolve-library-id"
       ],
       "args": [

--- a/docs/README.ru.md
+++ b/docs/README.ru.md
@@ -138,11 +138,9 @@ npx -y @smithery/cli install @upstash/context7-mcp --client claude
 {
   "context_servers": {
     "Context7": {
-      "command": {
-        "path": "npx",
-        "args": ["-y", "@upstash/context7-mcp"]
-      },
-      "settings": {}
+      "source": "custom",
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp", "--api-key", "YOUR_API_KEY"]
     }
   }
 }
@@ -219,7 +217,7 @@ claude mcp add context7 -- npx -y @upstash/context7-mcp
         "CONTEXT7_API_KEY": "YOUR_API_KEY"
       },
       "tools": [
-        "get-library-docs", 
+        "get-library-docs",
         "resolve-library-id"
       ]
     }
@@ -236,7 +234,7 @@ claude mcp add context7 -- npx -y @upstash/context7-mcp
       "type": "local",
       "command": "npx",
       "tools": [
-        "get-library-docs", 
+        "get-library-docs",
         "resolve-library-id"
       ],
       "args": [

--- a/docs/README.tr.md
+++ b/docs/README.tr.md
@@ -140,11 +140,9 @@ Bunu VS Code MCP yapılandırma dosyanıza ekleyin. Daha fazla bilgi için [VS C
 {
   "context_servers": {
     "Context7": {
-      "command": {
-        "path": "npx",
-        "args": ["-y", "@upstash/context7-mcp@latest"]
-      },
-      "settings": {}
+      "source": "custom",
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp", "--api-key", "YOUR_API_KEY"]
     }
   }
 }

--- a/docs/README.uk.md
+++ b/docs/README.uk.md
@@ -288,11 +288,9 @@ npx -y @smithery/cli@latest install @upstash/context7-mcp --client <CLIENT_NAME>
 {
   "context_servers": {
     "Context7": {
-      "command": {
-        "path": "npx",
-        "args": ["-y", "@upstash/context7-mcp"]
-      },
-      "settings": {}
+      "source": "custom",
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp", "--api-key", "YOUR_API_KEY"]
     }
   }
 }
@@ -342,7 +340,7 @@ npx -y @smithery/cli@latest install @upstash/context7-mcp --client <CLIENT_NAME>
         "CONTEXT7_API_KEY": "YOUR_API_KEY"
       },
       "tools": [
-        "get-library-docs", 
+        "get-library-docs",
         "resolve-library-id"
       ]
     }
@@ -359,7 +357,7 @@ npx -y @smithery/cli@latest install @upstash/context7-mcp --client <CLIENT_NAME>
       "type": "local",
       "command": "npx",
       "tools": [
-        "get-library-docs", 
+        "get-library-docs",
         "resolve-library-id"
       ],
       "args": [

--- a/docs/README.vi.md
+++ b/docs/README.vi.md
@@ -290,11 +290,9 @@ Có thể cài đặt thông qua [Zed Extensions](https://zed.dev/extensions?que
 {
   "context_servers": {
     "Context7": {
-      "command": {
-        "path": "npx",
-        "args": ["-y", "@upstash/context7-mcp"]
-      },
-      "settings": {}
+      "source": "custom",
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp", "--api-key", "YOUR_API_KEY"]
     }
   }
 }
@@ -751,7 +749,7 @@ Thêm cấu hình sau vào phần `mcp` trong file cấu hình Copilot Coding Ag
         "CONTEXT7_API_KEY": "YOUR_API_KEY"
       },
       "tools": [
-        "get-library-docs", 
+        "get-library-docs",
         "resolve-library-id"
       ]
     }
@@ -768,7 +766,7 @@ Hoặc, đối với server cục bộ:
       "type": "local",
       "command": "npx",
       "tools": [
-        "get-library-docs", 
+        "get-library-docs",
         "resolve-library-id"
       ],
       "args": [
@@ -785,9 +783,9 @@ Hoặc, đối với server cục bộ:
 Nếu file `mcp-config.json` không tồn tại, hãy tạo nó.
 
 </details>
-  
+
 <details>
-  
+
 <summary><b>Cài đặt trong Kiro</b></summary>
 
 Xem [Tài liệu Kiro Model Context Protocol](https://kiro.dev/docs/mcp/configuration/) để biết chi tiết.

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -245,11 +245,9 @@ claude mcp add context7 -- npx -y @upstash/context7-mcp --api-key YOUR_API_KEY
 {
   "context_servers": {
     "Context7": {
-      "command": {
-        "path": "npx",
-        "args": ["-y", "@upstash/context7-mcp", "--api-key", "YOUR_API_KEY"]
-      },
-      "settings": {}
+      "source": "custom",
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp", "--api-key", "YOUR_API_KEY"]
     }
   }
 }
@@ -755,7 +753,7 @@ http_headers = { "CONTEXT7_API_KEY" = "YOUR_API_KEY" }
         "CONTEXT7_API_KEY": "YOUR_API_KEY"
       },
       "tools": [
-        "get-library-docs", 
+        "get-library-docs",
         "resolve-library-id"
       ]
     }
@@ -772,7 +770,7 @@ http_headers = { "CONTEXT7_API_KEY" = "YOUR_API_KEY" }
       "type": "local",
       "command": "npx",
       "tools": [
-        "get-library-docs", 
+        "get-library-docs",
         "resolve-library-id"
       ],
       "args": [

--- a/docs/README.zh-TW.md
+++ b/docs/README.zh-TW.md
@@ -279,11 +279,9 @@ npx -y @smithery/cli@latest install @upstash/context7-mcp --client <CLIENT_NAME>
 {
   "context_servers": {
     "Context7": {
-      "command": {
-        "path": "npx",
-        "args": ["-y", "@upstash/context7-mcp"]
-      },
-      "settings": {}
+      "source": "custom",
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp", "--api-key", "YOUR_API_KEY"]
     }
   }
 }
@@ -458,7 +456,7 @@ claude mcp add context7 -- npx -y @upstash/context7-mcp
         "CONTEXT7_API_KEY": "YOUR_API_KEY"
       },
       "tools": [
-        "get-library-docs", 
+        "get-library-docs",
         "resolve-library-id"
       ]
     }
@@ -475,7 +473,7 @@ claude mcp add context7 -- npx -y @upstash/context7-mcp
       "type": "local",
       "command": "npx",
       "tools": [
-        "get-library-docs", 
+        "get-library-docs",
         "resolve-library-id"
       ],
       "args": [


### PR DESCRIPTION
The documentation in the `docs` directory has outdated configuration versions for Zed.