### PR TITLE
docs: add Google Antigravity installation instructions

### DIFF
--- a/.github/workflows/ecr-deploy.yml
+++ b/.github/workflows/ecr-deploy.yml
@@ -1,51 +1,51 @@
 name: Deploy to AWS ECR
 
 on:
-    workflow_dispatch:
-        inputs:
-            version:
-                description: 'Docker image version tag (e.g., v0.0.22)'
-                required: true
-                type: string
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Docker image version tag (e.g., v0.0.22)"
+        required: true
+        type: string
 
 jobs:
-    build-and-push:
-        runs-on: ubuntu-latest
+  build-and-push:
+    runs-on: ubuntu-latest
 
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v4
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-            - name: Configure AWS credentials
-              uses: aws-actions/configure-aws-credentials@v4
-              with:
-                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-                  aws-region: ${{ secrets.AWS_REGION }}
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
 
-            - name: Login to Amazon ECR
-              id: login-ecr
-              uses: aws-actions/amazon-ecr-login@v2
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
 
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-            - name: Build and push Docker image
-              id: build-push
-              uses: docker/build-push-action@v5
-              with:
-                  context: .
-                  platforms: linux/amd64
-                  push: true
-                  tags: |
-                      ${{ secrets.ECR_REGISTRY }}/${{ secrets.ECR_REPOSITORY }}:${{ inputs.version }}
-                  cache-from: type=gha
-                  cache-to: type=gha,mode=max
+      - name: Build and push Docker image
+        id: build-push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ secrets.ECR_REGISTRY }}/${{ secrets.ECR_REPOSITORY }}:${{ inputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
-            - name: Create GitHub Summary
-              run: |
-                  echo "## Docker Image Deployed Successfully" >> $GITHUB_STEP_SUMMARY
-                  echo "" >> $GITHUB_STEP_SUMMARY
-                  echo "**Image Tag:** \`${{ inputs.version }}\`" >> $GITHUB_STEP_SUMMARY
-                  echo "" >> $GITHUB_STEP_SUMMARY
-                  echo "**Status:** ✅ Image pushed to AWS ECR" >> $GITHUB_STEP_SUMMARY
+      - name: Create GitHub Summary
+        run: |
+          echo "## Docker Image Deployed Successfully" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Image Tag:** \`${{ inputs.version }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Status:** ✅ Image pushed to AWS ECR" >> $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -170,41 +170,6 @@ amp mcp add context7 --header "CONTEXT7_API_KEY=YOUR_API_KEY" https://mcp.contex
 </details>
 
 <details>
-<summary><b>Install in Google Antigravity</b></summary>
-
-Add this to your Antigravity MCP config file. See [Antigravity MCP docs](https://antigravity.google/docs/mcp) for more info.
-
-#### Google Antigravity Remote Server Connection
-
-```json
-{
-    "mcpServers": {
-        "context7": {
-            "serverUrl": "https://mcp.context7.com/mcp",
-            "headers": {
-                "CONTEXT7_API_KEY": "YOUR_API_KEY"
-            }
-        }
-    }
-}
-```
-
-#### Google Antigravity Local Server Connection
-
-```json
-{
-  "mcpServers": {
-    "context7": {
-      "command": "npx",
-      "args": ["-y", "@upstash/context7-mcp", "--api-key", "YOUR_API_KEY"]
-    }
-  }
-}
-```
-
-</details>
-
-<details>
 <summary><b>Install in Windsurf</b></summary>
 
 Add this to your Windsurf MCP config file. See [Windsurf MCP docs](https://docs.windsurf.com/windsurf/cascade/mcp) for more info.
@@ -316,76 +281,6 @@ Or you can directly edit MCP servers configuration:
 </details>
 
 <details>
-<summary><b>Install in Kilo Code</b></summary>
-
-You can configure the Context7 MCP server in **Kilo Code** using either the UI or by editing your project's MCP configuration file.
-
-Kilo Code supports two configuration levels:
-
-- **Global MCP Configuration** — stored in `mcp_settings.json`
-- **Project-level MCP Configuration** — stored in `.kilocode/mcp.json` (recommended)
-
-If a server is defined in both places, the **project-level configuration overrides the global one**.
-
----
-
-## Configure via Kilo Code UI
-
-1. Open **Kilo Code**.
-2. Click the **Settings** icon in the top-right corner.
-3. Navigate to **Settings → MCP Servers**.
-4. Click **Add Server**.
-5. Choose **HTTP Server** (Streamable HTTP Transport).
-6. Enter the details:
-
-**URL**
-`https://mcp.context7.com/mcp`
-
-**Headers → Add Header**
-- **Key:** `Authorization`
-- **Value:** `Bearer YOUR_API_KEY`
-
-7. Click **Save**.
-8. Ensure the server toggle is **enabled**.
-9. If needed, click **Refresh MCP Servers** to reload the configuration.
-
----
-
-## Manual Configuration (`.kilocode/mcp.json`)
-
-To configure the server at the project level (recommended for team environments), create the following file:
-
-**`.kilocode/mcp.json`:**
-
-```json
-{
-  "mcpServers": {
-    "context7": {
-      "type": "streamable-http",
-      "url": "https://mcp.context7.com/mcp",
-      "headers": {
-        "Authorization": "Bearer YOUR_API_KEY"
-      },
-      "alwaysAllow": [],
-      "disabled": false
-    }
-  }
-}
-```
-
-Replace YOUR_API_KEY with your actual Context7 API key.
-
-After saving the file:
-
-- Open Settings → MCP Servers
-
-- Click Refresh MCP Servers
-
-Kilo Code will automatically detect and load the configuration.
-
-</details>
-
-<details>
 <summary><b>Install in Zed</b></summary>
 
 It can be installed via [Zed Extensions](https://zed.dev/extensions?query=Context7) or you can add this to your Zed `settings.json`. See [Zed Context Server docs](https://zed.dev/docs/assistant/context-servers) for more info.
@@ -448,6 +343,112 @@ Once the MCP server is added, you can start using Context7's up-to-date code doc
 ```
 
 Once the MCP server is added, restart your editor. If you receive any errors, check the syntax to make sure closing brackets or commas are not missing.
+
+</details>
+
+<details>
+<summary><b>Install in Kilo Code</b></summary>
+
+You can configure the Context7 MCP server in **Kilo Code** using either the UI or by editing your project's MCP configuration file.
+
+Kilo Code supports two configuration levels:
+
+- **Global MCP Configuration** — stored in `mcp_settings.json`
+- **Project-level MCP Configuration** — stored in `.kilocode/mcp.json` (recommended)
+
+If a server is defined in both places, the **project-level configuration overrides the global one**.
+
+---
+
+## Configure via Kilo Code UI
+
+1. Open **Kilo Code**.
+2. Click the **Settings** icon in the top-right corner.
+3. Navigate to **Settings → MCP Servers**.
+4. Click **Add Server**.
+5. Choose **HTTP Server** (Streamable HTTP Transport).
+6. Enter the details:
+
+**URL**
+`https://mcp.context7.com/mcp`
+
+**Headers → Add Header**
+
+- **Key:** `Authorization`
+- **Value:** `Bearer YOUR_API_KEY`
+
+7. Click **Save**.
+8. Ensure the server toggle is **enabled**.
+9. If needed, click **Refresh MCP Servers** to reload the configuration.
+
+---
+
+## Manual Configuration (`.kilocode/mcp.json`)
+
+To configure the server at the project level (recommended for team environments), create the following file:
+
+**`.kilocode/mcp.json`:**
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "type": "streamable-http",
+      "url": "https://mcp.context7.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      },
+      "alwaysAllow": [],
+      "disabled": false
+    }
+  }
+}
+```
+
+Replace YOUR_API_KEY with your actual Context7 API key.
+
+After saving the file:
+
+- Open Settings → MCP Servers
+
+- Click Refresh MCP Servers
+
+Kilo Code will automatically detect and load the configuration.
+
+</details>
+
+<details>
+<summary><b>Install in Google Antigravity</b></summary>
+
+Add this to your Antigravity MCP config file. See [Antigravity MCP docs](https://antigravity.google/docs/mcp) for more info.
+
+#### Google Antigravity Remote Server Connection
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "serverUrl": "https://mcp.context7.com/mcp",
+      "headers": {
+        "CONTEXT7_API_KEY": "YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+#### Google Antigravity Local Server Connection
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp", "--api-key", "YOUR_API_KEY"]
+    }
+  }
+}
+```
 
 </details>
 
@@ -1294,6 +1295,7 @@ Once configured, Context7 tools will be available in your droid sessions. Type `
 [Emdash](https://github.com/generalaction/emdash) is an orchestration layer for running multiple coding agents in parallel. Provider-agnostic, worktree-isolated, and local-first. Emdash supports Context7 MCP to enable Context7 for your agents.
 
 **What Emdash provides:**
+
 - Global toggle: Settings → MCP → "Enable Context7 MCP"
 - Per-workspace enable: The Context7 button in the ProviderBar (off by default). First click enables it for that workspace. Clicking again disables it.
 - ProviderBar: The Context7 button shows status, a short explanation, and a link to docs

--- a/README.md
+++ b/README.md
@@ -170,6 +170,41 @@ amp mcp add context7 --header "CONTEXT7_API_KEY=YOUR_API_KEY" https://mcp.contex
 </details>
 
 <details>
+<summary><b>Install in Google Antigravity</b></summary>
+
+Add this to your Antigravity MCP config file. See [Antigravity MCP docs](https://antigravity.google/docs/mcp) for more info.
+
+#### Google Antigravity Remote Server Connection
+
+```json
+{
+    "mcpServers": {
+        "context7": {
+            "serverUrl": "https://mcp.context7.com/mcp",
+            "headers": {
+                "CONTEXT7_API_KEY": "YOUR_API_KEY"
+            }
+        }
+    }
+}
+```
+
+#### Google Antigravity Local Server Connection
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp", "--api-key", "YOUR_API_KEY"]
+    }
+  }
+}
+```
+
+</details>
+
+<details>
 <summary><b>Install in Windsurf</b></summary>
 
 Add this to your Windsurf MCP config file. See [Windsurf MCP docs](https://docs.windsurf.com/windsurf/cascade/mcp) for more info.

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -30,11 +30,12 @@ After installing Context7 (see instructions below), enhance your workflow by add
 - Or the equivalent in your MCP client
 
 **Example Rule:**
+
 ```txt
-Always use context7 when I need code generation, setup or 
-configuration steps, or library/API documentation. This means 
-you should automatically use the Context7 MCP tools to resolve 
-library id and get library docs without me having to 
+Always use context7 when I need code generation, setup or
+configuration steps, or library/API documentation. This means
+you should automatically use the Context7 MCP tools to resolve
+library id and get library docs without me having to
 explicitly ask.
 ```
 


### PR DESCRIPTION
## Summary
- add collapsible instructions for installing context7 MCP in Google Antigravity
- document both remote server and local npx connection examples with API key header
- include link to the official Antigravity MCP docs for reference

## Testing
- doc change only