### PR TITLE
docs: update tool name to query-docs in install guides

### DIFF
--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -638,7 +638,7 @@ Get your Smithery key from your account at [smithery.ai](https://smithery.ai/ser
     }
     ```
 
-    Use `get-library-docs` in the chat with your Context7 documentation ID.
+    Use `query-docs` in the chat with your Context7 documentation ID.
 
   </Accordion>
 
@@ -804,7 +804,7 @@ Get your Smithery key from your account at [smithery.ai](https://smithery.ai/ser
           "headers": {
             "CONTEXT7_API_KEY": "YOUR_API_KEY"
           },
-          "tools": ["get-library-docs", "resolve-library-id"]
+          "tools": ["query-docs", "resolve-library-id"]
         }
       }
     }
@@ -827,7 +827,7 @@ Get your Smithery key from your account at [smithery.ai](https://smithery.ai/ser
             "CONTEXT7_API_KEY": "YOUR_API_KEY"
           },
           "tools": [
-            "get-library-docs",
+            "query-docs",
             "resolve-library-id"
           ]
         }
@@ -843,7 +843,7 @@ Get your Smithery key from your account at [smithery.ai](https://smithery.ai/ser
           "type": "local",
           "command": "npx",
           "tools": [
-            "get-library-docs",
+            "query-docs",
             "resolve-library-id"
           ],
           "args": [


### PR DESCRIPTION
Following the official renaming of the tool get-library-docs to query-docs, this PR updates all references within the context7 project documentation to maintain consistency and ensure the installation instructions are accurate for users.