### PR TITLE
readme: fixing broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Add this to your VS Code MCP config file. See [VS Code MCP docs](https://code.vi
 
 </details>
 
-**[Other IDEs and Clients →](https://context7.com/docs/all-clients)**
+**[Other IDEs and Clients →](https://context7.com/docs/resources/all-clients)**
 
 ## Important Tips
 


### PR DESCRIPTION
closes #1330 

Fixing two broken links to Other Cli configurations
from https://context7.com/docs/all-clients
to https://context7.com/docs/resources/all-clients