### PR TITLE
chore(deps): upgrade ai to v6 and @ai-sdk/amazon-bedrock to v4

### DIFF
--- a/.changeset/good-worms-check.md
+++ b/.changeset/good-worms-check.md
@@ -1,0 +1,5 @@
+---
+"@upstash/context7-tools-ai-sdk": patch
+---
+
+Upgrade ai peer dependency to >=6.0.0 for AI SDK v6 compatibility

--- a/packages/tools-ai-sdk/package.json
+++ b/packages/tools-ai-sdk/package.json
@@ -30,14 +30,14 @@
   },
   "peerDependencies": {
     "@upstash/context7-sdk": ">=0.2.0",
-    "ai": ">=5.0.0",
+    "ai": ">=6.0.0",
     "zod": ">=3.24.0"
   },
   "devDependencies": {
     "@upstash/context7-sdk": "workspace:*",
-    "ai": "^5.0.0",
+    "ai": "^6.0.5",
     "zod": "^3.24.0",
-    "@ai-sdk/amazon-bedrock": "^3.0.55",
+    "@ai-sdk/amazon-bedrock": "^4.0.9",
     "@types/node": "^25.0.3",
     "dotenv": "^17.2.3",
     "tsup": "^8.5.1",

--- a/packages/tools-ai-sdk/src/agents/context7.ts
+++ b/packages/tools-ai-sdk/src/agents/context7.ts
@@ -1,16 +1,11 @@
-import {
-  Experimental_Agent as Agent,
-  type Experimental_AgentSettings as AgentSettings,
-  type ToolSet,
-  stepCountIs,
-} from "ai";
+import { ToolLoopAgent, type ToolLoopAgentSettings, type ToolSet, stepCountIs } from "ai";
 import { resolveLibraryId, queryDocs } from "@tools";
 import { AGENT_PROMPT } from "@prompts";
 
 /**
  * Configuration for Context7 agent.
  */
-export interface Context7AgentConfig extends AgentSettings<ToolSet> {
+export interface Context7AgentConfig extends ToolLoopAgentSettings<never, ToolSet> {
   /**
    * Context7 API key. If not provided, uses the CONTEXT7_API_KEY environment variable.
    */
@@ -40,16 +35,24 @@ export interface Context7AgentConfig extends AgentSettings<ToolSet> {
  * });
  * ```
  */
-export class Context7Agent extends Agent<ToolSet> {
+export class Context7Agent extends ToolLoopAgent<never, ToolSet> {
   constructor(config: Context7AgentConfig) {
-    const { model, stopWhen = stepCountIs(5), system, apiKey, tools, ...agentSettings } = config;
+    const {
+      model,
+      stopWhen = stepCountIs(5),
+      instructions,
+      apiKey,
+
+      tools,
+      ...agentSettings
+    } = config;
 
     const context7Config = { apiKey };
 
     super({
       ...agentSettings,
       model,
-      system: system || AGENT_PROMPT,
+      instructions: instructions || AGENT_PROMPT,
       tools: {
         ...tools,
         resolveLibraryId: resolveLibraryId(context7Config),

--- a/packages/tools-ai-sdk/src/index.test.ts
+++ b/packages/tools-ai-sdk/src/index.test.ts
@@ -128,10 +128,10 @@ describe("@upstash/context7-tools-ai-sdk", () => {
       expect(agent).toBeDefined();
     });
 
-    test("should accept custom system prompt", () => {
+    test("should accept custom instructions", () => {
       const agent = new Context7Agent({
         model: bedrock("anthropic.claude-3-haiku-20240307-v1:0"),
-        system: "Custom system prompt for testing",
+        instructions: "Custom instructions for testing",
       });
 
       expect(agent).toBeDefined();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,8 +88,8 @@ importers:
   packages/tools-ai-sdk:
     devDependencies:
       '@ai-sdk/amazon-bedrock':
-        specifier: ^3.0.55
-        version: 3.0.62(zod@3.25.76)
+        specifier: ^4.0.9
+        version: 4.0.9(zod@3.25.76)
       '@types/node':
         specifier: ^25.0.3
         version: 25.0.3
@@ -97,8 +97,8 @@ importers:
         specifier: workspace:*
         version: link:../sdk
       ai:
-        specifier: ^5.0.0
-        version: 5.0.104(zod@3.25.76)
+        specifier: ^6.0.5
+        version: 6.0.14(zod@3.25.76)
       dotenv:
         specifier: ^17.2.3
         version: 17.2.3
@@ -117,32 +117,32 @@ importers:
 
 packages:
 
-  '@ai-sdk/amazon-bedrock@3.0.62':
-    resolution: {integrity: sha512-vVtndaj5zfHmgw8NSqN4baFDbFDTBZP6qufhKfqSNLtygEm8+8PL9XQX9urgzSzU3zp+zi3AmNNemvKLkkqblg==}
+  '@ai-sdk/amazon-bedrock@4.0.9':
+    resolution: {integrity: sha512-ObpdX+ws91P0Z0e4D3/HeGypFjmsa8UlZY1rA32iGb94GeNuyndOshpmHEzqgssQy9AGiVs26IJWYn7RmO3beg==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/anthropic@2.0.50':
-    resolution: {integrity: sha512-21PaHfoLmouOXXNINTsZJsMw+wE5oLR2He/1kq/sKokTVKyq7ObGT1LDk6ahwxaz/GoaNaGankMh+EgVcdv2Cw==}
+  '@ai-sdk/anthropic@3.0.7':
+    resolution: {integrity: sha512-WFE56yxgjecd77f8pNj1TkusfCKh34E4h+0J0qVOKDNFXuOsZiAb6dIG9Q3PUrwY1MuiMQLD/9ir0s+dVcVfeA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/gateway@2.0.17':
-    resolution: {integrity: sha512-oVAG6q72KsjKlrYdLhWjRO7rcqAR8CjokAbYuyVZoCO4Uh2PH/VzZoxZav71w2ipwlXhHCNaInGYWNs889MMDA==}
+  '@ai-sdk/gateway@3.0.9':
+    resolution: {integrity: sha512-EA5dZIukimwoJ9HIPuuREotAqaTItpdc/yImzVF0XGNg7B0YRJmYI8Uq3aCMr87vjr1YB1cWUfnrTt6OJ9eHiQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider-utils@3.0.18':
-    resolution: {integrity: sha512-ypv1xXMsgGcNKUP+hglKqtdDuMg68nWHucPPAhIENrbFAI+xCHiqPVN8Zllxyv1TNZwGWUghPxJXU+Mqps0YRQ==}
+  '@ai-sdk/provider-utils@4.0.4':
+    resolution: {integrity: sha512-VxhX0B/dWGbpNHxrKCWUAJKXIXV015J4e7qYjdIU9lLWeptk0KMLGcqkB4wFxff5Njqur8dt8wRi1MN9lZtDqg==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider@2.0.0':
-    resolution: {integrity: sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==}
+  '@ai-sdk/provider@3.0.2':
+    resolution: {integrity: sha512-HrEmNt/BH/hkQ7zpi2o6N3k1ZR1QTb7z85WYhYygiTxOQuaml4CMtHCWRbric5WPU+RNsYI7r1EpyVQMKO1pYw==}
     engines: {node: '>=18'}
 
   '@aws-crypto/crc32@5.2.0':
@@ -787,6 +787,9 @@ packages:
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
 
@@ -897,8 +900,8 @@ packages:
     resolution: {integrity: sha512-SIV3/6eftCy1bNzCQoPmbWsRLujS8t5iDIZ4spZOBHqrM+yfX2ogg8Tt3PDTAVKw3sSCiUgg30uOAvK2r9zGjQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@vercel/oidc@3.0.5':
-    resolution: {integrity: sha512-fnYhv671l+eTTp48gB4zEsTW/YtRgRPnkI2nT7x6qw5rkI1Lq2hTmQIpHPgyThI0znLK+vX2n9XxKdXZ7BUbbw==}
+  '@vercel/oidc@3.1.0':
+    resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
     engines: {node: '>= 20'}
 
   '@vitest/expect@4.0.14':
@@ -944,8 +947,8 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  ai@5.0.104:
-    resolution: {integrity: sha512-MZOkL9++nY5PfkpWKBR3Rv+Oygxpb9S16ctv8h91GvrSif7UnNEdPMVZe3bUyMd2djxf0AtBk/csBixP0WwWZQ==}
+  ai@6.0.14:
+    resolution: {integrity: sha512-OaEJFeQ3gb45eZtC/lSNKqAxmsrqWxC8wLmIVXFYAMvPXE3lb96zIdS3swYArR4uXOVt6N7H/XZSyQz/Dl+HTw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -2137,37 +2140,37 @@ packages:
 
 snapshots:
 
-  '@ai-sdk/amazon-bedrock@3.0.62(zod@3.25.76)':
+  '@ai-sdk/amazon-bedrock@4.0.9(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/anthropic': 2.0.50(zod@3.25.76)
-      '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.18(zod@3.25.76)
+      '@ai-sdk/anthropic': 3.0.7(zod@3.25.76)
+      '@ai-sdk/provider': 3.0.2
+      '@ai-sdk/provider-utils': 4.0.4(zod@3.25.76)
       '@smithy/eventstream-codec': 4.2.5
       '@smithy/util-utf8': 4.2.0
       aws4fetch: 1.0.20
       zod: 3.25.76
 
-  '@ai-sdk/anthropic@2.0.50(zod@3.25.76)':
+  '@ai-sdk/anthropic@3.0.7(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.18(zod@3.25.76)
+      '@ai-sdk/provider': 3.0.2
+      '@ai-sdk/provider-utils': 4.0.4(zod@3.25.76)
       zod: 3.25.76
 
-  '@ai-sdk/gateway@2.0.17(zod@3.25.76)':
+  '@ai-sdk/gateway@3.0.9(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.18(zod@3.25.76)
-      '@vercel/oidc': 3.0.5
+      '@ai-sdk/provider': 3.0.2
+      '@ai-sdk/provider-utils': 4.0.4(zod@3.25.76)
+      '@vercel/oidc': 3.1.0
       zod: 3.25.76
 
-  '@ai-sdk/provider-utils@3.0.18(zod@3.25.76)':
+  '@ai-sdk/provider-utils@4.0.4(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 2.0.0
-      '@standard-schema/spec': 1.0.0
+      '@ai-sdk/provider': 3.0.2
+      '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
       zod: 3.25.76
 
-  '@ai-sdk/provider@2.0.0':
+  '@ai-sdk/provider@3.0.2':
     dependencies:
       json-schema: 0.4.0
 
@@ -2729,6 +2732,8 @@ snapshots:
 
   '@standard-schema/spec@1.0.0': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
@@ -2884,7 +2889,7 @@ snapshots:
       '@typescript-eslint/types': 8.47.0
       eslint-visitor-keys: 4.2.1
 
-  '@vercel/oidc@3.0.5': {}
+  '@vercel/oidc@3.1.0': {}
 
   '@vitest/expect@4.0.14':
     dependencies:
@@ -2936,11 +2941,11 @@ snapshots:
 
   acorn@8.15.0: {}
 
-  ai@5.0.104(zod@3.25.76):
+  ai@6.0.14(zod@3.25.76):
     dependencies:
-      '@ai-sdk/gateway': 2.0.17(zod@3.25.76)
-      '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.18(zod@3.25.76)
+      '@ai-sdk/gateway': 3.0.9(zod@3.25.76)
+      '@ai-sdk/provider': 3.0.2
+      '@ai-sdk/provider-utils': 4.0.4(zod@3.25.76)
       '@opentelemetry/api': 1.9.0
       zod: 3.25.76
 


### PR DESCRIPTION
- Upgrade ai from 5.x to 6.x
- Upgrade @ai-sdk/amazon-bedrock from 3.x to 4.x
- Update Context7Agent to use ToolLoopAgent (renamed from Experimental_Agent)
- Rename system to instructions per AI SDK v6 API changes
- Update tests for new API