### PR TITLE
fix(docs): reoder claude installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,16 +87,16 @@ Pasting the following configuration into your Cursor `~/.cursor/mcp.json` file i
 
 Run this command. See [Claude Code MCP docs](https://code.claude.com/docs/en/mcp) for more info.
 
-#### Claude Code Remote Server Connection
-
-```sh
-claude mcp add --transport http context7 https://mcp.context7.com/mcp --header "CONTEXT7_API_KEY: YOUR_API_KEY"
-```
-
 #### Claude Code Local Server Connection
 
 ```sh
 claude mcp add context7 -- npx -y @upstash/context7-mcp --api-key YOUR_API_KEY
+```
+
+#### Claude Code Remote Server Connection
+
+```sh
+claude mcp add --transport http context7 https://mcp.context7.com/mcp --header "CONTEXT7_API_KEY: YOUR_API_KEY"
 ```
 
 </details>

--- a/docs/resources/all-clients.mdx
+++ b/docs/resources/all-clients.mdx
@@ -57,16 +57,16 @@ Since Cursor 1.0, you can click the install button below for instant one-click i
 
 Run this command. See [Claude Code MCP docs](https://docs.anthropic.com/en/docs/claude-code/mcp) for more info.
 
-#### Remote Server Connection
-
-```sh
-claude mcp add --transport http context7 https://mcp.context7.com/mcp --header "CONTEXT7_API_KEY: YOUR_API_KEY"
-```
-
 #### Local Server Connection
 
 ```sh
 claude mcp add context7 -- npx -y @upstash/context7-mcp --api-key YOUR_API_KEY
+```
+
+#### Remote Server Connection
+
+```sh
+claude mcp add --transport http context7 https://mcp.context7.com/mcp --header "CONTEXT7_API_KEY: YOUR_API_KEY"
 ```
 
 </Accordion>

--- a/i18n/README.id-ID.md
+++ b/i18n/README.id-ID.md
@@ -266,13 +266,13 @@ Jika objek `mcpServers` tidak ada, buatlah.
 <details>
 <summary><b>Instal di Claude Code</b></summary>
 Jalankan perintah ini. Lihat [dokumentasi MCP Claude Code](https://docs.anthropic.com/id/docs/claude-code/mcp) untuk info lebih lanjut.
-#### Koneksi Server Remote Claude Code
-```sh
-claude mcp add --transport http context7 https://mcp.context7.com/mcp
-```
 #### Koneksi Server Lokal Claude Code
 ```sh
 claude mcp add context7 -- npx -y @upstash/context7-mcp
+```
+#### Koneksi Server Remote Claude Code
+```sh
+claude mcp add --transport http context7 https://mcp.context7.com/mcp
 ```
 </details>
 <details>

--- a/i18n/README.ja.md
+++ b/i18n/README.ja.md
@@ -241,13 +241,13 @@ Smithery キーは [Smithery.ai Web ページ](https://smithery.ai/server/@upsta
 <details>
 <summary><b>Claude Code へのインストール</b></summary>
 このコマンドを実行します。詳細は [Claude Code MCP ドキュメント](https://docs.anthropic.com/ja/docs/claude-code/mcp) を参照してください。
-#### Claude Code リモートサーバー接続
-```sh
-claude mcp add --transport http context7 https://mcp.context7.com/mcp
-```
 #### Claude Code ローカルサーバー接続
 ```sh
 claude mcp add context7 -- npx -y @upstash/context7-mcp
+```
+#### Claude Code リモートサーバー接続
+```sh
+claude mcp add --transport http context7 https://mcp.context7.com/mcp
 ```
 </details>
 <details>

--- a/i18n/README.ko.md
+++ b/i18n/README.ko.md
@@ -85,16 +85,16 @@ Cursor의 `~/.cursor/mcp.json` 파일에 다음 설정을 붙여넣는 것이 �
 
 이 명령어를 실행하세요. 자세한 내용은 [Claude Code MCP 문서](https://code.claude.com/docs/en/mcp)를 참조하세요.
 
-#### Claude Code 원격 서버 연결
-
-```sh
-claude mcp add --transport http context7 https://mcp.context7.com/mcp --header "CONTEXT7_API_KEY: YOUR_API_KEY"
-```
-
 #### Claude Code 로컬 서버 연결
 
 ```sh
 claude mcp add context7 -- npx -y @upstash/context7-mcp --api-key YOUR_API_KEY
+```
+
+#### Claude Code 원격 서버 연결
+
+```sh
+claude mcp add --transport http context7 https://mcp.context7.com/mcp --header "CONTEXT7_API_KEY: YOUR_API_KEY"
 ```
 
 </details>

--- a/i18n/README.pt-BR.md
+++ b/i18n/README.pt-BR.md
@@ -85,13 +85,13 @@ Colar a seguinte configuração no arquivo `~/.cursor/mcp.json` do Cursor é a a
 <details>
 <summary><b>Instalar no Claude Code</b></summary>
 Execute este comando. Veja mais em [Claude Code MCP docs](https://docs.anthropic.com/pt/docs/claude-code/mcp).
-#### Conexão Remota do Servidor Claude Code
-```sh
-claude mcp add --transport http context7 https://mcp.context7.com/mcp
-```
 #### Conexão Local do Servidor Claude Code
 ```sh
 claude mcp add context7 -- npx -y @upstash/context7-mcp
+```
+#### Conexão Remota do Servidor Claude Code
+```sh
+claude mcp add --transport http context7 https://mcp.context7.com/mcp
 ```
 </details>
 <details>

--- a/i18n/README.uk.md
+++ b/i18n/README.uk.md
@@ -313,13 +313,13 @@ npx -y @smithery/cli@latest install @upstash/context7-mcp --client <CLIENT_NAME>
 <details>
 <summary><b>Встановлення в Claude Code</b></summary>
 Виконайте цю команду. Детальніше див. у [документації Claude Code MCP](https://docs.anthropic.com/en/docs/claude-code/mcp).
-#### Підключення до віддаленого сервера Claude Code
-```sh
-claude mcp add --transport http context7 https://mcp.context7.com/mcp
-```
 #### Підключення до локального сервера Claude Code
 ```sh
 claude mcp add context7 -- npx -y @upstash/context7-mcp
+```
+#### Підключення до віддаленого сервера Claude Code
+```sh
+claude mcp add --transport http context7 https://mcp.context7.com/mcp
 ```
 </details>
 <details>

--- a/i18n/README.vi.md
+++ b/i18n/README.vi.md
@@ -271,13 +271,13 @@ Nếu object `mcpServers` không tồn tại, hãy tạo nó.
 <details>
 <summary><b>Cài đặt trong Claude Code</b></summary>
 Chạy lệnh này. Xem [tài liệu Claude Code MCP](https://docs.anthropic.com/en/docs/claude-code/mcp) để biết thêm thông tin.
-#### Kết nối Claude Code Remote Server
-```sh
-claude mcp add --transport http context7 https://mcp.context7.com/mcp
-```
 #### Kết nối Claude Code Local Server
 ```sh
 claude mcp add context7 -- npx -y @upstash/context7-mcp
+```
+#### Kết nối Claude Code Remote Server
+```sh
+claude mcp add --transport http context7 https://mcp.context7.com/mcp
 ```
 </details>
 <details>

--- a/i18n/README.zh-CN.md
+++ b/i18n/README.zh-CN.md
@@ -91,13 +91,13 @@ npx -y @smithery/cli@latest install @upstash/context7-mcp --client <CLIENT_NAME>
 <details>
 <summary><b>在 Claude Code 中安装</b></summary>
 运行以下命令。更多信息请参见 [Claude Code MCP 文档](https://docs.anthropic.com/zh-CN/docs/claude-code/mcp)。
-#### Claude Code 远程服务器连接
-```sh
-claude mcp add --transport http context7 https://mcp.context7.com/mcp --header "CONTEXT7_API_KEY: YOUR_API_KEY"
-```
 #### Claude Code 本地服务器连接
 ```sh
 claude mcp add context7 -- npx -y @upstash/context7-mcp --api-key YOUR_API_KEY
+```
+#### Claude Code 远程服务器连接
+```sh
+claude mcp add --transport http context7 https://mcp.context7.com/mcp --header "CONTEXT7_API_KEY: YOUR_API_KEY"
 ```
 </details>
 <details>

--- a/i18n/README.zh-TW.md
+++ b/i18n/README.zh-TW.md
@@ -263,13 +263,13 @@ npx -y @smithery/cli@latest install @upstash/context7-mcp --client <CLIENT_NAME>
 <details>
 <summary><b>在 Claude Code 安裝</b></summary>
 執行下列指令。詳見 [Claude Code MCP 文件](https://docs.anthropic.com/zh-TW/docs/claude-code/mcp)。
-#### Claude Code 遠端伺服器連線
-```sh
-claude mcp add --transport http context7 https://mcp.context7.com/mcp
-```
 #### Claude Code 本地伺服器連線
 ```sh
 claude mcp add context7 -- npx -y @upstash/context7-mcp
+```
+#### Claude Code 遠端伺服器連線
+```sh
+claude mcp add --transport http context7 https://mcp.context7.com/mcp
 ```
 </details>
 <details>

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -136,16 +136,16 @@ Pasting the following configuration into your Cursor `~/.cursor/mcp.json` file i
 
 Run this command. See [Claude Code MCP docs](https://docs.anthropic.com/en/docs/claude-code/mcp) for more info.
 
-#### Claude Code Remote Server Connection
-
-```sh
-claude mcp add --transport http context7 https://mcp.context7.com/mcp --header "CONTEXT7_API_KEY: YOUR_API_KEY"
-```
-
 #### Claude Code Local Server Connection
 
 ```sh
 claude mcp add context7 -- npx -y @upstash/context7-mcp --api-key YOUR_API_KEY
+```
+
+#### Claude Code Remote Server Connection
+
+```sh
+claude mcp add --transport http context7 https://mcp.context7.com/mcp --header "CONTEXT7_API_KEY: YOUR_API_KEY"
 ```
 
 </details>


### PR DESCRIPTION
Claude's `--header` field doesn't work on HTTP remote server. This pr reorders the guides to highlight STDIO for now.