### PR TITLE
docs: remove invalid OAuth warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,6 @@ Add this to your Opencode configuration file. See [Opencode MCP docs](https://op
 <details>
 <summary><b>OAuth Authentication</b></summary>
 
-> **Warning:** Currently, only **Claude Code** and **Cursor** are confirmed to work with OAuth. Other clients should use API key authentication instead.
-
 Context7 MCP server supports OAuth 2.0 authentication for MCP clients that implement the [MCP OAuth specification](https://modelcontextprotocol.io/specification/2025-03-26/basic/authorization).
 
 To use OAuth, change the endpoint from `/mcp` to `/mcp/oauth` in your client configuration:

--- a/docs/howto/oauth.mdx
+++ b/docs/howto/oauth.mdx
@@ -3,10 +3,6 @@ title: OAuth
 description: Authenticate with Context7 MCP server using OAuth 2.0
 ---
 
-<Warning>
-  **Currently, only Claude Code and Cursor are confirmed to work with OAuth.** Other clients should use [API key authentication](/howto/api-keys) instead.
-</Warning>
-
 <Note>
   OAuth is only available for remote HTTP connections. For local MCP connections using stdio
   transport, use [API key authentication](/howto/api-keys) instead.

--- a/docs/resources/all-clients.mdx
+++ b/docs/resources/all-clients.mdx
@@ -5,10 +5,6 @@ description: Installation examples for MCP clients
 
 Context7 supports all MCP clients. Below are configuration examples for popular clients. If your client isn't listed, check its documentation for MCP server installation.
 
-<Note>
-  **OAuth Support:** Currently, only **Claude Code** and **Cursor** are confirmed to work with [OAuth authentication](/howto/oauth). For other clients, use API key authentication as shown in the examples below.
-</Note>
-
 <AccordionGroup>
 
 <Accordion title="Cursor">


### PR DESCRIPTION
Existing bug about the OAuth authentication of clients directly using MCP sdk is solved, so we remove the related docs.