### PR TITLE
Add mpak.dev registry publishing

### DIFF
--- a/.github/workflows/mpak.yml
+++ b/.github/workflows/mpak.yml
@@ -1,0 +1,22 @@
+name: Publish to mpak.dev
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: NimbleBrainInc/mcpb-pack@v2
+        with:
+          directory: packages/mcp/mcpb
+          bundle-path: context7.mcpb
+          build: false
+          platform-os: any
+          platform-arch: any

--- a/packages/mcp/mcpb/manifest.json
+++ b/packages/mcp/mcpb/manifest.json
@@ -1,6 +1,6 @@
 {
   "dxt_version": "0.1",
-  "name": "context7",
+  "name": "@upstash/context7",
   "display_name": "Context7",
   "version": "2.0.0",
   "description": "Up-to-date Code Docs For Any Prompt",


### PR DESCRIPTION
## Summary

Adds automatic publishing of the Context7 MCPB bundle to [mpak.dev](https://mpak.dev), a public registry for MCP bundles.

This gives Context7 additional distribution through:
- `mpak search context7` - discover via CLI
- `mpak run @upstash/context7` - run directly without manual installation
- Registry web UI at mpak.dev

## Changes

- Adds `.github/workflows/mpak.yml` that triggers on release
- Updates `packages/mcp/mcpb/manifest.json` name to `@upstash/context7` for OIDC verification
- Uses the existing `context7.mcpb` bundle (no rebuild required)
- Registers as cross-platform (`any/any`) since Context7 is pure Node.js

## How it works

The [mcpb-pack](https://github.com/NimbleBrainInc/mcpb-pack) action:
1. Uses your pre-built `context7.mcpb` bundle
2. Computes SHA256 for integrity verification
3. Uploads to the GitHub release
4. Announces to mpak.dev using GitHub OIDC (no API keys needed)

The scoped name `@upstash/context7` allows the registry to verify the bundle came from `upstash/context7` via the OIDC token.

If the announce step fails (e.g., registry is down), it warns but **does not block your release**.

## Test plan

- [ ] Create a test release to verify workflow runs
- [ ] Verify bundle appears at https://mpak.dev/bundles/@upstash/context7