### PR TITLE
chore(cli): bump version to 0.1.1

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ctx7",
-  "version": "0.1.0-canary.3",
+  "version": "0.1.1",
   "description": "Context7 CLI - Manage AI coding skills and documentation context",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Bump CLI version to 0.1.1 for npm release