### PR TITLE
CTX7-1141: don't loop paginated results

### DIFF
--- a/.changeset/ten-islands-kick.md
+++ b/.changeset/ten-islands-kick.md
@@ -1,0 +1,5 @@
+---
+"ctx7": patch
+---
+
+Fix circular scrolling in list prompts - navigation now stops at list boundaries instead of wrapping around

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+## 0.1.4
+
+- Add prompt injection detection with warning messages for blocked skills
+
+## 0.1.3
+
+- Auto-detect installed IDE configurations in project/global directories
+- Add confirmation prompt before installing to detected locations
+
+## 0.1.0
+
+- Initial stable release
+- Commands: `install`, `search`, `list`, `remove`, `info`
+- Multi-IDE support: Claude, Cursor, Codex, OpenCode, Amp, Antigravity
+- Global and project-level skill installation
+- Symlink support (Claude gets original files, others get symlinks)
+- Short aliases: `si`, `ss`
+- Single skill installation via `ctx7 skills install /owner/repo skill-name`
+- Installation tracking metrics

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ctx7",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Context7 CLI - Manage AI coding skills and documentation context",
   "type": "module",
   "bin": {

--- a/packages/cli/src/commands/skill.ts
+++ b/packages/cli/src/commands/skill.ts
@@ -242,6 +242,7 @@ async function installCommand(
           message: "Select skills:",
           choices,
           pageSize: 15,
+          loop: false,
           theme: {
             style: {
               renderSelectedChoices: (selected: Array<{ name?: string; value: unknown }>) =>
@@ -390,6 +391,7 @@ async function searchCommand(query: string): Promise<void> {
       message: "Select skills to install:",
       choices,
       pageSize: 15,
+      loop: false,
       theme: {
         style: {
           renderSelectedChoices: (selected: Array<{ name?: string; value: unknown }>) =>

--- a/packages/cli/src/utils/ide.ts
+++ b/packages/cli/src/utils/ide.ts
@@ -139,6 +139,7 @@ export async function promptForInstallTargets(options: AddOptions): Promise<Inst
       message: `Which clients do you want to install the skill(s) for?\n${pc.dim(baseDir)}`,
       choices: ideChoices,
       required: true,
+      loop: false,
     });
   } catch {
     return null;
@@ -175,6 +176,7 @@ export async function promptForSingleTarget(
       message: "Which client?",
       choices: ideChoices,
       default: DEFAULT_CONFIG.defaultIde,
+      loop: false,
     });
   } catch {
     return null;
@@ -198,6 +200,7 @@ export async function promptForSingleTarget(
           },
         ],
         default: DEFAULT_CONFIG.defaultScope,
+        loop: false,
       });
     } catch {
       return null;


### PR DESCRIPTION
## Summary
- Fix circular scrolling in CLI list prompts - lists now stop at bounds instead of wrapping
- Add CHANGELOG.md for CLI package

## Test plan
- Run `ctx7 skills search pdf` and verify scrolling stops at list end