### PR TITLE
fix: typo in retry count comment

### DIFF
--- a/packages/sdk/src/http/index.ts
+++ b/packages/sdk/src/http/index.ts
@@ -53,7 +53,7 @@ export type RetryConfig =
        */
       retries?: number;
       /**
-       * A backoff function receives the current retry cound and returns a number in milliseconds to wait before retrying.
+       * A backoff function receives the current retry count and returns a number in milliseconds to wait before retrying.
        *
        * @default
        * ```ts


### PR DESCRIPTION
## Summary
- Fixed typo in JSDoc comment: `cound` → `count`

## Files Changed
- `packages/sdk/src/http/index.ts:56`