### PR TITLE
fix(cli): validate required checkbox selections instead of exiting

### DIFF
--- a/.changeset/yellow-knives-report.md
+++ b/.changeset/yellow-knives-report.md
@@ -1,0 +1,5 @@
+---
+"ctx7": patch
+---
+
+Fix checkbox prompts to stay open when no selection is made instead of exiting. Added validation with custom error messages for skill and IDE client selection prompts.

--- a/packages/cli/src/commands/skill.ts
+++ b/packages/cli/src/commands/skill.ts
@@ -242,6 +242,7 @@ async function installCommand(
           message: "Select skills:",
           choices,
           pageSize: 15,
+          validate: (selected) => selected.length > 0 || "Please select at least one skill",
           theme: {
             style: {
               renderSelectedChoices: (selected: Array<{ name?: string; value: unknown }>) =>
@@ -390,6 +391,7 @@ async function searchCommand(query: string): Promise<void> {
       message: "Select skills to install:",
       choices,
       pageSize: 15,
+      validate: (selected) => selected.length > 0 || "Please select at least one skill",
       theme: {
         style: {
           renderSelectedChoices: (selected: Array<{ name?: string; value: unknown }>) =>

--- a/packages/cli/src/utils/ide.ts
+++ b/packages/cli/src/utils/ide.ts
@@ -138,7 +138,7 @@ export async function promptForInstallTargets(options: AddOptions): Promise<Inst
     selectedIdes = await checkbox({
       message: `Which clients do you want to install the skill(s) for?\n${pc.dim(baseDir)}`,
       choices: ideChoices,
-      required: true,
+      validate: (selected) => selected.length > 0 || "Please select at least one client",
     });
   } catch {
     return null;


### PR DESCRIPTION
Checkbox prompts for skill and IDE selection now show validation errors and stay open when submitted empty, instead of exiting with a warning.