### PR TITLE
feat(cli): show exact install counts and sort by installs

### DIFF
--- a/.changeset/social-pumas-look.md
+++ b/.changeset/social-pumas-look.md
@@ -1,0 +1,5 @@
+---
+"ctx7": patch
+---
+
+Show exact install counts instead of rounded values, sort skills by install count in the install command, and display "installs" column header inline with the prompt

--- a/packages/cli/src/commands/skill.ts
+++ b/packages/cli/src/commands/skill.ts
@@ -215,7 +215,9 @@ async function installCommand(
       return;
     }
 
-    const skillsWithRepo = data.skills.map((s) => ({ ...s, project: repo }));
+    const skillsWithRepo = data.skills
+      .map((s) => ({ ...s, project: repo }))
+      .sort((a, b) => (b.installCount ?? 0) - (a.installCount ?? 0));
 
     spinner.succeed(`Found ${data.skills.length} skill(s)`);
 
@@ -259,9 +261,15 @@ async function installCommand(
 
       log.blank();
 
+      // Align "installs" column header with the count values
+      // "? " prefix = 2 chars, checkbox prefix "❯◯ " = 4 chars, index + dot + space, padded name + space
+      const installsOffset = 4 + indexWidth + 1 + 1 + maxNameLen + 1 - 3;
+      const message =
+        "Select skills:" + " ".repeat(Math.max(1, installsOffset - 14)) + pc.dim("installs");
+
       try {
         selectedSkills = await checkboxWithHover({
-          message: "Select skills:",
+          message,
           choices,
           pageSize: 15,
           loop: false,
@@ -417,10 +425,14 @@ async function searchCommand(query: string): Promise<void> {
 
   log.blank();
 
+  const installsOffset = 4 + indexWidth + 1 + 1 + maxNameLen + 1 - 3;
+  const message =
+    "Select skills to install:" + " ".repeat(Math.max(1, installsOffset - 25)) + pc.dim("installs");
+
   let selectedSkills: SkillSearchResult[];
   try {
     selectedSkills = await checkboxWithHover({
-      message: "Select skills to install:",
+      message,
       choices,
       pageSize: 15,
       loop: false,

--- a/packages/cli/src/utils/prompts.ts
+++ b/packages/cli/src/utils/prompts.ts
@@ -14,26 +14,12 @@ export function terminalLink(text: string, url: string, color?: (s: string) => s
 }
 
 /**
- * Formats install count with rounded display showing highest round number.
- * Examples: 5→"5", 15→"10+", 67→"50+", 150→"100+", 350→"300+", 1500→"1k+"
+ * Formats install count for display.
  */
 export function formatInstallCount(count: number | undefined): string {
   if (count === undefined || count === 0) return "";
 
-  let display: string;
-  if (count >= 1000) {
-    display = `${Math.floor(count / 1000)}k+`;
-  } else if (count >= 100) {
-    const hundreds = Math.floor(count / 100) * 100;
-    display = `${hundreds}+`;
-  } else if (count >= 10) {
-    const tens = Math.floor(count / 10) * 10;
-    display = `${tens}+`;
-  } else {
-    display = String(count);
-  }
-
-  return `\x1b[38;5;214m↓${display}\x1b[0m`;
+  return pc.yellow(String(count));
 }
 export interface CheckboxWithHoverOptions<T> {
   /** Function to extract display name from value. Defaults to (v) => v.name */


### PR DESCRIPTION
## Summary
- Show exact install counts instead of rounded values (41 vs 40+)
- Sort skills by install count (descending) in the install command only
- Display "installs" column header inline with the prompt