### PR TITLE
feat: add context7_ prefix to tool names for consistency (#1419)

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,11 +195,11 @@ Context7 will automatically match the appropriate version.
 
 Context7 MCP provides the following tools that LLMs can use:
 
-- `resolve-library-id`: Resolves a general library name into a Context7-compatible library ID.
+- `context7_resolve-library-id`: Resolves a general library name into a Context7-compatible library ID.
   - `query` (required): The user's question or task (used to rank results by relevance)
   - `libraryName` (required): The name of the library to search for
 
-- `query-docs`: Retrieves documentation for a library using a Context7-compatible library ID.
+- `context7_query-docs`: Retrieves documentation for a library using a Context7-compatible library ID.
   - `libraryId` (required): Exact Context7-compatible library ID (e.g., `/mongodb/docs`, `/vercel/next.js`)
   - `query` (required): The question or task to get relevant documentation for
 

--- a/docs/agentic-tools/ai-sdk/tools/resolve-library-id.mdx
+++ b/docs/agentic-tools/ai-sdk/tools/resolve-library-id.mdx
@@ -170,5 +170,5 @@ The tool's description instructs the AI model to select libraries based on:
 
 ## Related
 
-- [queryDocs](/agentic-tools/ai-sdk/tools/query-docs) - Fetch documentation using the resolved library ID
+- [queryDocs](/agentic-tools/ai-sdk/tools/query-docs) - Fetch documentation using the resolved library ID (context7_query-docs)
 - [Context7Agent](/agentic-tools/ai-sdk/agents/context7-agent) - Pre-built agent that handles the full workflow

--- a/docs/resources/all-clients.mdx
+++ b/docs/resources/all-clients.mdx
@@ -561,7 +561,7 @@ Add the following configuration to Repository->Settings->Copilot->Coding agent->
       "headers": {
         "CONTEXT7_API_KEY": "YOUR_API_KEY"
       },
-      "tools": ["query-docs", "resolve-library-id"]
+      "tools": ["context7_query-docs", "context7_resolve-library-id"]
     }
   }
 }
@@ -598,7 +598,7 @@ Or, for a local server:
     "context7": {
       "type": "local",
       "command": "npx",
-      "tools": ["query-docs", "resolve-library-id"],
+      "tools": ["context7_query-docs", "context7_resolve-library-id"],
       "args": ["-y", "@upstash/context7-mcp", "--api-key", "YOUR_API_KEY"]
     }
   }

--- a/docs/resources/troubleshooting.mdx
+++ b/docs/resources/troubleshooting.mdx
@@ -211,7 +211,7 @@ For stdio transport:
 If you get `404 Not Found` errors:
 
 1. **Verify the library ID** format is correct: `/owner/repo` or `/owner/repo/version`
-2. **Search for the library** first using `resolve-library-id` tool
+2. **Search for the library** first using `context7_resolve-library-id` tool
 3. **Check if the library exists** at [context7.com](https://context7.com)
 
 ## MCP Client-Specific Issues

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -142,12 +142,12 @@ server.server.oninitialized = () => {
 };
 
 server.registerTool(
-  "resolve-library-id",
+  "context7_resolve-library-id",
   {
     title: "Resolve Context7 Library ID",
     description: `Resolves a package/product name to a Context7-compatible library ID and returns matching libraries.
 
-You MUST call this function before 'query-docs' to obtain a valid Context7-compatible library ID UNLESS the user explicitly provides a library ID in the format '/org/project' or '/org/project/version' in their query.
+You MUST call this function before 'context7_query-docs' to obtain a valid Context7-compatible library ID UNLESS the user explicitly provides a library ID in the format '/org/project' or '/org/project/version' in their query.
 
 Selection Process:
 1. Analyze the query to understand what library/package the user is looking for
@@ -228,12 +228,12 @@ ${resultsText}`;
 );
 
 server.registerTool(
-  "query-docs",
+  "context7_query-docs",
   {
     title: "Query Documentation",
     description: `Retrieves and queries up-to-date documentation and code examples from Context7 for any programming library or framework.
 
-You must call 'resolve-library-id' first to obtain the exact Context7-compatible library ID required to use this tool, UNLESS the user explicitly provides a library ID in the format '/org/project' or '/org/project/version' in their query.
+You must call 'context7_resolve-library-id' first to obtain the exact Context7-compatible library ID required to use this tool, UNLESS the user explicitly provides a library ID in the format '/org/project' or '/org/project/version' in their query.
 
 IMPORTANT: Do not call this tool more than 3 times per question. If you cannot find what you need after 3 calls, use the best information you have.`,
     inputSchema: {

--- a/plugins/claude/context7/README.md
+++ b/plugins/claude/context7/README.md
@@ -70,4 +70,4 @@ To get documentation for a specific version, include the version in the library 
 /supabase/supabase/v2.45.0
 ```
 
-The `resolve-library-id` tool returns available versions, so you can pick the one that matches your project.
+The `context7_resolve-library-id` tool returns available versions, so you can pick the one that matches your project.

--- a/plugins/claude/context7/agents/docs-researcher.md
+++ b/plugins/claude/context7/agents/docs-researcher.md
@@ -14,7 +14,7 @@ When given a question about a library or framework, fetch the relevant documenta
 
 1. **Identify the library**: Extract the library/framework name from the user's question.
 
-2. **Resolve the library ID**: Call `resolve-library-id` with:
+2. **Resolve the library ID**: Call `context7_resolve-library-id` with:
    - `libraryName`: The library name (e.g., "react", "next.js", "prisma")
    - `query`: The user's full question for relevance ranking
 
@@ -23,7 +23,7 @@ When given a question about a library or framework, fetch the relevant documenta
    - Highest benchmark score
    - Appropriate version if the user specified one (e.g., "React 19" → look for v19.x)
 
-4. **Fetch documentation**: Call `query-docs` with:
+4. **Fetch documentation**: Call `context7_query-docs` with:
    - `libraryId`: The selected Context7 library ID (e.g., `/vercel/next.js`)
    - `query`: The user's specific question for targeted results
 
@@ -36,5 +36,5 @@ When given a question about a library or framework, fetch the relevant documenta
 
 - Pass the user's full question as the query parameter for better relevance
 - When the user mentions a version (e.g., "Next.js 15"), use version-specific library IDs if available
-- If `resolve-library-id` returns multiple matches, prefer official/primary packages over community forks
+- If `context7_resolve-library-id` returns multiple matches, prefer official/primary packages over community forks
 - Keep responses concise - the goal is to answer the question, not dump entire documentation

--- a/plugins/claude/context7/commands/docs.md
+++ b/plugins/claude/context7/commands/docs.md
@@ -29,8 +29,8 @@ Fetches up-to-date documentation and code examples for a library.
 ## How It Works
 
 1. If the library starts with `/`, it's used directly as the Context7 ID
-2. Otherwise, `resolve-library-id` finds the best matching library
-3. `query-docs` fetches documentation relevant to your query
+2. Otherwise, `context7_resolve-library-id` finds the best matching library
+3. `context7_query-docs` fetches documentation relevant to your query
 4. Results include code examples and explanations
 
 ## Version-Specific Lookups

--- a/plugins/claude/context7/skills/documentation-lookup/SKILL.md
+++ b/plugins/claude/context7/skills/documentation-lookup/SKILL.md
@@ -18,7 +18,7 @@ Activate this skill when the user:
 
 ### Step 1: Resolve the Library ID
 
-Call `resolve-library-id` with:
+Call `context7_resolve-library-id` with:
 
 - `libraryName`: The library name extracted from the user's question
 - `query`: The user's full question (improves relevance ranking)
@@ -33,7 +33,7 @@ From the resolution results, choose based on:
 
 ### Step 3: Fetch the Documentation
 
-Call `query-docs` with:
+Call `context7_query-docs` with:
 
 - `libraryId`: The selected Context7 library ID (e.g., `/vercel/next.js`)
 - `query`: The user's specific question


### PR DESCRIPTION
- Rename resolve-library-id to context7_resolve-library-id
- Rename query-docs to context7_query-docs
- Update all documentation and examples
- Update integration guides for all platforms
- Update plugin files and skill definitions

This change unifies tool naming with other MCP servers in the ecosystem.

Fixes #1419