### PR TITLE
feat(cli): add telemetry tracking for CLI usage metrics

### DIFF
--- a/.changeset/sour-lands-grin.md
+++ b/.changeset/sour-lands-grin.md
@@ -1,0 +1,5 @@
+---
+"ctx7": patch
+---
+
+Add CLI telemetry for usage metrics collection (commands, searches, installs, generation feedback) via fire-and-forget events to /api/v2/cli/events. Respects CTX7_TELEMETRY_DISABLED env var.

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -14,6 +14,8 @@ import {
   isTokenExpired,
 } from "../utils/auth.js";
 
+import { trackEvent } from "../utils/tracking.js";
+
 const CLI_CLIENT_ID = "2veBSofhicRBguUT";
 
 let baseUrl = "https://context7.com";
@@ -47,6 +49,7 @@ export function registerAuthCommands(program: Command): void {
 }
 
 async function loginCommand(options: { browser: boolean }): Promise<void> {
+  trackEvent("command", { name: "login" });
   const existingTokens = loadTokens();
   if (existingTokens) {
     const expired = isTokenExpired(existingTokens);
@@ -128,6 +131,7 @@ async function loginCommand(options: { browser: boolean }): Promise<void> {
 }
 
 function logoutCommand(): void {
+  trackEvent("command", { name: "logout" });
   if (clearTokens()) {
     console.log(pc.green("Logged out successfully."));
   } else {
@@ -136,6 +140,7 @@ function logoutCommand(): void {
 }
 
 async function whoamiCommand(): Promise<void> {
+  trackEvent("command", { name: "whoami" });
   const tokens = loadTokens();
 
   if (!tokens) {

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -17,6 +17,7 @@ import { log } from "../utils/logger.js";
 import { promptForInstallTargets, getTargetDirs } from "../utils/ide.js";
 import selectOrInput from "../utils/selectOrInput.js";
 import { checkboxWithHover, terminalLink } from "../utils/prompts.js";
+import { trackEvent } from "../utils/tracking.js";
 import type {
   GenerateOptions,
   LibrarySearchResult,
@@ -53,6 +54,7 @@ export function registerGenerateCommand(skillCommand: Command): void {
 }
 
 async function generateCommand(options: GenerateOptions): Promise<void> {
+  trackEvent("command", { name: "generate" });
   log.blank();
 
   // Check authentication
@@ -426,6 +428,7 @@ async function generateCommand(options: GenerateOptions): Promise<void> {
         log.warn("Generation cancelled");
         return;
       } else if (action === "feedback") {
+        trackEvent("gen_feedback");
         feedback = await input({
           message: "What changes would you like? (press Enter to skip)",
         });
@@ -489,6 +492,7 @@ async function generateCommand(options: GenerateOptions): Promise<void> {
   }
 
   writeSpinner.succeed(pc.green(`Created skill in ${targetDirs.length} location(s)`));
+  trackEvent("gen_install");
 
   log.blank();
   console.log(pc.green(pc.bold("Skill saved successfully")));

--- a/packages/cli/src/commands/skill.ts
+++ b/packages/cli/src/commands/skill.ts
@@ -5,13 +5,7 @@ import { readdir, rm } from "fs/promises";
 import { join } from "path";
 
 import { parseSkillInput } from "../utils/parse-input.js";
-import {
-  listProjectSkills,
-  searchSkills,
-  downloadSkill,
-  getSkill,
-  trackInstalls,
-} from "../utils/api.js";
+import { listProjectSkills, searchSkills, downloadSkill, getSkill } from "../utils/api.js";
 import { log } from "../utils/logger.js";
 import {
   promptForInstallTargets,
@@ -23,6 +17,7 @@ import {
 } from "../utils/ide.js";
 import { checkboxWithHover, terminalLink, formatInstallCount } from "../utils/prompts.js";
 import { installSkillFiles, symlinkSkill } from "../utils/installer.js";
+import { trackEvent } from "../utils/tracking.js";
 import { registerGenerateCommand } from "./generate.js";
 import type {
   Skill,
@@ -162,6 +157,7 @@ async function installCommand(
   skillName: string | undefined,
   options: AddOptions
 ): Promise<void> {
+  trackEvent("command", { name: "install" });
   const parsed = parseSkillInput(input);
   if (!parsed) {
     log.error(`Invalid input format: ${input}`);
@@ -355,13 +351,14 @@ async function installCommand(
   }
 
   installSpinner.succeed(`Installed ${installedSkills.length} skill(s)`);
-  trackInstalls(installedSkills, targets.ides);
+  trackEvent("install", { skills: installedSkills, ides: targets.ides });
 
   const installedNames = selectedSkills.map((s) => s.name);
   logInstallSummary(targets, targetDirs, installedNames);
 }
 
 async function searchCommand(query: string): Promise<void> {
+  trackEvent("command", { name: "search" });
   log.blank();
   const spinner = ora(`Searching for "${query}"...`).start();
 
@@ -384,6 +381,7 @@ async function searchCommand(query: string): Promise<void> {
   }
 
   spinner.succeed(`Found ${data.results.length} skill(s)`);
+  trackEvent("search_query", { query, resultCount: data.results.length });
 
   const indexWidth = data.results.length.toString().length;
   const maxNameLen = Math.max(...data.results.map((s) => s.name.length));
@@ -514,13 +512,14 @@ async function searchCommand(query: string): Promise<void> {
   }
 
   installSpinner.succeed(`Installed ${installedSkills.length} skill(s)`);
-  trackInstalls(installedSkills, targets.ides);
+  trackEvent("install", { skills: installedSkills, ides: targets.ides });
 
   const installedNames = uniqueSkills.map((s) => s.name);
   logInstallSummary(targets, targetDirs, installedNames);
 }
 
 async function listCommand(options: ListOptions): Promise<void> {
+  trackEvent("command", { name: "list" });
   const scope: Scope = options.global ? "global" : "project";
   const pathMap = scope === "global" ? IDE_GLOBAL_PATHS : IDE_PATHS;
   const baseDir = scope === "global" ? homedir() : process.cwd();
@@ -565,6 +564,7 @@ async function listCommand(options: ListOptions): Promise<void> {
 }
 
 async function removeCommand(name: string, options: RemoveOptions): Promise<void> {
+  trackEvent("command", { name: "remove" });
   const target = await promptForSingleTarget(options);
   if (!target) {
     log.warn("Cancelled");
@@ -590,6 +590,7 @@ async function removeCommand(name: string, options: RemoveOptions): Promise<void
 }
 
 async function infoCommand(input: string): Promise<void> {
+  trackEvent("command", { name: "info" });
   const parsed = parseSkillInput(input);
   if (!parsed) {
     log.blank();

--- a/packages/cli/src/utils/api.ts
+++ b/packages/cli/src/utils/api.ts
@@ -13,6 +13,10 @@ import { downloadSkillFromGitHub } from "./github.js";
 
 let baseUrl = "https://context7.com";
 
+export function getBaseUrl(): string {
+  return baseUrl;
+}
+
 export function setBaseUrl(url: string): void {
   baseUrl = url;
 }
@@ -33,15 +37,6 @@ export async function searchSkills(query: string): Promise<SearchResponse> {
   const params = new URLSearchParams({ query });
   const response = await fetch(`${baseUrl}/api/v2/skills?${params}`);
   return (await response.json()) as SearchResponse;
-}
-
-export function trackInstalls(skills: string[], ides: string[]): void {
-  if (process.env.CTX7_TELEMETRY_DISABLED || !skills.length) return;
-  fetch(`${baseUrl}/api/v2/skills/track`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ skills, ides }),
-  }).catch(() => {});
 }
 
 export async function downloadSkill(project: string, skillName: string): Promise<DownloadResponse> {

--- a/packages/cli/src/utils/tracking.ts
+++ b/packages/cli/src/utils/tracking.ts
@@ -1,0 +1,10 @@
+import { getBaseUrl } from "./api.js";
+
+export function trackEvent(event: string, data?: Record<string, unknown>): void {
+  if (process.env.CTX7_TELEMETRY_DISABLED) return;
+  fetch(`${getBaseUrl()}/api/v2/cli/events`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ event, data }),
+  }).catch(() => {});
+}


### PR DESCRIPTION
## Summary
- Add fire-and-forget `trackEvent()` utility that sends CLI telemetry events to `/api/v2/cli/events` (respects `CTX7_TELEMETRY_DISABLED` env var)
- Track command invocations (install, search, list, remove, info, generate, login, logout, whoami), search queries with result counts, and generation install/feedback events
- Export `baseUrl` from `api.ts` for reuse by tracking module