### PR TITLE
feat: add GitHub Copilot and Gemini skills directory support

### DIFF
--- a/docs/skills.mdx
+++ b/docs/skills.mdx
@@ -94,6 +94,8 @@ The CLI automatically detects which AI coding assistants you have installed and 
 | OpenCode | `.opencode/skills/` |
 | Amp | `.agents/skills/` |
 | Antigravity | `.agent/skills/` |
+| GitHub Copilot  | `.github/skills/` |
+| Gemini CLI | `.gemini/skills/` |
 
 ## Shortcuts
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -144,14 +144,16 @@ ctx7 skills remove pdf --global
 
 The CLI automatically detects which AI coding assistants you have installed and offers to install skills for them:
 
-| Client | Skills Directory |
-|--------|-----------------|
-| Claude Code | `.claude/skills/` |
-| Cursor | `.cursor/skills/` |
-| Codex | `.codex/skills/` |
-| OpenCode | `.opencode/skills/` |
-| Amp | `.agents/skills/` |
-| Antigravity | `.agent/skills/` |
+| Client         | Skills Directory    |
+| -------------- | ------------------- |
+| Claude Code    | `.claude/skills/`   |
+| Cursor         | `.cursor/skills/`   |
+| Codex          | `.codex/skills/`    |
+| OpenCode       | `.opencode/skills/` |
+| Amp            | `.agents/skills/`   |
+| Antigravity    | `.agent/skills/`    |
+| GitHub Copilot | `.github/skills/`   |
+| Gemini CLI     | `.gemini/skills/`   |
 
 ## Shortcuts
 

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -47,6 +47,8 @@ export function registerGenerateCommand(skillCommand: Command): void {
     .option("--opencode", "OpenCode (.opencode/skills/)")
     .option("--amp", "Amp (.agents/skills/)")
     .option("--antigravity", "Antigravity (.agent/skills/)")
+    .option("--copilot", "GitHub Copilot (.github/skills/)")
+    .option("--gemini", "Gemini CLI (.gemini/skills/)")
     .description("Generate a skill for a library using AI")
     .action(async (options: GenerateOptions) => {
       await generateCommand(options);

--- a/packages/cli/src/commands/skill.ts
+++ b/packages/cli/src/commands/skill.ts
@@ -70,6 +70,8 @@ export function registerSkillCommands(program: Command): void {
     .option("--opencode", "OpenCode (.opencode/skills/)")
     .option("--amp", "Amp (.agents/skills/)")
     .option("--antigravity", "Antigravity (.agent/skills/)")
+    .option("--copilot", "GitHub Copilot (.github/skills/)")
+    .option("--gemini", "Gemini CLI (.gemini/skills/)")
     .description("Install skills from a repository")
     .action(async (project: string, skillName: string | undefined, options: AddOptions) => {
       await installCommand(project, skillName, options);
@@ -94,6 +96,8 @@ export function registerSkillCommands(program: Command): void {
     .option("--opencode", "OpenCode (.opencode/skills/)")
     .option("--amp", "Amp (.agents/skills/)")
     .option("--antigravity", "Antigravity (.agent/skills/)")
+    .option("--copilot", "GitHub Copilot (.github/skills/)")
+    .option("--gemini", "Gemini CLI (.gemini/skills/)")
     .description("List installed skills")
     .action(async (options: ListOptions) => {
       await listCommand(options);
@@ -111,6 +115,8 @@ export function registerSkillCommands(program: Command): void {
     .option("--opencode", "OpenCode (.opencode/skills/)")
     .option("--amp", "Amp (.agents/skills/)")
     .option("--antigravity", "Antigravity (.agent/skills/)")
+    .option("--copilot", "GitHub Copilot (.github/skills/)")
+    .option("--gemini", "Gemini CLI (.gemini/skills/)")
     .description("Remove an installed skill")
     .action(async (name: string, options: RemoveOptions) => {
       await removeCommand(name, options);
@@ -138,6 +144,8 @@ export function registerSkillAliases(program: Command): void {
     .option("--opencode", "OpenCode (.opencode/skills/)")
     .option("--amp", "Amp (.agents/skills/)")
     .option("--antigravity", "Antigravity (.agent/skills/)")
+    .option("--copilot", "GitHub Copilot (.github/skills/)")
+    .option("--gemini", "Gemini CLI (.gemini/skills/)")
     .description("Install skills (alias for: skills install)")
     .action(async (project: string, skillName: string | undefined, options: AddOptions) => {
       await installCommand(project, skillName, options);

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -124,7 +124,7 @@ export interface ErrorEvent {
 
 export type GenerateStreamEvent = ProgressEvent | ToolResultEvent | CompleteEvent | ErrorEvent;
 
-export type IDE = "claude" | "cursor" | "codex" | "opencode" | "amp" | "antigravity";
+export type IDE = "claude" | "cursor" | "codex" | "opencode" | "amp" | "antigravity" | "copilot" | "gemini";
 
 export type Scope = "project" | "global";
 
@@ -162,6 +162,8 @@ export const IDE_PATHS: Record<IDE, string> = {
   opencode: ".opencode/skills",
   amp: ".agents/skills",
   antigravity: ".agent/skills",
+  copilot: ".github/skills",
+  gemini: ".gemini/skills",
 };
 
 export const IDE_GLOBAL_PATHS: Record<IDE, string> = {
@@ -171,6 +173,8 @@ export const IDE_GLOBAL_PATHS: Record<IDE, string> = {
   opencode: ".config/opencode/skills",
   amp: ".config/agents/skills",
   antigravity: ".agent/skills",
+  copilot: ".github/skills",
+  gemini: ".gemini/skills",
 };
 
 export const IDE_NAMES: Record<IDE, string> = {
@@ -180,6 +184,8 @@ export const IDE_NAMES: Record<IDE, string> = {
   opencode: "OpenCode",
   amp: "Amp",
   antigravity: "Antigravity",
+  copilot: "GitHub Copilot",
+  gemini: "Gemini CLI",
 };
 
 export interface C7Config {


### PR DESCRIPTION
## Summary
This PR adds support for GitHub Copilot and Gemini CLI agent skills directories by recognizing the following paths:
- `.github/skills`
- `.gemini/skills`

Context7 previously supported only `.claude/skills`. This change allows Copilot and Gemini users to use agent skills without renaming directories.

## Changes
- Added `.github/skills` as a supported skills directory for GitHub Copilot
- Added `.gemini/skills` as a supported skills directory for Gemini CLI
- Improved multi-client agent skills compatibility

## Related Issue
close #1539
