### PR TITLE
feat(cli): improve skill search display and revamp generate UX

### DIFF
--- a/.changeset/bright-skills-trust.md
+++ b/.changeset/bright-skills-trust.md
@@ -2,4 +2,10 @@
 "ctx7": patch
 ---
 
-Add trust score and installs columns to skill search results display with aligned column headers.
+Skill search & generate command improvements:
+
+- Add "Installs" and "Trust(0-10)" columns to skill search results with aligned column headers
+- Auto-login via OAuth when the generate command requires authentication instead of showing an error
+- Reorder question options so the recommended choice always appears first with a "✓ Recommended" badge
+- Add "View skill" action that opens generated content in the user's default editor (`$EDITOR`)
+- Revamp generate wizard copy: do/don't examples for skill descriptions, rename "libraries" to "sources", and clarify follow-up question and generation spinner text

--- a/.changeset/bright-skills-trust.md
+++ b/.changeset/bright-skills-trust.md
@@ -1,0 +1,5 @@
+---
+"ctx7": patch
+---
+
+Add trust score and installs columns to skill search results display with aligned column headers.

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -4,7 +4,7 @@ import ora from "ora";
 import { mkdir, writeFile, readFile, unlink } from "fs/promises";
 import { join } from "path";
 import { homedir } from "os";
-import { execFile } from "child_process";
+import { spawn } from "child_process";
 import { input, select } from "@inquirer/prompts";
 
 import {
@@ -375,6 +375,7 @@ async function generateCommand(options: GenerateOptions): Promise<void> {
 
     queryLog.length = 0;
     isGeneratingContent = false;
+    previewFileWritten = false;
     initialStatus = feedback
       ? "Regenerating skill with your feedback..."
       : "Reading selected Context7 sources to generate the skill...";
@@ -429,7 +430,11 @@ async function generateCommand(options: GenerateOptions): Promise<void> {
       }
       const editor = process.env.EDITOR || "open";
       await new Promise<void>((resolve) => {
-        execFile(editor, [previewFile!], () => resolve());
+        const child = spawn(editor, [previewFile!], {
+          stdio: "inherit",
+          shell: true,
+        });
+        child.on("close", () => resolve());
       });
     };
 

--- a/packages/cli/src/commands/skill.ts
+++ b/packages/cli/src/commands/skill.ts
@@ -404,7 +404,8 @@ async function searchCommand(query: string): Promise<void> {
     const paddedName = s.name.padEnd(maxNameLen);
     const installsRaw = s.installCount ? String(s.installCount) : "-";
     const paddedInstalls =
-      formatInstallCount(s.installCount) + " ".repeat(installsColWidth - installsRaw.length);
+      formatInstallCount(s.installCount, pc.dim("-")) +
+      " ".repeat(installsColWidth - installsRaw.length);
     const trust = formatTrustScore(s.trustScore);
 
     const skillLink = terminalLink(

--- a/packages/cli/src/commands/skill.ts
+++ b/packages/cli/src/commands/skill.ts
@@ -402,10 +402,9 @@ async function searchCommand(query: string): Promise<void> {
   const choices = data.results.map((s, index) => {
     const indexStr = pc.dim(`${(index + 1).toString().padStart(indexWidth)}.`);
     const paddedName = s.name.padEnd(maxNameLen);
-    const installsRaw = s.installCount ? String(s.installCount) : "";
-    const paddedInstalls = installsRaw
-      ? formatInstallCount(s.installCount) + " ".repeat(installsColWidth - installsRaw.length)
-      : " ".repeat(installsColWidth);
+    const installsRaw = s.installCount ? String(s.installCount) : "-";
+    const paddedInstalls =
+      formatInstallCount(s.installCount) + " ".repeat(installsColWidth - installsRaw.length);
     const trust = formatTrustScore(s.trustScore);
 
     const skillLink = terminalLink(

--- a/packages/cli/src/commands/skill.ts
+++ b/packages/cli/src/commands/skill.ts
@@ -15,7 +15,12 @@ import {
   getSelectedIdes,
   hasExplicitIdeOption,
 } from "../utils/ide.js";
-import { checkboxWithHover, terminalLink, formatInstallCount } from "../utils/prompts.js";
+import {
+  checkboxWithHover,
+  terminalLink,
+  formatInstallCount,
+  formatTrustScore,
+} from "../utils/prompts.js";
 import { installSkillFiles, symlinkSkill } from "../utils/installer.js";
 import { trackEvent } from "../utils/tracking.js";
 import { registerGenerateCommand } from "./generate.js";
@@ -393,12 +398,16 @@ async function searchCommand(query: string): Promise<void> {
 
   const indexWidth = data.results.length.toString().length;
   const maxNameLen = Math.max(...data.results.map((s) => s.name.length));
+  const installsColWidth = 10;
   const choices = data.results.map((s, index) => {
     const indexStr = pc.dim(`${(index + 1).toString().padStart(indexWidth)}.`);
     const paddedName = s.name.padEnd(maxNameLen);
-    const installs = formatInstallCount(s.installCount);
+    const installsRaw = s.installCount ? String(s.installCount) : "";
+    const paddedInstalls = installsRaw
+      ? formatInstallCount(s.installCount) + " ".repeat(installsColWidth - installsRaw.length)
+      : " ".repeat(installsColWidth);
+    const trust = formatTrustScore(s.trustScore);
 
-    // Build metadata panel shown when item is hovered
     const skillLink = terminalLink(
       s.name,
       `https://context7.com/skills${s.project}/${s.name}`,
@@ -415,7 +424,7 @@ async function searchCommand(query: string): Promise<void> {
     ];
 
     return {
-      name: installs ? `${indexStr} ${paddedName} ${installs}` : `${indexStr} ${paddedName}`,
+      name: `${indexStr} ${paddedName} ${paddedInstalls}${trust}`,
       value: s,
       description: metadataLines.join("\n"),
     };
@@ -423,9 +432,11 @@ async function searchCommand(query: string): Promise<void> {
 
   log.blank();
 
-  const installsOffset = 4 + indexWidth + 1 + 1 + maxNameLen + 1 - 3;
-  const message =
-    "Select skills to install:" + " ".repeat(Math.max(1, installsOffset - 25)) + pc.dim("installs");
+  const checkboxPrefixWidth = 3; // "❯◯ " or " ◯ "
+  const headerPad = " ".repeat(checkboxPrefixWidth + indexWidth + 1 + 1 + maxNameLen + 1);
+  const headerLine =
+    headerPad + pc.dim("Installs".padEnd(installsColWidth)) + pc.dim("Trust(0-10)");
+  const message = "Select skills to install:\n" + headerLine;
 
   let selectedSkills: SkillSearchResult[];
   try {

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -8,12 +8,11 @@ export interface Skill {
   description: string;
   url: string;
   installCount?: number;
+  trustScore?: number;
 }
 
 export interface SkillSearchResult extends Skill {
   project: string;
-  installCount?: number;
-  trustScore?: number;
 }
 
 export interface ListSkillsResponse {

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -13,6 +13,7 @@ export interface Skill {
 export interface SkillSearchResult extends Skill {
   project: string;
   installCount?: number;
+  trustScore?: number;
 }
 
 export interface ListSkillsResponse {

--- a/packages/cli/src/utils/prompts.ts
+++ b/packages/cli/src/utils/prompts.ts
@@ -17,13 +17,13 @@ export function terminalLink(text: string, url: string, color?: (s: string) => s
  * Formats install count for display.
  */
 export function formatInstallCount(count: number | undefined): string {
-  if (count === undefined || count === 0) return "";
+  if (count === undefined || count === 0) return pc.dim("-");
 
   return pc.yellow(String(count));
 }
 
 export function formatTrustScore(score: number | undefined): string {
-  if (score === undefined || score < 0) return "";
+  if (score === undefined || score < 0) return pc.dim("-");
 
   if (score < 3) return pc.red(score.toFixed(1));
   return pc.yellow(score.toFixed(1));

--- a/packages/cli/src/utils/prompts.ts
+++ b/packages/cli/src/utils/prompts.ts
@@ -21,6 +21,13 @@ export function formatInstallCount(count: number | undefined): string {
 
   return pc.yellow(String(count));
 }
+
+export function formatTrustScore(score: number | undefined): string {
+  if (score === undefined || score < 0) return "";
+
+  if (score < 3) return pc.red(score.toFixed(1));
+  return pc.yellow(score.toFixed(1));
+}
 export interface CheckboxWithHoverOptions<T> {
   /** Function to extract display name from value. Defaults to (v) => v.name */
   getName?: (value: T) => string;

--- a/packages/cli/src/utils/prompts.ts
+++ b/packages/cli/src/utils/prompts.ts
@@ -16,8 +16,8 @@ export function terminalLink(text: string, url: string, color?: (s: string) => s
 /**
  * Formats install count for display.
  */
-export function formatInstallCount(count: number | undefined): string {
-  if (count === undefined || count === 0) return pc.dim("-");
+export function formatInstallCount(count: number | undefined, placeholder = ""): string {
+  if (count === undefined || count === 0) return placeholder;
 
   return pc.yellow(String(count));
 }

--- a/packages/cli/src/utils/prompts.ts
+++ b/packages/cli/src/utils/prompts.ts
@@ -10,7 +10,7 @@ type CheckboxChoice<T> = Exclude<CheckboxConfig<T>["choices"][number], Separator
  */
 export function terminalLink(text: string, url: string, color?: (s: string) => string): string {
   const colorFn = color ?? ((s: string) => s);
-  return `\x1b]8;;${url}\x07${colorFn(text)}\x1b]8;;\x07`;
+  return `\x1b]8;;${url}\x07${colorFn(text)}\x1b]8;;\x07 ${pc.white("↗")}`;
 }
 
 /**

--- a/packages/cli/src/utils/selectOrInput.ts
+++ b/packages/cli/src/utils/selectOrInput.ts
@@ -16,12 +16,22 @@ export interface SelectOrInputConfig {
   recommendedIndex?: number;
 }
 
+function reorderOptions(options: string[], recommendedIndex: number): string[] {
+  if (recommendedIndex === 0) return options;
+  const reordered = [options[recommendedIndex]];
+  for (let i = 0; i < options.length; i++) {
+    if (i !== recommendedIndex) reordered.push(options[i]);
+  }
+  return reordered;
+}
+
 const selectOrInput: (config: SelectOrInputConfig) => Promise<string> = createPrompt<
   string,
   SelectOrInputConfig
 >((config, done): string => {
-  const { message, options, recommendedIndex = 0 } = config;
-  const [cursor, setCursor] = useState(recommendedIndex);
+  const { message, options: rawOptions, recommendedIndex = 0 } = config;
+  const options = reorderOptions(rawOptions, recommendedIndex);
+  const [cursor, setCursor] = useState(0);
   const [inputValue, setInputValue] = useState("");
 
   const prefix = usePrefix({});
@@ -40,7 +50,7 @@ const selectOrInput: (config: SelectOrInputConfig) => Promise<string> = createPr
     if (isEnterKey(key)) {
       if (cursor === options.length) {
         const finalValue = inputValue.trim();
-        done(finalValue || options[recommendedIndex]);
+        done(finalValue || options[0]);
       } else {
         done(options[cursor]);
       }
@@ -76,7 +86,7 @@ const selectOrInput: (config: SelectOrInputConfig) => Promise<string> = createPr
   let output = `${prefix} ${pc.bold(message)}\n\n`;
 
   options.forEach((opt: string, idx: number) => {
-    const isRecommended = idx === recommendedIndex;
+    const isRecommended = idx === 0;
     const isCursor = idx === cursor;
     const number = pc.cyan(`${idx + 1}.`);
     const text = isRecommended ? `${opt} ${pc.green("✓ Recommended")}` : opt;


### PR DESCRIPTION
## Summary

- **Trust score & installs columns**: Add Installs and Trust(0-10) columns to skill search results with aligned column headers
- **Auto-login for generate**: Instead of showing an error when unauthenticated, automatically trigger the OAuth login flow
- **Recommended option first**: Reorder question options so the recommended choice is always at the top
- **View in editor**: Open generated skill content in the user's default editor (`$EDITOR` or `open` fallback) instead of dumping inline
- **Generate UX revamp**: Improved copy, do/don't examples, renamed "libraries" to "sources", clearer spinner text