### PR TITLE
feat: add Context7 plugin for Cursor marketplace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,6 +172,7 @@ dist
 .idea
 
 .cursor
+!plugins/cursor/context7/.cursor
 .opencode
 .claude
 

--- a/plugins/cursor/context7/.cursor/plugin.json
+++ b/plugins/cursor/context7/.cursor/plugin.json
@@ -3,9 +3,9 @@
   "version": "1.0.0",
   "description": "Upstash Context7 MCP server for up-to-date documentation lookup. Pull version-specific documentation and code examples directly from source repositories into your LLM context.",
   "author": {
-    "name": "Fahreddin Ozcan",
-    "email": "fahreddin@upstash.com",
-    "url": "https://upstash.com"
+    "name": "Context7",
+    "email": "context7@upstash.com",
+    "url": "https://context7.com"
   },
   "keywords": ["documentation", "mcp", "context7", "libraries", "frameworks"],
   "logo": "https://context7.com/brand/context7-logo-light.svg",

--- a/plugins/cursor/context7/.cursor/plugin.json
+++ b/plugins/cursor/context7/.cursor/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "context7",
+  "version": "1.0.0",
+  "description": "Upstash Context7 MCP server for up-to-date documentation lookup. Pull version-specific documentation and code examples directly from source repositories into your LLM context.",
+  "author": {
+    "name": "Fahreddin Ozcan",
+    "email": "fahreddin@upstash.com",
+    "url": "https://upstash.com"
+  },
+  "keywords": ["documentation", "mcp", "context7", "libraries", "frameworks"],
+  "logo": "https://context7.com/brand/context7-logo-light.svg",
+  "primaryColor": "#059669"
+}

--- a/plugins/cursor/context7/README.md
+++ b/plugins/cursor/context7/README.md
@@ -1,0 +1,53 @@
+# Context7 Plugin for Cursor
+
+Context7 solves a common problem with AI coding assistants: outdated training data and hallucinated APIs. Instead of relying on stale knowledge, Context7 fetches current documentation directly from source repositories.
+
+## What's Included
+
+This plugin provides:
+
+- **MCP Server** — Connects Cursor to Context7's documentation service
+- **Rules** — An always-on `use-context7` rule that nudges the agent to fetch docs when unsure about library APIs
+- **Skills** — A `context7-docs-lookup` skill with detailed instructions on resolving libraries and fetching documentation
+- **Agents** — A dedicated `docs-researcher` agent for focused lookups
+
+## Available Tools
+
+### resolve-library-id
+
+Searches for libraries and returns Context7-compatible identifiers.
+
+```
+Input: "next.js"
+Output: { id: "/vercel/next.js", name: "Next.js", versions: ["v15.1.8", "v14.2.0", ...] }
+```
+
+### query-docs
+
+Fetches documentation for a specific library, ranked by relevance to your question.
+
+```
+Input: { libraryId: "/vercel/next.js", query: "app router middleware" }
+Output: Relevant documentation snippets with code examples
+```
+
+## Usage Examples
+
+The plugin works automatically when you ask about libraries:
+
+- "How do I set up authentication in Next.js 15?"
+- "Show me React Server Components examples"
+- "What's the Prisma syntax for relations?"
+
+Or use the docs-researcher agent when you want to keep your main context clean.
+
+## Version Pinning
+
+To get documentation for a specific version, include the version in the library ID:
+
+```
+/vercel/next.js/v15.1.8
+/supabase/supabase/v2.45.0
+```
+
+The `resolve-library-id` tool returns available versions, so you can pick the one that matches your project.

--- a/plugins/cursor/context7/agents/docs-researcher.md
+++ b/plugins/cursor/context7/agents/docs-researcher.md
@@ -1,0 +1,39 @@
+---
+name: docs-researcher
+description: Lightweight agent for fetching library documentation without cluttering your main conversation context.
+---
+
+You are a documentation researcher specializing in fetching up-to-date library and framework documentation from Context7.
+
+## Your Task
+
+When given a question about a library or framework, fetch the relevant documentation and return a concise, actionable answer with code examples.
+
+## Process
+
+1. **Identify the library**: Extract the library/framework name from the user's question.
+
+2. **Resolve the library ID**: Call `resolve-library-id` with:
+   - `libraryName`: The library name (e.g., "react", "next.js", "prisma")
+   - `query`: The user's full question for relevance ranking
+
+3. **Select the best match**: From the results, pick the library with:
+   - Exact or closest name match
+   - Highest benchmark score
+   - Appropriate version if the user specified one (e.g., "React 19" → look for v19.x)
+
+4. **Fetch documentation**: Call `query-docs` with:
+   - `libraryId`: The selected Context7 library ID (e.g., `/vercel/next.js`)
+   - `query`: The user's specific question for targeted results
+
+5. **Return a focused answer**: Summarize the relevant documentation with:
+   - Direct answer to the question
+   - Code examples from the docs
+   - Links or references if available
+
+## Guidelines
+
+- Pass the user's full question as the query parameter for better relevance
+- When the user mentions a version (e.g., "Next.js 15"), use version-specific library IDs if available
+- If `resolve-library-id` returns multiple matches, prefer official/primary packages over community forks
+- Keep responses concise - the goal is to answer the question, not dump entire documentation

--- a/plugins/cursor/context7/mcp.json
+++ b/plugins/cursor/context7/mcp.json
@@ -1,0 +1,5 @@
+{
+  "context7": {
+    "url": "https://mcp.context7.com/mcp/oauth"
+  }
+}

--- a/plugins/cursor/context7/rules/use-context7.mdc
+++ b/plugins/cursor/context7/rules/use-context7.mdc
@@ -1,0 +1,18 @@
+---
+description: Use Context7 MCP to fetch up-to-date documentation when unsure about library APIs, syntax, or behavior instead of guessing from training data.
+alwaysApply: true
+---
+
+When you're unsure about a library's API, syntax, configuration, or behavior, use Context7 to fetch current documentation rather than guessing from training data that may be outdated.
+
+Use Context7 when:
+- You're not confident about the exact API or syntax for a library
+- The user asks about a specific version (e.g., "Next.js 15", "React 19")
+- The library or framework has had recent major changes
+- You need accurate code examples for a specific use case
+
+You don't need to use Context7 for:
+- Well-established language features (e.g., JavaScript array methods, Python builtins)
+- Conversations where the user has already provided the relevant code or docs
+
+See the `context7-docs-lookup` skill for detailed instructions on how to resolve libraries and fetch documentation.

--- a/plugins/cursor/context7/skills/context7-docs-lookup/SKILL.md
+++ b/plugins/cursor/context7/skills/context7-docs-lookup/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: context7-docs-lookup
+description: Use Context7 to fetch up-to-date library documentation. Activates when the user asks about libraries, frameworks, API references, or needs code examples — especially for setup questions, code generation, or mentions of specific frameworks like React, Vue, Next.js, Prisma, Supabase, etc.
+---
+
+When the user asks about libraries, frameworks, or needs code examples, use Context7 to fetch current documentation instead of relying on training data.
+
+## When to Use This Skill
+
+Activate this skill when the user:
+
+- Asks setup or configuration questions ("How do I configure Next.js middleware?")
+- Requests code involving libraries ("Write a Prisma query for...")
+- Needs API references ("What are the Supabase auth methods?")
+- Mentions specific frameworks (React, Vue, Svelte, Express, Tailwind, etc.)
+
+## How to Fetch Documentation
+
+### Step 1: Resolve the Library ID
+
+Call `resolve-library-id` with:
+
+- `libraryName`: The library name extracted from the user's question
+- `query`: The user's full question (improves relevance ranking)
+
+### Step 2: Select the Best Match
+
+From the resolution results, choose based on:
+
+- Exact or closest name match to what the user asked for
+- Higher benchmark scores indicate better documentation quality
+- If the user mentioned a version (e.g., "React 19"), prefer version-specific IDs
+
+### Step 3: Fetch the Documentation
+
+Call `query-docs` with:
+
+- `libraryId`: The selected Context7 library ID (e.g., `/vercel/next.js`)
+- `query`: The user's specific question
+
+### Step 4: Use the Documentation
+
+Incorporate the fetched documentation into your response:
+
+- Answer the user's question using current, accurate information
+- Include relevant code examples from the docs
+- Cite the library version when relevant
+
+## Guidelines
+
+- **Be specific**: Pass the user's full question as the query for better results
+- **Version awareness**: When users mention versions ("Next.js 15", "React 19"), use version-specific library IDs if available from the resolution step
+- **Prefer official sources**: When multiple matches exist, prefer official/primary packages over community forks


### PR DESCRIPTION
## Summary
- Adds a Cursor marketplace plugin for Context7 with MCP server (OAuth), rules, skill, and agent
- Includes an always-on `use-context7` rule that nudges the agent to fetch docs when unsure about library APIs
- Includes a `context7-docs-lookup` skill with detailed instructions on resolving libraries and fetching documentation
- Includes a `docs-researcher` agent for focused documentation lookups
- Adds `.gitignore` exception for `plugins/cursor/context7/.cursor`