### PR TITLE
feat(cli): use backend suggest endpoint

### DIFF
--- a/.changeset/bright-tigers-dance.md
+++ b/.changeset/bright-tigers-dance.md
@@ -1,0 +1,5 @@
+---
+"ctx7": patch
+---
+
+Add `skills suggest` command that scans your project's dependencies (package.json, requirements.txt, pyproject.toml) and recommends relevant skills. Results show install counts, trust scores, and which dependency each skill matches.

--- a/packages/cli/src/commands/skill.ts
+++ b/packages/cli/src/commands/skill.ts
@@ -36,7 +36,7 @@ import type {
   AddOptions,
   ListOptions,
   RemoveOptions,
-  DiscoverOptions,
+  SuggestOptions,
   InstallTargets,
 } from "../types.js";
 import { IDE_NAMES, IDE_PATHS, IDE_GLOBAL_PATHS } from "../types.js";
@@ -148,7 +148,7 @@ export function registerSkillCommands(program: Command): void {
     .option("--amp", "Amp (.agents/skills/)")
     .option("--antigravity", "Antigravity (.agent/skills/)")
     .description("Suggest skills based on your project dependencies")
-    .action(async (options: DiscoverOptions) => {
+    .action(async (options: SuggestOptions) => {
       await suggestCommand(options);
     });
 }
@@ -189,7 +189,7 @@ export function registerSkillAliases(program: Command): void {
     .option("--amp", "Amp (.agents/skills/)")
     .option("--antigravity", "Antigravity (.agent/skills/)")
     .description("Suggest skills (alias for: skills suggest)")
-    .action(async (options: DiscoverOptions) => {
+    .action(async (options: SuggestOptions) => {
       await suggestCommand(options);
     });
 }
@@ -693,7 +693,7 @@ async function infoCommand(input: string): Promise<void> {
   );
 }
 
-async function suggestCommand(options: DiscoverOptions): Promise<void> {
+async function suggestCommand(options: SuggestOptions): Promise<void> {
   trackEvent("command", { name: "suggest" });
   log.blank();
 

--- a/packages/cli/src/commands/skill.ts
+++ b/packages/cli/src/commands/skill.ts
@@ -769,7 +769,7 @@ async function suggestCommand(options: DiscoverOptions): Promise<void> {
       "",
       `${pc.yellow("Skill:")}       ${skillLink}`,
       `${pc.yellow("Repo:")}        ${repoLink}`,
-      `${pc.yellow("Relevant:")}    ${pc.cyan(s.matchedDep)}`,
+      `${pc.yellow("Relevant:")}    ${pc.white(s.matchedDep)}`,
       `${pc.yellow("Description:")}`,
       pc.white(s.description || "No description"),
     ];

--- a/packages/cli/src/commands/skill.ts
+++ b/packages/cli/src/commands/skill.ts
@@ -43,6 +43,7 @@ import { IDE_NAMES, IDE_PATHS, IDE_GLOBAL_PATHS } from "../types.js";
 import type { IDE, Scope } from "../types.js";
 import { homedir } from "os";
 import { detectProjectDependencies } from "../utils/deps.js";
+import { loadTokens, isTokenExpired } from "../utils/auth.js";
 
 function logInstallSummary(
   targets: InstallTargets,
@@ -713,9 +714,16 @@ async function suggestCommand(options: DiscoverOptions): Promise<void> {
 
   type SuggestedSkill = SkillSearchResult & { matchedDep: string };
 
+  // Load auth token if available
+  const tokens = loadTokens();
+  const accessToken = tokens && !isTokenExpired(tokens) ? tokens.access_token : undefined;
+
   let data;
   try {
-    data = await suggestSkills(deps.map((d) => ({ name: d.name, ecosystem: d.ecosystem })));
+    data = await suggestSkills(
+      deps.map((d) => ({ name: d.name, ecosystem: d.ecosystem })),
+      accessToken
+    );
   } catch {
     searchSpinner.fail(pc.red("Failed to connect to Context7"));
     return;

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -194,13 +194,12 @@ export const DEFAULT_CONFIG: C7Config = {
 };
 
 // Suggest endpoint types
-export interface SuggestGroup {
-  dependency: string;
-  skills: SkillSearchResult[];
+export interface SuggestSkill extends SkillSearchResult {
+  matchedDep: string;
 }
 
 export interface SuggestResponse {
-  groups: SuggestGroup[];
+  skills: SuggestSkill[];
   error?: string;
   message?: string;
 }

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -193,6 +193,18 @@ export const DEFAULT_CONFIG: C7Config = {
   defaultScope: "project",
 };
 
+// Suggest endpoint types
+export interface SuggestGroup {
+  dependency: string;
+  skills: SkillSearchResult[];
+}
+
+export interface SuggestResponse {
+  groups: SuggestGroup[];
+  error?: string;
+  message?: string;
+}
+
 export interface SkillQuotaResponse {
   used: number;
   limit: number;

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -142,7 +142,7 @@ export interface ScopeOptions {
 }
 
 export type AddOptions = IDEOptions & ScopeOptions & { all?: boolean };
-export type DiscoverOptions = IDEOptions & ScopeOptions;
+export type SuggestOptions = IDEOptions & ScopeOptions;
 export type ListOptions = IDEOptions & ScopeOptions;
 export type RemoveOptions = IDEOptions & ScopeOptions;
 export type GenerateOptions = IDEOptions &

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -142,6 +142,7 @@ export interface ScopeOptions {
 }
 
 export type AddOptions = IDEOptions & ScopeOptions & { all?: boolean };
+export type DiscoverOptions = IDEOptions & ScopeOptions;
 export type ListOptions = IDEOptions & ScopeOptions;
 export type RemoveOptions = IDEOptions & ScopeOptions;
 export type GenerateOptions = IDEOptions &

--- a/packages/cli/src/utils/api.ts
+++ b/packages/cli/src/utils/api.ts
@@ -41,7 +41,7 @@ export async function searchSkills(query: string): Promise<SearchResponse> {
 }
 
 export async function suggestSkills(
-  dependencies: Array<{ name: string; ecosystem: string }>,
+  dependencies: string[],
   accessToken?: string
 ): Promise<SuggestResponse> {
   const headers: Record<string, string> = { "Content-Type": "application/json" };

--- a/packages/cli/src/utils/api.ts
+++ b/packages/cli/src/utils/api.ts
@@ -2,6 +2,7 @@ import type {
   ListSkillsResponse,
   SingleSkillResponse,
   SearchResponse,
+  SuggestResponse,
   DownloadResponse,
   LibrarySearchResponse,
   SkillQuestionsResponse,
@@ -37,6 +38,17 @@ export async function searchSkills(query: string): Promise<SearchResponse> {
   const params = new URLSearchParams({ query });
   const response = await fetch(`${baseUrl}/api/v2/skills?${params}`);
   return (await response.json()) as SearchResponse;
+}
+
+export async function suggestSkills(
+  dependencies: Array<{ name: string; ecosystem: string }>
+): Promise<SuggestResponse> {
+  const response = await fetch(`${baseUrl}/api/v2/skills/suggest`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ dependencies }),
+  });
+  return (await response.json()) as SuggestResponse;
 }
 
 export async function downloadSkill(project: string, skillName: string): Promise<DownloadResponse> {

--- a/packages/cli/src/utils/api.ts
+++ b/packages/cli/src/utils/api.ts
@@ -41,11 +41,16 @@ export async function searchSkills(query: string): Promise<SearchResponse> {
 }
 
 export async function suggestSkills(
-  dependencies: Array<{ name: string; ecosystem: string }>
+  dependencies: Array<{ name: string; ecosystem: string }>,
+  accessToken?: string
 ): Promise<SuggestResponse> {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (accessToken) {
+    headers["Authorization"] = `Bearer ${accessToken}`;
+  }
   const response = await fetch(`${baseUrl}/api/v2/skills/suggest`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers,
     body: JSON.stringify({ dependencies }),
   });
   return (await response.json()) as SuggestResponse;

--- a/packages/cli/src/utils/deps.ts
+++ b/packages/cli/src/utils/deps.ts
@@ -1,0 +1,234 @@
+import { readFile } from "fs/promises";
+import { join } from "path";
+
+export interface DetectedDependency {
+  name: string;
+  source: string;
+  ecosystem: string;
+}
+
+const SKIP_SET = new Set([
+  "typescript",
+  "python",
+  "setuptools",
+  "pip",
+  "wheel",
+  "node",
+  "npm",
+  "yarn",
+  "pnpm",
+  "eslint",
+  "prettier",
+  "jest",
+  "mocha",
+  "vitest",
+  "webpack",
+  "vite",
+  "esbuild",
+  "tsup",
+  "turbo",
+]);
+
+// Well-known frameworks and libraries that are likely to have relevant skills
+const NOTABLE_SET = new Set([
+  // Node / JS / TS
+  "react",
+  "next",
+  "vue",
+  "nuxt",
+  "svelte",
+  "angular",
+  "express",
+  "fastify",
+  "nestjs",
+  "@nestjs/core",
+  "hono",
+  "remix",
+  "astro",
+  "gatsby",
+  "tailwindcss",
+  "prisma",
+  "@prisma/client",
+  "drizzle-orm",
+  "typeorm",
+  "sequelize",
+  "mongoose",
+  "graphql",
+  "@trpc/server",
+  "zod",
+  "socket.io",
+  "three",
+  "d3",
+  "electron",
+  "redis",
+  "ioredis",
+  "bullmq",
+  "stripe",
+  "@supabase/supabase-js",
+  "firebase",
+  "@auth/core",
+  "next-auth",
+  "lucia",
+  "better-auth",
+  "convex",
+  "@tanstack/react-query",
+  "zustand",
+  "jotai",
+  "mobx",
+  "redux",
+  "@reduxjs/toolkit",
+  "playwright",
+  "cypress",
+  "storybook",
+  "docker",
+  "kubernetes",
+  // Python
+  "django",
+  "flask",
+  "fastapi",
+  "pytorch",
+  "torch",
+  "tensorflow",
+  "numpy",
+  "pandas",
+  "scikit-learn",
+  "langchain",
+  "celery",
+  "sqlalchemy",
+  "pydantic",
+  "streamlit",
+  "scrapy",
+  "boto3",
+  "transformers",
+  "openai",
+  "anthropic",
+]);
+
+const MAX_QUERIES = 15;
+
+async function readFileOrNull(path: string): Promise<string | null> {
+  try {
+    return await readFile(path, "utf-8");
+  } catch {
+    return null;
+  }
+}
+
+function isSkipped(name: string): boolean {
+  if (SKIP_SET.has(name)) return true;
+  if (name.startsWith("@types/")) return true;
+  return false;
+}
+
+function isNotable(name: string): boolean {
+  return NOTABLE_SET.has(name.toLowerCase());
+}
+
+async function parsePackageJson(cwd: string): Promise<DetectedDependency[]> {
+  const content = await readFileOrNull(join(cwd, "package.json"));
+  if (!content) return [];
+
+  try {
+    const pkg = JSON.parse(content);
+    const names = new Set<string>();
+
+    for (const key of Object.keys(pkg.dependencies || {})) {
+      if (!isSkipped(key) && isNotable(key)) names.add(key);
+    }
+    for (const key of Object.keys(pkg.devDependencies || {})) {
+      if (!isSkipped(key) && isNotable(key)) names.add(key);
+    }
+
+    return [...names].map((name) => ({
+      name,
+      source: "package.json",
+      ecosystem: "node",
+    }));
+  } catch {
+    return [];
+  }
+}
+
+async function parseRequirementsTxt(cwd: string): Promise<DetectedDependency[]> {
+  const content = await readFileOrNull(join(cwd, "requirements.txt"));
+  if (!content) return [];
+
+  const deps: DetectedDependency[] = [];
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#") || trimmed.startsWith("-")) continue;
+    const name = trimmed.split(/[=<>!~;@\s\[]/)[0].trim();
+    if (name && !isSkipped(name) && isNotable(name)) {
+      deps.push({ name, source: "requirements.txt", ecosystem: "python" });
+    }
+  }
+  return deps;
+}
+
+async function parsePyprojectToml(cwd: string): Promise<DetectedDependency[]> {
+  const content = await readFileOrNull(join(cwd, "pyproject.toml"));
+  if (!content) return [];
+
+  const deps: DetectedDependency[] = [];
+  const seen = new Set<string>();
+
+  // Match dependencies in [project.dependencies] array
+  const projectDepsMatch = content.match(/\[project\]\s[\s\S]*?dependencies\s*=\s*\[([\s\S]*?)\]/);
+  if (projectDepsMatch) {
+    const entries = projectDepsMatch[1].match(/"([^"]+)"/g) || [];
+    for (const entry of entries) {
+      const name = entry
+        .replace(/"/g, "")
+        .split(/[=<>!~;@\s\[]/)[0]
+        .trim();
+      if (name && !isSkipped(name) && isNotable(name) && !seen.has(name)) {
+        seen.add(name);
+        deps.push({ name, source: "pyproject.toml", ecosystem: "python" });
+      }
+    }
+  }
+
+  // Match [tool.poetry.dependencies] section
+  const poetryMatch = content.match(/\[tool\.poetry\.dependencies\]([\s\S]*?)(?:\n\[|$)/);
+  if (poetryMatch) {
+    const lines = poetryMatch[1].split("\n");
+    for (const line of lines) {
+      const match = line.match(/^(\S+)\s*=/);
+      if (match) {
+        const name = match[1].trim();
+        if (name && !isSkipped(name) && isNotable(name) && name !== "python" && !seen.has(name)) {
+          seen.add(name);
+          deps.push({ name, source: "pyproject.toml", ecosystem: "python" });
+        }
+      }
+    }
+  }
+
+  return deps;
+}
+
+export async function detectProjectDependencies(cwd: string): Promise<DetectedDependency[]> {
+  const results = await Promise.all([
+    parsePackageJson(cwd),
+    parseRequirementsTxt(cwd),
+    parsePyprojectToml(cwd),
+  ]);
+
+  return results.flat();
+}
+
+export function buildSearchQueries(deps: DetectedDependency[]): { query: string; dep: string }[] {
+  const queries: { query: string; dep: string }[] = [];
+  const seen = new Set<string>();
+
+  for (const dep of deps) {
+    if (queries.length >= MAX_QUERIES) break;
+    const lower = dep.name.toLowerCase();
+    if (seen.has(lower)) continue;
+    seen.add(lower);
+
+    queries.push({ query: dep.name, dep: dep.name });
+  }
+
+  return queries;
+}


### PR DESCRIPTION
## Summary
- Replace client-side NOTABLE_SET/SKIP_SET with single API call to `/api/v2/skills/suggest`
- Backend now handles filtering, vector search, and ranking
- Simplify `deps.ts` to only collect dependencies without filtering