### PR TITLE
Remove deprecated downlevelIteration option

### DIFF
--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -8,7 +8,6 @@
     "allowImportingTsExtensions": true,
     "noEmit": true,
     "strict": true,
-    "downlevelIteration": true,
     "skipLibCheck": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
This option is deprecated in TypeScript 6.0. It doesn't do anything when `target` is `esnext`, so can be safely removed from this config file.