### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -21,7 +21,7 @@ jobs:
           ref: ${{ inputs.branch || github.ref }}
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
 

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 0
 
       - name: Check for changeset
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const { execSync } = require('child_process');

--- a/.github/workflows/mcp-registry.yml
+++ b/.github/workflows/mcp-registry.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
 


### PR DESCRIPTION
This PR updates outdated GitHub Action versions.

- Updated `actions/setup-node` from `v4` to `v6` in `.github/workflows/canary-release.yml`
- Updated `actions/github-script` from `v7` to `v8` in `.github/workflows/changeset-check.yml`
- Updated `actions/setup-node` from `v4` to `v6` in `.github/workflows/release.yml`
- Updated `actions/setup-node` from `v4` to `v6` in `.github/workflows/test.yml`
- Updated `actions/setup-node` from `v4` to `v6` in `.github/workflows/mcp-registry.yml`
