### PR TITLE
docs: add add-mcp install snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@ Context7 fetches up-to-date code examples and documentation right into your LLM'
 > [!NOTE]
 > **API Key Recommended**: Get a free API key at [context7.com/dashboard](https://context7.com/dashboard) for higher rate limits.
 
+### Install with add-mcp
+
+Install the MCP server for all your coding agents:
+
+```bash
+npx add-mcp https://mcp.context7.com/mcp --header "CONTEXT7_API_KEY: YOUR_API_KEY"
+```
+
+Add `-y` to skip the confirmation prompt and install to all detected agents already in use in the project directory.
+
 <details>
 <summary><b>Install in Cursor</b></summary>
 


### PR DESCRIPTION
Add `add-mcp` to installation section to quickly install context7 across all editors / coding agents

About [add-mcp](https://www.npmjs.com/package/add-mcp):

- Supports all major agents/editors (claude code, claude web, opencode, codex, cursor, vscode, zed, and more)
- Auto-detects existing editors & agents by their config files
- Remember last-selected editors & agents
- Supports global and local/project-scoped (default) installation 
