### PR TITLE
fix(sdk): handle non-JSON error responses, add HTTP retry, defensive null checks

### DIFF
--- a/packages/sdk/src/commands/get-context/get-context.unit.test.ts
+++ b/packages/sdk/src/commands/get-context/get-context.unit.test.ts
@@ -1,0 +1,126 @@
+import { describe, test, expect, vi } from "vitest";
+import { GetContextCommand } from "./index";
+import { Context7Error } from "@error";
+import type { Requester } from "@http";
+
+function mockRequester(result: unknown): Requester {
+  return {
+    request: vi.fn().mockResolvedValue({ result }),
+  };
+}
+
+describe("GetContextCommand — defensive parsing", () => {
+  test("should handle response with missing codeSnippets field", async () => {
+    const requester = mockRequester({
+      infoSnippets: [
+        { content: "Some docs", breadcrumb: "Guide", pageId: "p1" },
+      ],
+    });
+
+    const command = new GetContextCommand("how to use hooks", "/facebook/react");
+    const result = await command.exec(requester);
+
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toHaveLength(1);
+  });
+
+  test("should handle response with missing infoSnippets field", async () => {
+    const requester = mockRequester({
+      codeSnippets: [
+        {
+          codeTitle: "Example",
+          codeDescription: "A hook example",
+          codeLanguage: "tsx",
+          codeList: [{ language: "tsx", code: "const x = 1;" }],
+          codeId: "c1",
+        },
+      ],
+    });
+
+    const command = new GetContextCommand("how to use hooks", "/facebook/react");
+    const result = await command.exec(requester);
+
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toHaveLength(1);
+  });
+
+  test("should handle response with both fields missing", async () => {
+    const requester = mockRequester({});
+
+    const command = new GetContextCommand("how to use hooks", "/facebook/react");
+    const result = await command.exec(requester);
+
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toHaveLength(0);
+  });
+
+  test("should handle response with null fields", async () => {
+    const requester = mockRequester({
+      codeSnippets: null,
+      infoSnippets: null,
+    });
+
+    const command = new GetContextCommand("how to use hooks", "/facebook/react");
+    const result = await command.exec(requester);
+
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toHaveLength(0);
+  });
+
+  test("should handle undefined result", async () => {
+    const requester = mockRequester(undefined);
+
+    const command = new GetContextCommand("how to use hooks", "/facebook/react");
+    await expect(command.exec(requester)).rejects.toThrow(Context7Error);
+  });
+
+  test("should return text for txt type", async () => {
+    const requester: Requester = {
+      request: vi.fn().mockResolvedValue({ result: "Plain text docs" }),
+    };
+
+    const command = new GetContextCommand("how to use hooks", "/facebook/react", {
+      type: "txt",
+    });
+    const result = await command.exec(requester);
+
+    expect(typeof result).toBe("string");
+    expect(result).toBe("Plain text docs");
+  });
+
+  test("should format code and info snippets correctly", async () => {
+    const requester = mockRequester({
+      codeSnippets: [
+        {
+          codeTitle: "useState Example",
+          codeDescription: "React hook for state",
+          codeLanguage: "tsx",
+          codeList: [{ language: "tsx", code: "const [count, setCount] = useState(0);" }],
+          codeId: "c1",
+        },
+      ],
+      infoSnippets: [
+        {
+          content: "useState is a React Hook...",
+          breadcrumb: "Hooks > useState",
+          pageId: "p1",
+        },
+      ],
+    });
+
+    const command = new GetContextCommand("how to use hooks", "/facebook/react");
+    const result = await command.exec(requester);
+
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toHaveLength(2);
+
+    const [codeDoc, infoDoc] = result as { title: string; content: string; source: string }[];
+    expect(codeDoc.title).toBe("useState Example");
+    expect(codeDoc.content).toContain("const [count, setCount] = useState(0);");
+    expect(codeDoc.source).toBe("c1");
+
+    expect(infoDoc.title).toBe("Hooks > useState");
+    expect(infoDoc.content).toBe("useState is a React Hook...");
+    expect(infoDoc.source).toBe("p1");
+  });
+});

--- a/packages/sdk/src/commands/get-context/index.ts
+++ b/packages/sdk/src/commands/get-context/index.ts
@@ -41,8 +41,8 @@ export class GetContextCommand extends Command<Documentation[] | string> {
     }
 
     const apiResult = result as ApiContextJsonResponse;
-    const codeDocs = apiResult.codeSnippets.map(formatCodeSnippet);
-    const infoDocs = apiResult.infoSnippets.map(formatInfoSnippet);
+    const codeDocs = (apiResult.codeSnippets ?? []).map(formatCodeSnippet);
+    const infoDocs = (apiResult.infoSnippets ?? []).map(formatInfoSnippet);
 
     return [...codeDocs, ...infoDocs];
   }

--- a/packages/sdk/src/commands/search-library/index.ts
+++ b/packages/sdk/src/commands/search-library/index.ts
@@ -36,6 +36,10 @@ export class SearchLibraryCommand extends Command<Library[] | string> {
       throw new Context7Error("Request did not return a result");
     }
 
+    if (!result.results || !Array.isArray(result.results)) {
+      return this.responseType === "txt" ? "No libraries found." : [];
+    }
+
     const libraries = result.results.map(formatLibrary);
 
     if (this.responseType === "txt") {

--- a/packages/sdk/src/commands/search-library/search-library.unit.test.ts
+++ b/packages/sdk/src/commands/search-library/search-library.unit.test.ts
@@ -1,0 +1,105 @@
+import { describe, test, expect, vi } from "vitest";
+import { SearchLibraryCommand } from "./index";
+import { Context7Error } from "@error";
+import type { Requester } from "@http";
+
+function mockRequester(result: unknown): Requester {
+  return {
+    request: vi.fn().mockResolvedValue({ result }),
+  };
+}
+
+describe("SearchLibraryCommand — defensive parsing", () => {
+  test("should handle response with missing results field", async () => {
+    const requester = mockRequester({});
+
+    const command = new SearchLibraryCommand("build UI", "react");
+    const result = await command.exec(requester);
+
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toHaveLength(0);
+  });
+
+  test("should handle response with null results", async () => {
+    const requester = mockRequester({ results: null });
+
+    const command = new SearchLibraryCommand("build UI", "react");
+    const result = await command.exec(requester);
+
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toHaveLength(0);
+  });
+
+  test("should handle response with results not being an array", async () => {
+    const requester = mockRequester({ results: "not-an-array" });
+
+    const command = new SearchLibraryCommand("build UI", "react");
+    const result = await command.exec(requester);
+
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toHaveLength(0);
+  });
+
+  test("should handle undefined result", async () => {
+    const requester = mockRequester(undefined);
+
+    const command = new SearchLibraryCommand("build UI", "react");
+    await expect(command.exec(requester)).rejects.toThrow(Context7Error);
+  });
+
+  test("should return empty text for txt type with missing results", async () => {
+    const requester = mockRequester({});
+
+    const command = new SearchLibraryCommand("build UI", "react", { type: "txt" });
+    const result = await command.exec(requester);
+
+    expect(typeof result).toBe("string");
+    expect(result).toBe("No libraries found.");
+  });
+
+  test("should throw on empty query", () => {
+    expect(() => new SearchLibraryCommand("", "react")).toThrow(Context7Error);
+  });
+
+  test("should throw on empty libraryName", () => {
+    expect(() => new SearchLibraryCommand("build UI", "")).toThrow(Context7Error);
+  });
+
+  test("should format valid results correctly", async () => {
+    const requester = mockRequester({
+      results: [
+        {
+          id: "/facebook/react",
+          title: "React",
+          description: "A JavaScript library for building user interfaces",
+          totalSnippets: 150,
+          trustScore: 9,
+          benchmarkScore: 85,
+          versions: ["v18.3.0", "v19.0.0"],
+        },
+      ],
+    });
+
+    const command = new SearchLibraryCommand("build UI", "react");
+    const result = await command.exec(requester);
+
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toHaveLength(1);
+
+    const library = result[0] as {
+      id: string;
+      name: string;
+      description: string;
+      totalSnippets: number;
+      trustScore: number;
+      benchmarkScore: number;
+      versions?: string[];
+    };
+    expect(library.id).toBe("/facebook/react");
+    expect(library.name).toBe("React");
+    expect(library.totalSnippets).toBe(150);
+    expect(library.trustScore).toBe(9);
+    expect(library.benchmarkScore).toBe(85);
+    expect(library.versions).toEqual(["v18.3.0", "v19.0.0"]);
+  });
+});

--- a/packages/sdk/src/http/index.test.ts
+++ b/packages/sdk/src/http/index.test.ts
@@ -1,0 +1,384 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import { HttpClient } from "./index";
+import { Context7Error } from "@error";
+
+// Mock global fetch
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+function createClient(options?: { retries?: number; backoff?: (n: number) => number }) {
+  return new HttpClient({
+    baseUrl: "https://api.example.com",
+    headers: { Authorization: "Bearer test-key" },
+    retry: {
+      retries: options?.retries ?? 2,
+      backoff: options?.backoff ?? (() => 1), // 1ms backoff for fast tests
+    },
+    cache: "no-store",
+  });
+}
+
+function jsonResponse(body: unknown, status = 200, headers?: Record<string, string>) {
+  return new Response(JSON.stringify(body), {
+    status,
+    statusText: status === 200 ? "OK" : `Error ${status}`,
+    headers: { "content-type": "application/json", ...headers },
+  });
+}
+
+function textResponse(body: string, status = 200, headers?: Record<string, string>) {
+  return new Response(body, {
+    status,
+    statusText: status === 200 ? "OK" : `Error ${status}`,
+    headers: { "content-type": "text/plain", ...headers },
+  });
+}
+
+function htmlResponse(body: string, status = 502) {
+  return new Response(body, {
+    status,
+    statusText: "Bad Gateway",
+    headers: { "content-type": "text/html" },
+  });
+}
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("HttpClient", () => {
+  describe("successful requests", () => {
+    test("should return JSON response", async () => {
+      const client = createClient();
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: "test" }));
+
+      const result = await client.request({ method: "GET", path: ["v1", "test"] });
+      expect(result.result).toEqual({ data: "test" });
+    });
+
+    test("should return text response with headers", async () => {
+      const client = createClient();
+      mockFetch.mockResolvedValueOnce(
+        textResponse("Documentation text here", 200, {
+          "x-context7-page": "1",
+          "x-context7-limit": "10",
+          "x-context7-total-pages": "5",
+          "x-context7-has-next": "true",
+          "x-context7-has-prev": "false",
+          "x-context7-total-tokens": "1500",
+        })
+      );
+
+      const result = await client.request<string>({ method: "GET", path: ["v1", "docs"] });
+      expect(result.result).toBe("Documentation text here");
+      expect(result.headers).toEqual({
+        page: 1,
+        limit: 10,
+        totalPages: 5,
+        hasNext: true,
+        hasPrev: false,
+        totalTokens: 1500,
+      });
+    });
+
+    test("should append query parameters for GET requests", async () => {
+      const client = createClient();
+      mockFetch.mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+      await client.request({
+        method: "GET",
+        path: ["v1", "search"],
+        query: { q: "react", limit: 10, enabled: true, empty: undefined },
+      });
+
+      const calledUrl = mockFetch.mock.calls[0][0];
+      expect(calledUrl).toContain("q=react");
+      expect(calledUrl).toContain("limit=10");
+      expect(calledUrl).toContain("enabled=true");
+      expect(calledUrl).not.toContain("empty");
+    });
+  });
+
+  describe("error handling — non-JSON error responses", () => {
+    test("should handle JSON error body", async () => {
+      const client = createClient({ retries: 0 });
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ error: "Invalid API key" }, 401)
+      );
+
+      try {
+        await client.request({ method: "GET", path: ["v1", "test"] });
+        expect.unreachable("should have thrown");
+      } catch (e) {
+        expect(e).toBeInstanceOf(Context7Error);
+        expect((e as Context7Error).message).toBe("Invalid API key");
+      }
+    });
+
+    test("should handle JSON error body with message field", async () => {
+      const client = createClient({ retries: 0 });
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ message: "Rate limited" }, 429)
+      );
+
+      await expect(
+        client.request({ method: "GET", path: ["v1", "test"] })
+      ).rejects.toThrow("Rate limited");
+    });
+
+    test("should handle HTML error response from proxy without crashing", async () => {
+      const client = createClient({ retries: 0 });
+      mockFetch.mockResolvedValueOnce(
+        htmlResponse("<html><body><h1>502 Bad Gateway</h1></body></html>")
+      );
+
+      // Should throw Context7Error, NOT SyntaxError from JSON.parse
+      try {
+        await client.request({ method: "GET", path: ["v1", "test"] });
+        expect.unreachable("should have thrown");
+      } catch (e) {
+        expect(e).toBeInstanceOf(Context7Error);
+        expect(e).not.toBeInstanceOf(SyntaxError);
+        // Long HTML body (>200 chars) falls back to statusText + status code
+        expect((e as Context7Error).message).toContain("Bad Gateway");
+      }
+    });
+
+    test("should truncate long non-JSON error bodies", async () => {
+      const client = createClient({ retries: 0 });
+      const longHtml = "<html>" + "x".repeat(500) + "</html>";
+      mockFetch.mockResolvedValueOnce(htmlResponse(longHtml, 502));
+
+      try {
+        await client.request({ method: "GET", path: ["v1", "test"] });
+        expect.unreachable("should have thrown");
+      } catch (e) {
+        expect(e).toBeInstanceOf(Context7Error);
+        // Long bodies (>200 chars) are replaced with statusText (status)
+        expect((e as Context7Error).message).toContain("Bad Gateway");
+        expect((e as Context7Error).message).toContain("502");
+      }
+    });
+
+    test("should handle short plain text error body", async () => {
+      const client = createClient({ retries: 0 });
+      mockFetch.mockResolvedValueOnce(textResponse("Service Unavailable", 503));
+
+      try {
+        await client.request({ method: "GET", path: ["v1", "test"] });
+        expect.unreachable("should have thrown");
+      } catch (e) {
+        expect(e).toBeInstanceOf(Context7Error);
+        // Short plain text body (<= 200 chars) is used directly
+        expect((e as Context7Error).message).toBe("Service Unavailable");
+      }
+    });
+
+    test("should fall back to statusText when error body is empty", async () => {
+      const client = createClient({ retries: 0 });
+      mockFetch.mockResolvedValueOnce(
+        new Response("", {
+          status: 404,
+          statusText: "Not Found",
+          headers: { "content-type": "text/plain" },
+        })
+      );
+
+      await expect(
+        client.request({ method: "GET", path: ["v1", "test"] })
+      ).rejects.toThrow("Not Found");
+    });
+  });
+
+  describe("retry logic — network errors", () => {
+    test("should retry on network failure and succeed", async () => {
+      const client = createClient({ retries: 2 });
+      mockFetch
+        .mockRejectedValueOnce(new TypeError("fetch failed"))
+        .mockResolvedValueOnce(jsonResponse({ data: "ok" }));
+
+      const result = await client.request({ method: "GET", path: ["v1", "test"] });
+      expect(result.result).toEqual({ data: "ok" });
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    test("should exhaust retries on persistent network failure", async () => {
+      const client = createClient({ retries: 2 });
+      const fetchError = new TypeError("fetch failed");
+      mockFetch.mockRejectedValue(fetchError);
+
+      await expect(
+        client.request({ method: "GET", path: ["v1", "test"] })
+      ).rejects.toThrow("fetch failed");
+      // 1 initial + 2 retries = 3 total attempts
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+
+    test("should not retry when abort signal fires", async () => {
+      const controller = new AbortController();
+      const client = new HttpClient({
+        baseUrl: "https://api.example.com",
+        retry: { retries: 3, backoff: () => 1 },
+        signal: () => controller.signal,
+      });
+
+      const abortError = new DOMException("Aborted", "AbortError");
+      mockFetch.mockRejectedValueOnce(abortError);
+      controller.abort();
+
+      await expect(
+        client.request({ method: "GET", path: ["v1", "test"] })
+      ).rejects.toThrow();
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("retry logic — HTTP status codes", () => {
+    test("should retry on 429 and succeed", async () => {
+      const client = createClient({ retries: 2 });
+      mockFetch
+        .mockResolvedValueOnce(jsonResponse({ error: "Rate limited" }, 429))
+        .mockResolvedValueOnce(jsonResponse({ data: "ok" }));
+
+      const result = await client.request({ method: "GET", path: ["v1", "test"] });
+      expect(result.result).toEqual({ data: "ok" });
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    test("should retry on 500 and succeed", async () => {
+      const client = createClient({ retries: 2 });
+      mockFetch
+        .mockResolvedValueOnce(jsonResponse({ error: "Internal Server Error" }, 500))
+        .mockResolvedValueOnce(jsonResponse({ data: "ok" }));
+
+      const result = await client.request({ method: "GET", path: ["v1", "test"] });
+      expect(result.result).toEqual({ data: "ok" });
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    test("should retry on 502 and succeed", async () => {
+      const client = createClient({ retries: 2 });
+      mockFetch
+        .mockResolvedValueOnce(htmlResponse("<html>502</html>", 502))
+        .mockResolvedValueOnce(jsonResponse({ data: "ok" }));
+
+      const result = await client.request({ method: "GET", path: ["v1", "test"] });
+      expect(result.result).toEqual({ data: "ok" });
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    test("should retry on 503 and succeed", async () => {
+      const client = createClient({ retries: 2 });
+      mockFetch
+        .mockResolvedValueOnce(textResponse("Service Unavailable", 503))
+        .mockResolvedValueOnce(jsonResponse({ data: "ok" }));
+
+      const result = await client.request({ method: "GET", path: ["v1", "test"] });
+      expect(result.result).toEqual({ data: "ok" });
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    test("should retry on 504 and succeed", async () => {
+      const client = createClient({ retries: 2 });
+      mockFetch
+        .mockResolvedValueOnce(textResponse("Gateway Timeout", 504))
+        .mockResolvedValueOnce(jsonResponse({ data: "ok" }));
+
+      const result = await client.request({ method: "GET", path: ["v1", "test"] });
+      expect(result.result).toEqual({ data: "ok" });
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    test("should NOT retry on 400 (client error)", async () => {
+      const client = createClient({ retries: 2 });
+      mockFetch.mockResolvedValueOnce(jsonResponse({ error: "Bad request" }, 400));
+
+      await expect(
+        client.request({ method: "GET", path: ["v1", "test"] })
+      ).rejects.toThrow("Bad request");
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    test("should NOT retry on 401 (unauthorized)", async () => {
+      const client = createClient({ retries: 2 });
+      mockFetch.mockResolvedValueOnce(jsonResponse({ error: "Unauthorized" }, 401));
+
+      await expect(
+        client.request({ method: "GET", path: ["v1", "test"] })
+      ).rejects.toThrow("Unauthorized");
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    test("should NOT retry on 404 (not found)", async () => {
+      const client = createClient({ retries: 2 });
+      mockFetch.mockResolvedValueOnce(jsonResponse({ error: "Not found" }, 404));
+
+      await expect(
+        client.request({ method: "GET", path: ["v1", "test"] })
+      ).rejects.toThrow("Not found");
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    test("should exhaust retries on persistent 500", async () => {
+      const client = createClient({ retries: 2 });
+      mockFetch.mockResolvedValue(jsonResponse({ error: "Internal Server Error" }, 500));
+
+      await expect(
+        client.request({ method: "GET", path: ["v1", "test"] })
+      ).rejects.toThrow("Internal Server Error");
+      // 1 initial + 2 retries = 3 total
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+
+    test("should respect Retry-After header on 429", async () => {
+      const backoffSpy = vi.fn().mockReturnValue(1);
+      const client = createClient({ retries: 2, backoff: backoffSpy });
+
+      mockFetch
+        .mockResolvedValueOnce(
+          jsonResponse({ error: "Rate limited" }, 429, { "retry-after": "1" })
+        )
+        .mockResolvedValueOnce(jsonResponse({ data: "ok" }));
+
+      const result = await client.request({ method: "GET", path: ["v1", "test"] });
+      expect(result.result).toEqual({ data: "ok" });
+      // Backoff function should NOT have been called for the HTTP retry
+      // since Retry-After header was present and valid
+      expect(backoffSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("retry logic — mixed failures", () => {
+    test("should handle network error then 502 then success", async () => {
+      const client = createClient({ retries: 3 });
+      mockFetch
+        .mockRejectedValueOnce(new TypeError("fetch failed"))
+        .mockResolvedValueOnce(htmlResponse("<html>502</html>", 502))
+        .mockResolvedValueOnce(jsonResponse({ data: "ok" }));
+
+      const result = await client.request({ method: "GET", path: ["v1", "test"] });
+      expect(result.result).toEqual({ data: "ok" });
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe("retry disabled", () => {
+    test("should not retry when retries=false", async () => {
+      const client = new HttpClient({
+        baseUrl: "https://api.example.com",
+        retry: false,
+        cache: "no-store",
+      });
+      mockFetch.mockRejectedValueOnce(new TypeError("fetch failed"));
+
+      await expect(
+        client.request({ method: "GET", path: ["v1", "test"] })
+      ).rejects.toThrow("fetch failed");
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
## Human View

### Summary

Fixes three related robustness issues in the `@upstash/context7` SDK's HTTP client and command layer:

#### Bug 1: `SyntaxError` crash on non-JSON error responses

**Before:** When the Context7 API (or an intermediary proxy) returned a non-JSON error response (e.g., HTML `502 Bad Gateway` page, plain text), `HttpClient.request()` called `res.json()` which threw an uncaught `SyntaxError`. Users saw a confusing `SyntaxError: Unexpected token < in JSON at position 0` instead of a meaningful `Context7Error`.

**After:** The error body is read once as text via `res.text()`, then `JSON.parse` is attempted. If parsing fails, short text bodies (<=200 chars) are used directly as the error message; long bodies (HTML pages) fall back to `statusText (status)`. The error is always wrapped in a `Context7Error`.

#### Bug 2: No retry on HTTP 429/5xx status codes

**Before:** The retry loop only caught network-level `fetch` failures (DNS errors, connection refused, etc.). Server errors (500, 502, 503, 504) and rate limits (429) were not retried, even though the client was configured with exponential backoff and up to 5 retries. This is especially impactful because Context7's own MCP server returns 429 for rate-limited requests.

**After:** HTTP 429, 500, 502, 503, and 504 responses are now retried with the configured backoff strategy. The `Retry-After` header is respected on 429 responses. Non-retryable client errors (400, 401, 404) are still immediately thrown.

#### Bug 3: Crash on incomplete API response fields

**Before:** `SearchLibraryCommand.exec()` assumed `result.results` was always a valid array, and `GetContextCommand.exec()` assumed `apiResult.codeSnippets` and `apiResult.infoSnippets` were always present. Missing or null fields caused `TypeError: Cannot read properties of undefined (reading 'map')`.

**After:** Added nullish coalescing for array fields and an `Array.isArray` guard for search results. Missing fields now gracefully return empty arrays.

#### Additional fix: `retry: false` created 2 attempts instead of 1

The constructor set `attempts: 1` for `retry: false`, but the loop condition `i <= attempts` produced 2 iterations. Fixed to `attempts: 0` (1 total attempt, 0 retries).

### Test plan

Added **39 new unit tests** (mocked `fetch`, no API key needed):

- [x] JSON error body parsing (error field, message field, statusText fallback)
- [x] HTML error body from proxy (no SyntaxError crash)
- [x] Long non-JSON body truncation
- [x] Short plain text error body
- [x] Empty error body fallback to statusText
- [x] Network failure retry + eventual success
- [x] Persistent network failure exhausts retries
- [x] Abort signal prevents retry
- [x] HTTP 429 retry + success
- [x] HTTP 500/502/503/504 retry + success
- [x] HTTP 400/401/404 NOT retried (client errors)
- [x] Persistent 500 exhausts all retries
- [x] Retry-After header respected on 429
- [x] Mixed failures (network error -> 502 -> success)
- [x] retry: false prevents any retry
- [x] Missing results field in search response
- [x] Missing codeSnippets/infoSnippets in context response
- [x] Null fields, non-array fields, undefined results
- [x] Correct formatting of valid responses

All 39 tests pass locally.

---

## AI View (DCCE Protocol v1.0)

### Metadata
- **Generator**: Claude (Anthropic) via Cursor IDE
- **Methodology**: AI-assisted development with human oversight and review

### AI Contribution Summary
- Solution design and implementation
- Test development (39 new test cases)

### Verification Steps Performed
1. Reproduced the reported issue
2. Analyzed source code to identify root cause
3. Implemented and tested the fix
4. Ran full test suite (39 tests passing)
5. Verified lint/formatting compliance

### Human Review Guidance
- Core changes are in: `JSON.parse`, `result.results`

Made with M7 [Cursor](https://cursor.com)
