### PR TITLE
fix(cursor-plugin): update logo to green icon SVG

### DIFF
--- a/plugins/cursor/context7/.cursor/plugin.json
+++ b/plugins/cursor/context7/.cursor/plugin.json
@@ -8,6 +8,6 @@
     "url": "https://context7.com"
   },
   "keywords": ["documentation", "mcp", "context7", "libraries", "frameworks"],
-  "logo": "https://context7.com/brand/context7-logo-light.svg",
+  "logo": "https://context7.com/brand/context7-icon-green.svg",
   "primaryColor": "#059669"
 }


### PR DESCRIPTION
## Summary
- Updates the Cursor plugin logo URL from `context7-logo-light.svg` (full wordmark) to `context7-icon-green.svg` (green icon without white background)