### PR TITLE
docs: add --scope user to Claude Code install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,14 +90,16 @@ Run this command. See [Claude Code MCP docs](https://code.claude.com/docs/en/mcp
 #### Claude Code Local Server Connection
 
 ```sh
-claude mcp add context7 -- npx -y @upstash/context7-mcp --api-key YOUR_API_KEY
+claude mcp add --scope user context7 -- npx -y @upstash/context7-mcp --api-key YOUR_API_KEY
 ```
 
 #### Claude Code Remote Server Connection
 
 ```sh
-claude mcp add --header "CONTEXT7_API_KEY: YOUR_API_KEY" --transport http context7 https://mcp.context7.com/mcp
+claude mcp add --scope user --header "CONTEXT7_API_KEY: YOUR_API_KEY" --transport http context7 https://mcp.context7.com/mcp
 ```
+
+> Remove `--scope user` to install for the current project only.
 
 </details>
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -139,14 +139,16 @@ Run this command. See [Claude Code MCP docs](https://docs.anthropic.com/en/docs/
 #### Claude Code Local Server Connection
 
 ```sh
-claude mcp add context7 -- npx -y @upstash/context7-mcp --api-key YOUR_API_KEY
+claude mcp add --scope user context7 -- npx -y @upstash/context7-mcp --api-key YOUR_API_KEY
 ```
 
 #### Claude Code Remote Server Connection
 
 ```sh
-claude mcp add --header "CONTEXT7_API_KEY: YOUR_API_KEY" --transport http context7 https://mcp.context7.com/mcp
+claude mcp add --scope user --header "CONTEXT7_API_KEY: YOUR_API_KEY" --transport http context7 https://mcp.context7.com/mcp
 ```
+
+> Remove `--scope user` to install for the current project only.
 
 </details>
 


### PR DESCRIPTION
## Problem

- `claude mcp add` defaults to project scope, installing the MCP server only for the current project. This is inconsistent with Cursor's recommended global install (`~/.cursor/mcp.json`)

## Changes

- added `--scope user` to both Claude Code commands (local and remote) in `README.md` and `packages/mcp/README.md`
- added a note saying that `--scope user` can be removed for project-only installs