### PR TITLE
fix: detect dependencies from monorepo workspace packages

### DIFF
--- a/packages/cli/src/utils/deps.ts
+++ b/packages/cli/src/utils/deps.ts
@@ -1,5 +1,5 @@
-import { readFile } from "fs/promises";
-import { join } from "path";
+import { readFile, readdir, stat } from "fs/promises";
+import { join, resolve } from "path";
 
 async function readFileOrNull(path: string): Promise<string | null> {
   try {
@@ -33,6 +33,113 @@ async function parsePackageJson(cwd: string): Promise<string[]> {
   } catch {
     return [];
   }
+}
+
+/**
+ * Resolve workspace glob patterns into concrete directory paths.
+ * Supports simple patterns like "packages/*" and "apps/*".
+ * Does not pull in a full glob library — handles the common single-star case.
+ */
+async function resolveWorkspaceGlobs(cwd: string, patterns: string[]): Promise<string[]> {
+  const dirs: string[] = [];
+
+  for (const pattern of patterns) {
+    // Strip trailing slashes
+    const clean = pattern.replace(/\/+$/, "");
+
+    if (clean.endsWith("/*")) {
+      // e.g. "packages/*" → list all directories under packages/
+      const parent = resolve(cwd, clean.slice(0, -2));
+      try {
+        const entries = await readdir(parent, { withFileTypes: true });
+        for (const entry of entries) {
+          if (entry.isDirectory()) {
+            dirs.push(join(parent, entry.name));
+          }
+        }
+      } catch {
+        // Parent doesn't exist — skip
+      }
+    } else if (!clean.includes("*")) {
+      // Exact path like "tools/foo"
+      const full = resolve(cwd, clean);
+      try {
+        const s = await stat(full);
+        if (s.isDirectory()) dirs.push(full);
+      } catch {
+        // Doesn't exist — skip
+      }
+    }
+    // More complex globs (e.g. "packages/**") are ignored for safety;
+    // the common monorepo convention is "packages/*".
+  }
+
+  return dirs;
+}
+
+/**
+ * Detect workspace package directories for JS/TS monorepos.
+ * Checks pnpm-workspace.yaml first, then falls back to the
+ * "workspaces" field in package.json (npm/yarn workspaces).
+ */
+async function getWorkspaceDirs(cwd: string): Promise<string[]> {
+  // 1. pnpm workspaces
+  const pnpmWs = await readFileOrNull(join(cwd, "pnpm-workspace.yaml"));
+  if (pnpmWs) {
+    // Simple YAML parsing for the packages array — avoids adding a YAML dep.
+    // Handles:
+    //   packages:
+    //     - "packages/*"
+    //     - "apps/*"
+    const patterns: string[] = [];
+    const lines = pnpmWs.split("\n");
+    let inPackages = false;
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (/^packages\s*:/.test(trimmed)) {
+        inPackages = true;
+        continue;
+      }
+      if (inPackages) {
+        if (trimmed.startsWith("- ")) {
+          const value = trimmed
+            .slice(2)
+            .trim()
+            .replace(/^["']|["']$/g, "");
+          if (value) patterns.push(value);
+        } else if (trimmed && !trimmed.startsWith("#")) {
+          // New top-level key — stop
+          break;
+        }
+      }
+    }
+
+    if (patterns.length > 0) {
+      return resolveWorkspaceGlobs(cwd, patterns);
+    }
+  }
+
+  // 2. npm/yarn workspaces (package.json "workspaces" field)
+  const rootPkg = await readFileOrNull(join(cwd, "package.json"));
+  if (rootPkg) {
+    try {
+      const pkg = JSON.parse(rootPkg);
+      const workspaces: string[] | undefined = Array.isArray(pkg.workspaces)
+        ? pkg.workspaces
+        : Array.isArray(pkg.workspaces?.packages)
+          ? pkg.workspaces.packages
+          : undefined;
+
+      if (workspaces && workspaces.length > 0) {
+        return resolveWorkspaceGlobs(cwd, workspaces);
+      }
+    } catch {
+      // malformed JSON — ignore
+    }
+  }
+
+  return [];
 }
 
 async function parseRequirementsTxt(cwd: string): Promise<string[]> {
@@ -98,5 +205,9 @@ export async function detectProjectDependencies(cwd: string): Promise<string[]> 
     parsePyprojectToml(cwd),
   ]);
 
-  return [...new Set(results.flat())];
+  // Also scan workspace packages in monorepos (pnpm, npm, yarn workspaces)
+  const workspaceDirs = await getWorkspaceDirs(cwd);
+  const workspaceResults = await Promise.all(workspaceDirs.map((dir) => parsePackageJson(dir)));
+
+  return [...new Set([...results.flat(), ...workspaceResults.flat()])];
 }


### PR DESCRIPTION
Fixes #1860

`detectProjectDependencies` only scans `package.json` in the given `cwd` directory. In monorepos using pnpm/npm/yarn workspaces, dependencies declared in sub-packages are completely missed.

This adds workspace detection:

- `getWorkspaceDirs(cwd)` checks `pnpm-workspace.yaml` and `package.json` workspaces field
- `resolveWorkspaceGlobs(cwd, patterns)` resolves `packages/*` style patterns into directories
- Each workspace package is scanned for its own `package.json` dependencies
- Results are deduplicated with the root dependencies

No new dependencies added. Backwards compatible — non-monorepo projects work exactly as before.

Supports pnpm workspaces, npm workspaces, and yarn workspaces.