### PR TITLE
Add ChatGPT web and desktop app MCP client examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,11 +159,11 @@ ChatGPT supports MCP servers through remote connectors via [Developer Mode](http
 
 #### 1. Enable Developer Mode
 
-Go to: `Settings` → `Apps & Connectors` → `Advanced settings` → Enable `Developer Mode`
+Go to: `Settings` → `Apps` → `Advanced settings` → Enable `Developer Mode`
 
-#### 2. Create a Connector
+#### 2. Create an App
 
-Go to: `Settings` → `Apps & Connectors` → `Create`
+Go to: `Settings` → `Apps` → `Create App`
 
 Fill in the following:
 
@@ -177,7 +177,9 @@ Fill in the following:
 
 #### 3. Use in a Conversation
 
-Start a new chat → Click the model selector → Choose `Developer Mode` → Select the `Context7` connector.
+Start a new chat → Click the plus icon → Hover over `More` → Select the `Context7` app.
+
+Alternatively, you can say `use context7` in your prompt and ChatGPT will automatically use the `Context7` app.
 
 See [OpenAI MCP docs](https://platform.openai.com/docs/mcp) for more info.
 
@@ -186,15 +188,15 @@ See [OpenAI MCP docs](https://platform.openai.com/docs/mcp) for more info.
 <details>
 <summary><b>Install in ChatGPT (Desktop)</b></summary>
 
-The ChatGPT desktop app shares connectors configured on the web. Set up the connector on [chatgpt.com](https://chatgpt.com) first.
+The ChatGPT desktop app shares apps configured on the web. Set up the app on [chatgpt.com](https://chatgpt.com) first.
 
 #### 1. Enable Developer Mode (on the Web)
 
-Go to: `Settings` → `Apps & Connectors` → `Advanced settings` → Enable `Developer Mode`
+Go to: `Settings` → `Apps` → `Advanced settings` → Enable `Developer Mode`
 
-#### 2. Create a Connector (on the Web)
+#### 2. Create an App (on the Web)
 
-Go to: `Settings` → `Apps & Connectors` → `Create`
+Go to: `Settings` → `Apps` → `Create App`
 
 Fill in the following:
 
@@ -208,9 +210,9 @@ Fill in the following:
 
 #### 3. Use in the Desktop App
 
-Open the ChatGPT desktop app → Start a new chat → Select `Developer Mode` from the model selector → Choose the `Context7` connector.
+Open the ChatGPT desktop app → Start a new chat → ChatGPT will automatically use the `Context7` app when you ask it to.
 
-Connectors configured on the web are automatically available in the desktop app.
+Apps configured on the web are automatically available in the desktop app.
 
 See [OpenAI MCP docs](https://platform.openai.com/docs/mcp) for more info.
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,70 @@ Authenticates via OAuth, generates an API key, and configures the MCP server and
 
 </details>
 
+<details>
+<summary><b>Install in ChatGPT (Web)</b></summary>
+
+ChatGPT supports MCP servers through remote connectors via [Developer Mode](https://platform.openai.com/docs/guides/developer-mode) (beta). Available for Pro, Plus, Team, Enterprise, and Edu plans.
+
+#### 1. Enable Developer Mode
+
+Go to: `Settings` → `Apps & Connectors` → `Advanced settings` → Enable `Developer Mode`
+
+#### 2. Create a Connector
+
+Go to: `Settings` → `Apps & Connectors` → `Create`
+
+Fill in the following:
+
+| Field            | Value                                                                                       |
+| ---------------- | ------------------------------------------------------------------------------------------- |
+| **Name**         | `Context7`                                                                                  |
+| **Description**  | `Fetch up-to-date documentation and code examples for any library directly from the source` |
+| **MCP Server URL** | `https://mcp.context7.com/mcp`                                                           |
+
+> Accept the security notice and confirm you trust this application.
+
+#### 3. Use in a Conversation
+
+Start a new chat → Click the model selector → Choose `Developer Mode` → Select the `Context7` connector.
+
+See [OpenAI MCP docs](https://platform.openai.com/docs/mcp) for more info.
+
+</details>
+
+<details>
+<summary><b>Install in ChatGPT (Desktop)</b></summary>
+
+The ChatGPT desktop app shares connectors configured on the web. Set up the connector on [chatgpt.com](https://chatgpt.com) first.
+
+#### 1. Enable Developer Mode (on the Web)
+
+Go to: `Settings` → `Apps & Connectors` → `Advanced settings` → Enable `Developer Mode`
+
+#### 2. Create a Connector (on the Web)
+
+Go to: `Settings` → `Apps & Connectors` → `Create`
+
+Fill in the following:
+
+| Field            | Value                                                                                       |
+| ---------------- | ------------------------------------------------------------------------------------------- |
+| **Name**         | `Context7`                                                                                  |
+| **Description**  | `Fetch up-to-date documentation and code examples for any library directly from the source` |
+| **MCP Server URL** | `https://mcp.context7.com/mcp`                                                           |
+
+> Accept the security notice and confirm you trust this application.
+
+#### 3. Use in the Desktop App
+
+Open the ChatGPT desktop app → Start a new chat → Select `Developer Mode` from the model selector → Choose the `Context7` connector.
+
+Connectors configured on the web are automatically available in the desktop app.
+
+See [OpenAI MCP docs](https://platform.openai.com/docs/mcp) for more info.
+
+</details>
+
 **[Other IDEs and Clients →](https://context7.com/docs/resources/all-clients)**
 
 <details>

--- a/README.md
+++ b/README.md
@@ -167,13 +167,13 @@ Go to: `Settings` → `Apps & Connectors` → `Create`
 
 Fill in the following:
 
-| Field            | Value                                                                                       |
-| ---------------- | ------------------------------------------------------------------------------------------- |
-| **Name**         | `Context7`                                                                                  |
-| **Description**  | `Fetch up-to-date documentation and code examples for any library directly from the source` |
-| **MCP Server URL** | `https://mcp.context7.com/mcp`                                                           |
+| Field              | Value                                                                                       |
+| ------------------ | ------------------------------------------------------------------------------------------- |
+| **Name**           | `Context7`                                                                                  |
+| **Description**    | `Fetch up-to-date documentation and code examples for any library directly from the source` |
+| **MCP Server URL** | `https://mcp.context7.com/mcp/oauth`                                                       |
 
-> Accept the security notice and confirm you trust this application.
+> Accept the security notice and complete the one-time OAuth authorization.
 
 #### 3. Use in a Conversation
 
@@ -198,13 +198,13 @@ Go to: `Settings` → `Apps & Connectors` → `Create`
 
 Fill in the following:
 
-| Field            | Value                                                                                       |
-| ---------------- | ------------------------------------------------------------------------------------------- |
-| **Name**         | `Context7`                                                                                  |
-| **Description**  | `Fetch up-to-date documentation and code examples for any library directly from the source` |
-| **MCP Server URL** | `https://mcp.context7.com/mcp`                                                           |
+| Field              | Value                                                                                       |
+| ------------------ | ------------------------------------------------------------------------------------------- |
+| **Name**           | `Context7`                                                                                  |
+| **Description**    | `Fetch up-to-date documentation and code examples for any library directly from the source` |
+| **MCP Server URL** | `https://mcp.context7.com/mcp/oauth`                                                       |
 
-> Accept the security notice and confirm you trust this application.
+> Accept the security notice and complete the one-time OAuth authorization.
 
 #### 3. Use in the Desktop App
 


### PR DESCRIPTION
Add installation instructions for connecting Context7 as an MCP
connector in ChatGPT (Web) and ChatGPT (Desktop) via Developer Mode.

https://claude.ai/code/session_01GRs4CVcBFNZt1otbGqZKH3