### PR TITLE
feat(cli): install documentation-lookup skill during ctx7 setup

### DIFF
--- a/.changeset/bright-wolves-dance.md
+++ b/.changeset/bright-wolves-dance.md
@@ -1,0 +1,5 @@
+---
+"ctx7": patch
+---
+
+Install documentation-lookup skill during `ctx7 setup`

--- a/packages/cli/src/setup/agents.ts
+++ b/packages/cli/src/setup/agents.ts
@@ -38,6 +38,10 @@ export interface AgentConfig {
     /** When set, the rule path is registered in the agent's config `instructions` array */
     instructionsGlob?: (scope: "project" | "global") => string;
   };
+  skill: {
+    name: string;
+    dir: (scope: "project" | "global") => string;
+  };
   detect: {
     projectPaths: string[];
     globalPaths: string[];
@@ -70,6 +74,11 @@ const agents: Record<SetupAgent, AgentConfig> = {
         scope === "global" ? join(homedir(), ".claude", "rules") : join(".claude", "rules"),
       filename: "context7.md",
     },
+    skill: {
+      name: "documentation-lookup",
+      dir: (scope) =>
+        scope === "global" ? join(homedir(), ".claude", "skills") : join(".claude", "skills"),
+    },
     detect: {
       projectPaths: [".mcp.json", ".claude"],
       globalPaths: [join(homedir(), ".claude")],
@@ -89,6 +98,11 @@ const agents: Record<SetupAgent, AgentConfig> = {
       dir: (scope) =>
         scope === "global" ? join(homedir(), ".cursor", "rules") : join(".cursor", "rules"),
       filename: "context7.mdc",
+    },
+    skill: {
+      name: "documentation-lookup",
+      dir: (scope) =>
+        scope === "global" ? join(homedir(), ".cursor", "skills") : join(".cursor", "skills"),
     },
     detect: {
       projectPaths: [".cursor"],
@@ -115,6 +129,11 @@ const agents: Record<SetupAgent, AgentConfig> = {
         scope === "global"
           ? join(homedir(), ".config", "opencode", "rules", "*.md")
           : ".opencode/rules/*.md",
+    },
+    skill: {
+      name: "documentation-lookup",
+      dir: (scope) =>
+        scope === "global" ? join(homedir(), ".agents", "skills") : join(".agents", "skills"),
     },
     detect: {
       projectPaths: [".opencode.json"],

--- a/packages/cli/src/setup/templates.ts
+++ b/packages/cli/src/setup/templates.ts
@@ -1,3 +1,58 @@
+export const SKILL_CONTENT = `---
+name: documentation-lookup
+description: This skill should be used when the user asks about libraries, frameworks, API references, or needs code examples. Activates for setup questions, code generation involving libraries, or mentions of specific frameworks like React, Vue, Next.js, Prisma, Supabase, etc.
+---
+
+When the user asks about libraries, frameworks, or needs code examples, use Context7 to fetch current documentation instead of relying on training data.
+
+## When to Use This Skill
+
+Activate this skill when the user:
+
+- Asks setup or configuration questions ("How do I configure Next.js middleware?")
+- Requests code involving libraries ("Write a Prisma query for...")
+- Needs API references ("What are the Supabase auth methods?")
+- Mentions specific frameworks (React, Vue, Svelte, Express, Tailwind, etc.)
+
+## How to Fetch Documentation
+
+### Step 1: Resolve the Library ID
+
+Call \`resolve-library-id\` with:
+
+- \`libraryName\`: The library name extracted from the user's question
+- \`query\`: The user's full question (improves relevance ranking)
+
+### Step 2: Select the Best Match
+
+From the resolution results, choose based on:
+
+- Exact or closest name match to what the user asked for
+- Higher benchmark scores indicate better documentation quality
+- If the user mentioned a version (e.g., "React 19"), prefer version-specific IDs
+
+### Step 3: Fetch the Documentation
+
+Call \`query-docs\` with:
+
+- \`libraryId\`: The selected Context7 library ID (e.g., \`/vercel/next.js\`)
+- \`query\`: The user's specific question
+
+### Step 4: Use the Documentation
+
+Incorporate the fetched documentation into your response:
+
+- Answer the user's question using current, accurate information
+- Include relevant code examples from the docs
+- Cite the library version when relevant
+
+## Guidelines
+
+- **Be specific**: Pass the user's full question as the query for better results
+- **Version awareness**: When users mention versions ("Next.js 15", "React 19"), use version-specific library IDs if available from the resolution step
+- **Prefer official sources**: When multiple matches exist, prefer official/primary packages over community forks
+`;
+
 export const RULE_CONTENT = `---
 alwaysApply: true
 ---


### PR DESCRIPTION
## Summary
- The `ctx7 setup` command now installs the **documentation-lookup** skill alongside the MCP server and rule for each agent
- Added `SKILL_CONTENT` template with full SKILL.md content (frontmatter + instructions)
- Added `skill` config to `AgentConfig` with per-agent skill directory paths

### Skill install paths:
| Agent | Project | Global |
|-------|---------|--------|
| Claude | `.claude/skills/documentation-lookup/` | `~/.claude/skills/documentation-lookup/` |
| Cursor | `.cursor/skills/documentation-lookup/` | `~/.cursor/skills/documentation-lookup/` |
| OpenCode | `.agents/skills/documentation-lookup/` | `~/.agents/skills/documentation-lookup/` |