### PR TITLE
fix: correct retry off-by-one when retry is disabled

### DIFF
--- a/packages/sdk/src/http/index.ts
+++ b/packages/sdk/src/http/index.ts
@@ -112,7 +112,7 @@ export class HttpClient implements Requester {
     this.retry =
       typeof config?.retry === "boolean" && config?.retry === false
         ? {
-            attempts: 1,
+            attempts: 0,
             backoff: () => 0,
           }
         : {


### PR DESCRIPTION
## Summary

Fix an off-by-one error in the HTTP client retry logic when `retry: false` is configured.

## Problem

When `retry` is set to `false`, the `HttpClient` constructor sets `attempts: 1`. The retry loop iterates with:

```typescript
for (let i = 0; i <= this.retry.attempts; i++)
```

With `attempts = 1`, this loop runs **twice** (i=0 and i=1), so a request configured with "no retry" still retries once on failure — doubling the number of requests sent.

## Fix

Change `attempts: 1` to `attempts: 0` in the `retry === false` branch.

With `attempts = 0`:
- The loop runs exactly once: `i = 0` executes, then `1 <= 0` is false → exits
- The backoff guard `i < this.retry.attempts` evaluates to `0 < 0 = false` → no delay

This correctly models "zero retries" (one attempt, no retry).

## Change

- `packages/sdk/src/http/index.ts`: `attempts: 1` → `attempts: 0`
