### PR TITLE
fix(sdk): avoid raw SyntaxError on non-JSON error responses

### DIFF
--- a/packages/sdk/src/http/index.test.ts
+++ b/packages/sdk/src/http/index.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { HttpClient } from "./index";
+import { Context7Error } from "@error";
+
+describe("HttpClient error handling", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("throws Context7Error for non-JSON error responses", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("<html>Bad gateway</html>", {
+        status: 502,
+        statusText: "Bad Gateway",
+        headers: { "content-type": "text/html" },
+      })
+    );
+
+    const client = new HttpClient({
+      baseUrl: "https://example.com/api",
+      retry: false,
+    });
+
+    try {
+      await client.request({ path: ["v2", "libs", "search"] });
+      throw new Error("Expected request to throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(Context7Error);
+      expect((error as Error).message).toBe("Bad Gateway");
+    }
+  });
+
+  test("prefers API error message when response body is JSON", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error: "rate limit exceeded" }), {
+        status: 429,
+        statusText: "Too Many Requests",
+        headers: { "content-type": "application/json" },
+      })
+    );
+
+    const client = new HttpClient({
+      baseUrl: "https://example.com/api",
+      retry: false,
+    });
+
+    await expect(client.request({ path: ["v2", "libs", "search"] })).rejects.toMatchObject({
+      message: "rate limit exceeded",
+    });
+  });
+});

--- a/packages/sdk/src/http/index.ts
+++ b/packages/sdk/src/http/index.ts
@@ -169,8 +169,15 @@ export class HttpClient implements Requester {
     }
 
     if (!res.ok) {
-      const errorBody = (await res.json()) as { error?: string; message?: string };
-      throw new Context7Error(errorBody.error || errorBody.message || res.statusText);
+      let errorBody: { error?: string; message?: string } | undefined;
+
+      try {
+        errorBody = (await res.json()) as { error?: string; message?: string };
+      } catch {
+        // Non-JSON error responses should still throw a typed Context7Error.
+      }
+
+      throw new Context7Error(errorBody?.error || errorBody?.message || res.statusText);
     }
 
     const contentType = res.headers.get("content-type");


### PR DESCRIPTION
## Summary
- wrap SDK error JSON parsing in a safe try/catch path inside HttpClient.request()
- ensure non-JSON error bodies still produce a typed Context7Error
- add unit tests for JSON and non-JSON error response behavior

## Why
When the API returns HTML/plain-text error content, res.json() throws a raw SyntaxError. This bypasses Context7Error handling in consumers.

## Verification
- pnpm --filter @upstash/context7-sdk lint
- pnpm --filter @upstash/context7-sdk exec vitest run src/http/index.test.ts

Closes #1964