### PR TITLE
feat(skills): expand ctx7-cli skill into folder structure with full CLI coverage

### DIFF
--- a/.agents/skills/ctx7-cli/SKILL.md
+++ b/.agents/skills/ctx7-cli/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: ctx7-cli
+description: Use the ctx7 CLI to fetch library documentation, manage AI coding skills, and configure Context7 MCP. Activate when the user mentions "ctx7" or "context7", needs current docs for any library, wants to install/search/generate skills, or needs to set up Context7 for their AI coding agent.
+---
+
+# ctx7 CLI
+
+The Context7 CLI does three things: fetches up-to-date library documentation, manages AI coding skills, and sets up Context7 MCP for your editor.
+
+Run with `npx ctx7` (no install needed) or install globally with `npm install -g ctx7`.
+
+## What this skill covers
+
+- **[Documentation](references/docs.md)** — Fetch current docs for any library. Use when writing code, verifying API signatures, or when training data may be outdated.
+- **[Skills management](references/skills.md)** — Install, search, suggest, list, remove, and generate AI coding skills.
+- **[Setup](references/setup.md)** — Configure Context7 MCP for Claude Code / Cursor / OpenCode.
+
+## Quick Reference
+
+```bash
+# Documentation
+ctx7 library <name> [query]           # Step 1: resolve library ID
+ctx7 docs <libraryId> <query>         # Step 2: fetch docs
+
+# Skills
+ctx7 skills install /owner/repo       # Install from a repo (interactive)
+ctx7 skills install /owner/repo name  # Install a specific skill
+ctx7 skills search <keywords>         # Search the registry
+ctx7 skills suggest                   # Auto-suggest based on project deps
+ctx7 skills list                      # List installed skills
+ctx7 skills remove <name>             # Uninstall a skill
+ctx7 skills generate                  # Generate a custom skill with AI (requires login)
+
+# Setup
+ctx7 setup                            # Configure Context7 MCP (interactive)
+ctx7 login                            # Log in for higher rate limits + skill generation
+ctx7 whoami                           # Check current login status
+```
+
+## Authentication
+
+```bash
+ctx7 login               # Opens browser for OAuth
+ctx7 login --no-browser  # Prints URL instead of opening browser
+ctx7 logout              # Clear stored tokens
+ctx7 whoami              # Show current login status (name + email)
+```
+
+Most commands work without login. Exceptions: `skills generate` always requires it; `ctx7 setup` requires it unless `--api-key` or `--oauth` is passed. Login also unlocks higher rate limits on docs commands.
+
+Set an API key via environment variable to skip interactive login entirely:
+
+```bash
+export CONTEXT7_API_KEY=your_key
+```
+
+## Common Mistakes
+
+- Library IDs require a `/` prefix — `/facebook/react` not `facebook/react`
+- Always run `ctx7 library` first — `ctx7 docs react "hooks"` will fail without a valid ID
+- Repository format for skills is `/owner/repo` — e.g., `ctx7 skills install /anthropics/skills`
+- `skills generate` requires login — run `ctx7 login` first

--- a/.agents/skills/ctx7-cli/references/docs.md
+++ b/.agents/skills/ctx7-cli/references/docs.md
@@ -1,23 +1,6 @@
----
-name: ctx7-cli
-description: Fetch up-to-date library documentation using the ctx7 CLI. Use this skill whenever you need current docs for any library, framework, or package — especially when writing code that depends on a specific API, verifying function signatures, checking configuration options, or when training data may be outdated. Also use when the user mentions "ctx7", "context7", library documentation, or asks you to look up how a library works.
----
+# Documentation Commands
 
-# ctx7 CLI
-
-Fetch current library documentation from Context7 directly in the terminal. Two-step workflow: resolve the library name, then query its docs.
-
-## Quick Reference
-
-```bash
-# Step 1: Find the library ID
-ctx7 library <name> [query] [--json]
-
-# Step 2: Fetch docs using the ID
-ctx7 docs <libraryId> <query> [--json]
-```
-
-Run with `npx ctx7` (no install needed) or install globally with `npm install -g ctx7`.
+Fetch current library documentation from Context7. Two-step workflow: resolve the library name to get its ID, then query docs using that ID.
 
 ## Step 1: Resolve a Library
 
@@ -65,28 +48,23 @@ Use `--json` to get structured output:
 ctx7 docs /facebook/react "hooks" --json
 ```
 
-## Authentication
-
-Works without authentication. For higher rate limits:
-
-```bash
-# Option A: API key
-export CONTEXT7_API_KEY=your_key
-
-# Option B: OAuth login
-ctx7 login
-```
-
 ## Piping
 
 Output is clean (no spinners or colors) when piped to another command:
 
 ```bash
 ctx7 docs /facebook/react "hooks" | head -50
+ctx7 docs /vercel/next.js "routing" | grep -A5 "middleware"
 ```
 
-## Common Mistakes
+## Authentication
 
-- Forgetting the `/` prefix on library IDs — `/facebook/react` not `facebook/react`
-- Skipping step 1 — always resolve first to get the correct ID
-- Using a library name where an ID is expected — `ctx7 docs react "hooks"` will fail; use the full ID from `ctx7 library`
+Works without authentication. For higher rate limits:
+
+```bash
+# Option A: environment variable
+export CONTEXT7_API_KEY=your_key
+
+# Option B: OAuth login
+ctx7 login
+```

--- a/.agents/skills/ctx7-cli/references/setup.md
+++ b/.agents/skills/ctx7-cli/references/setup.md
@@ -1,0 +1,27 @@
+# Setup
+
+## ctx7 setup
+
+One-time command to configure Context7 MCP for your AI coding agent. Writes the MCP server config, a Context7 rule file, and a `documentation-lookup` skill.
+
+```bash
+ctx7 setup                     # Interactive — prompts for agent selection
+ctx7 setup --claude            # Claude Code only
+ctx7 setup --cursor            # Cursor only
+ctx7 setup --opencode          # OpenCode only
+ctx7 setup --project           # Configure current project instead of globally
+ctx7 setup --yes               # Skip confirmation prompts
+```
+
+**Authentication options:**
+```bash
+ctx7 setup --api-key YOUR_KEY  # Use an existing API key
+ctx7 setup --oauth             # OAuth endpoint (IDE handles the auth flow)
+```
+
+Without `--api-key` or `--oauth`, setup opens a browser for OAuth login and generates a new API key automatically.
+
+**What gets written:**
+- MCP server entry in the agent's config file (`.mcp.json` for Claude, `.cursor/mcp.json` for Cursor, `.opencode.json` for OpenCode)
+- A Context7 rule file instructing the agent to use Context7 for library docs
+- A `documentation-lookup` skill in the agent's skills directory

--- a/.agents/skills/ctx7-cli/references/skills.md
+++ b/.agents/skills/ctx7-cli/references/skills.md
@@ -1,0 +1,118 @@
+# Skills Commands
+
+Manage AI coding skills from the Context7 registry. Skills are Markdown files that teach AI coding agents best practices, patterns, and workflows for specific libraries or tasks.
+
+## Install
+
+Install skills from any GitHub repository. Repository format is always `/owner/repo`.
+
+```bash
+ctx7 skills install /anthropics/skills           # Interactive — pick from a list
+ctx7 skills install /anthropics/skills pdf        # Install a specific skill by name
+ctx7 skills install /anthropics/skills --all      # Install everything without prompting
+```
+
+Target a specific IDE with a flag:
+```bash
+ctx7 skills install /anthropics/skills pdf --claude     # Claude Code only
+ctx7 skills install /anthropics/skills pdf --cursor     # Cursor only
+ctx7 skills install /anthropics/skills pdf --universal  # Universal (.agents/skills/)
+ctx7 skills install /anthropics/skills --all --global   # All skills, global install
+```
+
+Alias: `ctx7 si /anthropics/skills pdf`
+
+## Search
+
+Find skills across the entire registry by keyword. Shows an interactive list with install counts and trust scores. Select to install.
+
+```bash
+ctx7 skills search pdf
+ctx7 skills search typescript testing
+ctx7 skills search react nextjs
+```
+
+Alias: `ctx7 ss pdf`
+
+## Suggest
+
+Auto-detects your project dependencies and recommends relevant skills from the registry.
+
+```bash
+ctx7 skills suggest           # Scan current project, install to project
+ctx7 skills suggest --global  # Install suggestions globally
+ctx7 skills suggest --claude  # Target Claude Code only
+```
+
+Reads `package.json`, `requirements.txt`, `pyproject.toml`, `Cargo.toml`, `go.mod`, `Gemfile`. Falls back to suggesting `ctx7 skills search` if no dependencies are detected.
+
+Alias: `ctx7 ssg`
+
+## Generate (AI-powered)
+
+Generate a custom skill tailored to your stack using AI. **Requires login.**
+
+```bash
+ctx7 skills generate
+ctx7 skills generate --claude   # Install directly to Claude Code
+ctx7 skills generate --global   # Install to global skills
+```
+
+Interactive flow:
+1. Describe the expertise you want (e.g., "OAuth authentication with NextAuth.js")
+2. Select relevant libraries from search results
+3. Answer 3 clarifying questions to focus the skill
+4. Review the generated skill, request changes if needed
+5. Choose where to install it
+
+**Limits:** Free accounts get 6 generations/week, Pro accounts get 10.
+
+Aliases: `ctx7 skills gen`, `ctx7 skills g`
+
+## List
+
+Show all installed skills for the current project or globally.
+
+```bash
+ctx7 skills list                  # Current project (all detected IDEs)
+ctx7 skills list --claude         # Claude Code only
+ctx7 skills list --global         # Global skills
+ctx7 skills list --global --claude # Global Claude Code skills
+```
+
+## Remove
+
+Uninstall a skill by name.
+
+```bash
+ctx7 skills remove pdf
+ctx7 skills remove pdf --claude   # From Claude Code only
+ctx7 skills remove pdf --global   # From global skills
+```
+
+Aliases: `ctx7 skills rm`, `ctx7 skills delete`
+
+## Info
+
+Browse all skills in a repository without installing — useful for previewing what's available.
+
+```bash
+ctx7 skills info /anthropics/skills
+```
+
+Output shows each skill name, description, and URL, plus quick install commands.
+
+## IDE Flags
+
+All skills commands accept these flags to target a specific AI coding assistant:
+
+| Flag | Directory | Used by |
+|------|-----------|---------|
+| `--universal` | `.agents/skills/` | Amp, Codex, Gemini CLI, OpenCode, GitHub Copilot |
+| `--claude` | `.claude/skills/` | Claude Code |
+| `--cursor` | `.cursor/skills/` | Cursor |
+| `--antigravity` | `.agent/skills/` | Antigravity |
+
+Without a flag, the CLI prompts you to select one or more targets interactively.
+
+Add `--global` to any flag to install in your home directory instead of the current project.


### PR DESCRIPTION
## Summary

- Restructures `.agents/skills/ctx7-cli.md` (single flat file) into a proper skill folder with a hub `SKILL.md` and three reference files
- Adds full coverage of the skills management commands (`install`, `search`, `suggest`, `list`, `remove`, `info`, `generate`) which were previously undocumented
- Adds `ctx7 setup` documentation (MCP configuration for Claude Code / Cursor / OpenCode)
- Moves authentication (`login`, `logout`, `whoami`, API key) into `SKILL.md` as cross-cutting content

**New structure:**
```
.agents/skills/ctx7-cli/
├── SKILL.md                  ← hub: quick ref, auth, common mistakes
└── references/
    ├── docs.md               ← library + docs commands (preserved quality)
    ├── skills.md             ← all 7 skills subcommands + IDE flags table + aliases
    └── setup.md              ← ctx7 setup + what gets written
```

Reference files are loaded lazily — only when Claude decides they're relevant to the current task.