### PR TITLE
feat(docs): add dedicated CLI reference page and restructure skills docs

### DIFF
--- a/.agents/skills/ctx7-cli/references/docs.md
+++ b/.agents/skills/ctx7-cli/references/docs.md
@@ -1,10 +1,8 @@
 # Documentation Commands
 
-Fetch current library documentation from Context7. Two-step workflow: resolve the library name to get its ID, then query docs using that ID.
+Fetch current library documentation from Context7. Two-step workflow: resolve the library name to get its ID, then query docs using that ID. If the user already provided a library ID in `/org/project` or `/org/project/version` format, pass it directly to `ctx7 docs`.
 
 ## Step 1: Resolve a Library
-
-Search by name to get the Context7 library ID. The optional `query` argument ranks results by relevance to your task.
 
 ```bash
 ctx7 library react
@@ -12,22 +10,40 @@ ctx7 library nextjs "app router setup"
 ctx7 library prisma "database relations"
 ```
 
-**Example 1:**
-Input: `ctx7 library react`
-Output: A numbered list with library ID (`/facebook/react`), snippet count, stars, trust score, and versions.
+Always pass a `query` argument that reflects what the user is trying to do — it ranks results by relevance and helps disambiguate when multiple libraries share a similar name.
 
-**Example 2:**
-Input: `ctx7 library nextjs "app router setup"`
-Output: Results ranked by relevance to "app router setup". The top result's ID is what you pass to `ctx7 docs`.
+### Picking the right result
 
-Use `--json` to get raw JSON (useful for scripting):
+When multiple results are returned, select based on this priority order:
+
+1. **Name match** — exact or closest match to what the user asked for
+2. **Description relevance** — does the description match the user's intent?
+3. **Snippet count** — more snippets means more indexed documentation; prefer higher counts
+4. **Source reputation** — prefer High or Medium reputation over Unknown
+5. **Benchmark score** — higher is better (100 is the maximum)
+
+If multiple results look equally good, pick the most relevant one and proceed — don't call `ctx7 library` repeatedly trying to find a perfect match. Use the best result you have.
+
+### Version-specific IDs
+
+If the user mentions a specific version, use a version-specific library ID:
+
 ```bash
+# General (latest indexed)
+ctx7 docs /vercel/next.js "app router"
+
+# Version-specific
+ctx7 docs /vercel/next.js/v14.3.0-canary.87 "app router"
+```
+
+The available versions are listed in the `ctx7 library` output. Use the closest match to what the user specified.
+
+```bash
+# Output as JSON for scripting
 ctx7 library react --json | jq '.[0].id'
 ```
 
 ## Step 2: Query Documentation
-
-Pass the library ID (starts with `/`) and a question to fetch relevant code snippets and explanations.
 
 ```bash
 ctx7 docs /facebook/react "useEffect cleanup"
@@ -35,24 +51,26 @@ ctx7 docs /vercel/next.js "middleware authentication"
 ctx7 docs /prisma/prisma "one-to-many relations"
 ```
 
-**Example 1:**
-Input: `ctx7 docs /facebook/react "useEffect cleanup"`
-Output: Code snippets showing useEffect cleanup patterns, plus explanatory info snippets.
+### Writing good queries
 
-**Example 2:**
-Input: `ctx7 docs /vercel/next.js "middleware"`
-Output: Middleware configuration examples with code blocks and descriptions.
+The query directly affects the quality of results. Be specific and include context:
 
-Use `--json` to get structured output:
+| Quality | Example |
+|---------|---------|
+| Good | `"How to set up authentication with JWT in Express.js"` |
+| Good | `"React useEffect cleanup function with async operations"` |
+| Bad | `"auth"` |
+| Bad | `"hooks"` |
+
+Use the user's full question as the query when possible — vague one-word queries return generic results.
+
+The output contains two types of content: **code snippets** (titled, with language-tagged blocks) and **info snippets** (prose explanations with breadcrumb context).
+
 ```bash
+# Output as structured JSON
 ctx7 docs /facebook/react "hooks" --json
-```
 
-## Piping
-
-Output is clean (no spinners or colors) when piped to another command:
-
-```bash
+# Pipe to other tools — output is clean when not in a TTY (no spinners or colors)
 ctx7 docs /facebook/react "hooks" | head -50
 ctx7 docs /vercel/next.js "routing" | grep -A5 "middleware"
 ```

--- a/docs/clients/cli.mdx
+++ b/docs/clients/cli.mdx
@@ -1,4 +1,365 @@
 ---
 title: CLI
-url: https://github.com/upstash/context7/tree/master/packages/cli
+description: The ctx7 CLI — fetch library documentation, manage skills, and configure Context7 MCP from your terminal
 ---
+
+The `ctx7` CLI is the command-line interface for Context7. It does three things:
+
+- **Fetch library documentation** — resolve any library by name and query its up-to-date docs directly in your terminal, without opening a browser
+- **Manage AI coding skills** — install, search, generate, and remove skills from the Context7 registry
+- **Configure Context7 MCP** — set up the MCP server for Claude Code, Cursor, or OpenCode with a single command
+
+The CLI is useful both as a standalone tool (fetching docs while you code) and as a setup utility (wiring up Context7 for your AI coding agent).
+
+## Installation
+
+Requires Node.js 18 or later.
+
+<Tabs>
+  <Tab title="npx (no install)">
+    Run ctx7 directly without installing anything. Useful for one-off commands or trying it out.
+
+    ```bash
+    npx ctx7 --help
+    npx ctx7 library react
+    ```
+  </Tab>
+  <Tab title="Global install">
+    Install globally for faster access — no `npx` prefix needed on every command.
+
+    ```bash
+    npm install -g ctx7
+
+    # Verify installation
+    ctx7 --version
+    ```
+  </Tab>
+</Tabs>
+
+---
+
+## Query Library Documentation
+
+Fetching docs is a two-step process: first resolve the library name to get its Context7 ID, then use that ID to query documentation. The ID is stable and scoped to a specific library — it's what Context7 uses to know exactly which library and version to pull docs from.
+
+### Step 1 — ctx7 library
+
+Searches the Context7 index by name and returns matching libraries. Pass an optional `query` to rank results by relevance to your specific task — this helps when a library name is ambiguous or has multiple versions indexed.
+
+```bash
+ctx7 library react
+ctx7 library nextjs "app router setup"
+ctx7 library prisma "database relations"
+```
+
+Each result shows:
+
+| Field | Description |
+|-------|-------------|
+| **ID** | The library ID to pass to `ctx7 docs` (e.g., `/facebook/react`) |
+| **Snippets** | Number of indexed documentation snippets |
+| **Stars** | GitHub stars — a signal of library popularity |
+| **Trust score** | Documentation quality indicator (0–10) |
+| **Versions** | Indexed versions, if version-specific docs exist |
+
+Pick the top result's ID, or a version-specific one if the user mentioned a version (e.g., `/vercel/next.js@canary`).
+
+```bash
+# Output as JSON — useful for scripting or piping into other tools
+ctx7 library react --json | jq '.[0].id'
+```
+
+### Step 2 — ctx7 docs
+
+Pass the library ID and a natural-language question to fetch relevant code snippets and explanations from the indexed documentation.
+
+```bash
+ctx7 docs /facebook/react "useEffect cleanup"
+ctx7 docs /vercel/next.js "middleware authentication"
+ctx7 docs /prisma/prisma "one-to-many relations"
+```
+
+<Note>
+Library IDs always start with `/`. Running `ctx7 docs react "hooks"` will fail — always use the full ID returned by `ctx7 library` in Step 1.
+</Note>
+
+The output contains two types of content: **code snippets** (titled, with language-tagged blocks) and **info snippets** (prose explanations with breadcrumb context). Both are formatted for readability in the terminal.
+
+```bash
+# Output as structured JSON
+ctx7 docs /facebook/react "hooks" --json
+
+# Pipe to other tools — output is clean when not in a TTY (no spinners or colors)
+ctx7 docs /facebook/react "hooks" | head -50
+ctx7 docs /vercel/next.js "routing" | grep -A 10 "middleware"
+```
+
+---
+
+## Setup
+
+Configure Context7 MCP for your AI coding agent. Writes the MCP server config, a Context7 rule file, and a `documentation-lookup` skill.
+
+### ctx7 setup
+
+```bash
+# Interactive — prompts for agent selection
+ctx7 setup
+
+# Target a specific agent
+ctx7 setup --claude
+ctx7 setup --cursor
+ctx7 setup --opencode
+
+# Configure for current project only (default is global)
+ctx7 setup --project
+
+# Skip confirmation prompts
+ctx7 setup --yes
+```
+
+**Authentication options:**
+
+```bash
+# Use an existing API key
+ctx7 setup --api-key YOUR_API_KEY
+
+# Use OAuth endpoint (IDE handles the auth flow)
+ctx7 setup --oauth
+```
+
+Without `--api-key` or `--oauth`, setup opens a browser for OAuth login and generates a new API key automatically.
+
+**What gets written:**
+
+| File | Purpose |
+|------|---------|
+| `.mcp.json` / `.cursor/mcp.json` / `.opencode.json` | MCP server entry |
+| Agent rules directory | Rule file — instructs the agent to use Context7 for library docs |
+| Agent skills directory | `documentation-lookup` skill |
+
+---
+
+## Authentication
+
+Most commands work without authentication. Log in to unlock skill generation and higher rate limits on documentation commands.
+
+### Commands
+
+```bash
+# Log in (opens browser for OAuth)
+ctx7 login
+
+# Log in without opening the browser (prints URL instead)
+ctx7 login --no-browser
+
+# Check current login status
+ctx7 whoami
+
+# Log out
+ctx7 logout
+```
+
+### API Key
+
+Set an API key via environment variable to skip interactive login entirely — useful for CI or scripting:
+
+```bash
+export CONTEXT7_API_KEY=your_key
+```
+
+### When is authentication required?
+
+| Feature | Required |
+|---------|----------|
+| `ctx7 library` / `ctx7 docs` | No — login gives higher rate limits |
+| `ctx7 skills install / search / suggest / list / remove` | No |
+| `ctx7 skills generate` | Yes |
+| `ctx7 setup` | Yes — unless `--api-key` or `--oauth` is passed |
+
+---
+
+## Skills
+
+Manage AI coding skills from the Context7 registry. See [Skills](/skills) for a full explanation of what skills are, the registry, trust scores, and skill file structure.
+
+### ctx7 skills install
+
+Install skills from any GitHub repository. Repository format is `/owner/repo`.
+
+```bash
+# Interactive — pick from a list
+ctx7 skills install /anthropics/skills
+
+# Install a specific skill by name
+ctx7 skills install /anthropics/skills pdf
+
+# Install all skills without prompting
+ctx7 skills install /anthropics/skills --all
+```
+
+**Target a specific AI coding assistant:**
+
+```bash
+ctx7 skills install /anthropics/skills pdf --claude      # Claude Code
+ctx7 skills install /anthropics/skills pdf --cursor      # Cursor
+ctx7 skills install /anthropics/skills pdf --universal   # Universal (.agents/skills/)
+ctx7 skills install /anthropics/skills pdf --antigravity
+```
+
+**Install globally** (available across all projects):
+
+```bash
+ctx7 skills install /anthropics/skills pdf --global
+ctx7 skills install /anthropics/skills --all --global
+```
+
+<Note>
+When installing to multiple clients, the skill files are created in your primary client's directory and symlinked to the others.
+</Note>
+
+Alias: `ctx7 si /anthropics/skills pdf`
+
+### ctx7 skills search
+
+Find skills across all indexed repositories by keyword. Shows an interactive list — select to install directly.
+
+```bash
+ctx7 skills search pdf
+ctx7 skills search typescript testing
+ctx7 skills search react nextjs
+```
+
+Alias: `ctx7 ss pdf`
+
+### ctx7 skills suggest
+
+Auto-detects your project dependencies and recommends relevant skills from the registry.
+
+```bash
+# Scan current project
+ctx7 skills suggest
+
+# Target a specific client
+ctx7 skills suggest --claude
+ctx7 skills suggest --cursor
+
+# Install suggestions globally
+ctx7 skills suggest --global
+```
+
+Scans: `package.json`, `requirements.txt`, `pyproject.toml`, `Cargo.toml`, `go.mod`, `Gemfile`.
+
+Alias: `ctx7 ssg`
+
+### ctx7 skills generate
+
+Generate a custom skill tailored to your stack using AI. **Requires login.**
+
+```bash
+ctx7 skills generate
+
+# Generate and install to a specific client
+ctx7 skills generate --claude
+ctx7 skills generate --cursor
+ctx7 skills generate --universal
+
+# Generate as a global skill
+ctx7 skills generate --global
+```
+
+**Generation flow:**
+
+1. Describe the expertise you want (e.g., "OAuth authentication with NextAuth.js")
+2. Select relevant libraries from search results
+3. Answer 3 clarifying questions to focus the skill
+4. Review the generated skill and request changes if needed
+5. Choose where to install it
+
+<Tip>
+Describe best practices and constraints, not step-by-step tutorials. "TypeScript strict mode patterns" generates a more useful skill than "how to write TypeScript."
+</Tip>
+
+**Weekly limits:** Free accounts get 6 generations/week, Pro accounts get 10.
+
+Aliases: `ctx7 skills gen`, `ctx7 skills g`
+
+### ctx7 skills list
+
+View skills installed in your project or globally.
+
+```bash
+ctx7 skills list                   # All detected clients
+ctx7 skills list --claude
+ctx7 skills list --cursor
+ctx7 skills list --global
+```
+
+### ctx7 skills info
+
+Preview all available skills in a repository without installing.
+
+```bash
+ctx7 skills info /anthropics/skills
+```
+
+### ctx7 skills remove
+
+Uninstall a skill by name.
+
+```bash
+ctx7 skills remove pdf
+ctx7 skills remove pdf --claude
+ctx7 skills remove pdf --global
+```
+
+Aliases: `ctx7 skills rm`, `ctx7 skills delete`
+
+---
+
+## Shortcuts
+
+| Shortcut | Full command |
+|----------|-------------|
+| `ctx7 si` | `ctx7 skills install` |
+| `ctx7 ss` | `ctx7 skills search` |
+| `ctx7 ssg` | `ctx7 skills suggest` |
+| `ctx7 skills i` | `ctx7 skills install` |
+| `ctx7 skills s` | `ctx7 skills search` |
+| `ctx7 skills ls` | `ctx7 skills list` |
+| `ctx7 skills rm` | `ctx7 skills remove` |
+| `ctx7 skills gen` | `ctx7 skills generate` |
+| `ctx7 skills g` | `ctx7 skills generate` |
+
+---
+
+## Telemetry
+
+The CLI collects anonymous usage data to help improve the product. To disable:
+
+```bash
+# For a single command
+CTX7_TELEMETRY_DISABLED=1 ctx7 skills search pdf
+
+# Permanently — add to ~/.bashrc or ~/.zshrc
+export CTX7_TELEMETRY_DISABLED=1
+```
+
+---
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Browse Skills" icon="magnifying-glass" href="https://context7.com/skills">
+    Explore the skills registry
+  </Card>
+  <Card title="Skills Guide" icon="book" href="/skills">
+    Learn about skill file structure, trust scores, and the registry
+  </Card>
+  <Card title="Claude Code" icon="terminal" href="/clients/claude-code">
+    Set up Context7 in Claude Code
+  </Card>
+  <Card title="All Clients" icon="grid" href="/resources/all-clients">
+    Installation for every supported editor
+  </Card>
+</CardGroup>

--- a/docs/skills.mdx
+++ b/docs/skills.mdx
@@ -41,19 +41,63 @@ When browsing or searching skills, you'll see:
 | **Install Count** | Number of times the skill has been installed |
 | **Trust Score** | Quality and safety indicator (0-10) |
 
-**Quick start:**
+### CLI
+
+You can interact with the registry directly from your terminal using the `ctx7` CLI. No configuration needed — most commands work without authentication.
+
+**Discover and install skills:**
 
 ```bash
-# Search for a skill
-npx ctx7 skills search react
+# Search the registry by keyword
+ctx7 skills search pdf
+ctx7 skills search "react testing"
 
-# Install a popular skill
-npx ctx7 skills install /vercel-labs/agent-skills vercel-react-best-practices
+# Browse all skills in a specific repository
+ctx7 skills info /anthropics/skills
+
+# Install a skill interactively (prompts you to pick)
+ctx7 skills install /anthropics/skills
+
+# Install a specific skill by name
+ctx7 skills install /anthropics/skills pdf
+
+# Get suggestions based on your project's dependencies
+ctx7 skills suggest
 ```
 
-## Trust Scores
+**Manage installed skills:**
 
-Every skill in the registry has a **trust score** from 0 to 10 that indicates the reliability and safety of the skill source.
+```bash
+# List skills installed in the current project
+ctx7 skills list
+
+# List skills installed for a specific client
+ctx7 skills list --claude
+ctx7 skills list --cursor
+
+# Remove a skill
+ctx7 skills remove pdf
+```
+
+**Generate a custom skill with AI:**
+
+```bash
+# Requires login — opens an interactive generation flow
+ctx7 login
+ctx7 skills generate
+```
+
+All install commands accept `--claude`, `--cursor`, `--universal`, and `--global` flags to target a specific client or install location. 
+
+See the [CLI reference](/clients/cli#skills) for the full flag reference and examples.
+
+### Trust & Security
+
+Context7 vets every skill in the registry before it reaches you — both through automated scanning and community-driven quality signals.
+
+#### Trust Scores
+
+Every skill has a **trust score** from 0 to 10 that reflects the reliability of its source.
 
 | Score | Level | Meaning |
 |-------|-------|---------|
@@ -61,226 +105,15 @@ Every skill in the registry has a **trust score** from 0 to 10 that indicates th
 | 3.0 - 6.9 | Medium | Standard community contribution |
 | 0.0 - 2.9 | Low | New or unverified — review before using |
 
-Trust scores help you make informed decisions about which skills to install. Higher scores indicate skills from reputable sources with community validation.
+Higher scores indicate skills from reputable sources with community validation. Trust scores are visible in search results and install prompts so you can make an informed decision before installing.
 
-### Security Features
+#### Security Features
 
-Context7 automatically scans skills for potential security issues:
+Context7 automatically scans skills for potential security issues before they appear in the registry:
 
 - **Prompt injection detection**: Skills containing potentially malicious instructions are blocked from installation
 - **Blocked skill warnings**: When viewing a repository, you'll see how many skills were blocked due to security concerns
 - **Clear error messages**: If you try to install a blocked skill, you'll receive a specific warning explaining why
-
-## Prerequisites
-
-Skills require the Context7 CLI. You need Node.js 18 or later.
-
-```bash
-# Run directly with npx (no installation required)
-npx ctx7 skills search pdf
-
-# Or install globally for faster access
-npm install -g ctx7
-```
-
-## CLI Commands
-
-### Install Skills
-
-Install skills from a repository to your AI coding assistant's skills directory.
-
-```bash
-# Interactive selection from a repository
-npx ctx7 skills install /anthropics/skills
-
-# Install a specific skill
-npx ctx7 skills install /anthropics/skills pdf
-
-# Install multiple skills at once
-npx ctx7 skills install /anthropics/skills pdf commit
-
-# Install all skills without prompting
-npx ctx7 skills install /anthropics/skills --all
-```
-
-**Target a specific client:**
-
-```bash
-npx ctx7 skills install /anthropics/skills pdf --claude
-npx ctx7 skills install /anthropics/skills pdf --cursor
-npx ctx7 skills install /anthropics/skills pdf --universal
-npx ctx7 skills install /anthropics/skills pdf --antigravity
-```
-
-**Install globally** (available in all projects):
-
-```bash
-npx ctx7 skills install /anthropics/skills pdf --global
-```
-
-<Note>
-When installing to multiple clients, the CLI creates the skill files in your primary client's directory and symlinks them to other clients.
-</Note>
-
-### Search Skills
-
-Find skills across all indexed repositories in the registry.
-
-```bash
-npx ctx7 skills search pdf
-npx ctx7 skills search typescript
-npx ctx7 skills search "react testing"
-```
-
-Search results display:
-- Skill name and repository
-- Description
-- Install count
-- Trust score
-
-You can install directly from search results by selecting a skill interactively.
-
-### Suggest Skills
-
-Automatically discover relevant skills based on your project's dependencies. The CLI scans your `package.json`, `requirements.txt`, or `pyproject.toml` and suggests matching skills from the registry.
-
-```bash
-# Scan current project and suggest skills
-npx ctx7 skills suggest
-
-# Suggest and install to a specific client
-npx ctx7 skills suggest --claude
-npx ctx7 skills suggest --cursor
-npx ctx7 skills suggest --universal
-
-# Suggest and install globally
-npx ctx7 skills suggest --global
-```
-
-**How it works:**
-
-1. Scans your project for dependencies (Node.js and Python supported)
-2. Queries Context7 for skills that match your dependencies
-3. Shows results with install count, trust score, and which dependency matched
-4. Lets you select and install skills interactively
-
-**Supported dependency files:**
-
-| File | Language |
-|------|----------|
-| `package.json` | Node.js (dependencies + devDependencies) |
-| `requirements.txt` | Python |
-| `pyproject.toml` | Python (PEP 621 + Poetry) |
-
-<Tip>
-Run `npx ctx7 skills suggest` when starting on a new project to quickly find skills for your tech stack.
-</Tip>
-
-### List Installed Skills
-
-View skills installed in your project or globally.
-
-```bash
-# List all installed skills
-npx ctx7 skills list
-
-# List for a specific client
-npx ctx7 skills list --claude
-npx ctx7 skills list --cursor
-npx ctx7 skills list --universal
-
-# List globally installed skills
-npx ctx7 skills list --global
-```
-
-### Show Skill Information
-
-Get details about all available skills in a repository.
-
-```bash
-npx ctx7 skills info /anthropics/skills
-```
-
-This displays:
-- Available skill names
-- Descriptions
-- Direct URLs
-- Quick install commands
-
-### Remove Skills
-
-Uninstall a skill from your project or global directory.
-
-```bash
-# Remove with interactive prompts
-npx ctx7 skills remove pdf
-
-# Remove from a specific client
-npx ctx7 skills remove pdf --claude
-npx ctx7 skills remove pdf --universal
-
-# Remove from global directory
-npx ctx7 skills remove pdf --global
-```
-
-## Generate Custom Skills
-
-Create custom skills tailored to your specific needs using AI. This feature requires authentication.
-
-### Authentication
-
-```bash
-# Log in (opens browser for OAuth)
-npx ctx7 login
-
-# Check your login status
-npx ctx7 whoami
-
-# Log out
-npx ctx7 logout
-```
-
-### Generate a Skill
-
-```bash
-# Start interactive generation
-npx ctx7 skills generate
-
-# Generate for a specific client
-npx ctx7 skills generate --cursor
-npx ctx7 skills generate --claude
-npx ctx7 skills generate --universal
-
-# Generate as a global skill
-npx ctx7 skills generate --global
-```
-
-### Generation Workflow
-
-1. **Describe your expertise**: Enter what you want the skill to do (e.g., "OAuth authentication with NextAuth.js best practices")
-2. **Select documentation**: Search and choose relevant libraries to inform the skill
-3. **Answer questions**: Respond to 3 clarifying questions to focus the skill
-4. **Review**: See the generated skill and optionally request changes
-5. **Install**: Save the skill to your selected client(s)
-
-<Tip>
-Describe best practices and constraints, not step-by-step tutorials. For example, "TypeScript strict mode patterns" is better than "how to write TypeScript."
-</Tip>
-
-## Supported Clients
-
-The CLI automatically detects installed AI coding assistants and offers to install skills for them.
-
-| Client | Project Directory | Global Directory |
-|--------|-------------------|------------------|
-| Universal (Amp, Codex, Gemini CLI, GitHub Copilot, OpenCode + more) | `.agents/skills/` | `~/.config/agents/skills/` |
-| Claude Code | `.claude/skills/` | `~/.claude/skills/` |
-| Cursor | `.cursor/skills/` | `~/.cursor/skills/` |
-| Antigravity | `.agent/skills/` | `~/.agent/skills/` |
-
-**Project vs Global:**
-- **Project skills** (default): Installed in your current project directory, available only in that project
-- **Global skills** (`--global`): Installed in your home directory, available across all projects
 
 ## Skill File Structure
 
@@ -312,25 +145,34 @@ Use markdown formatting, code examples, and clear steps.
 | Field | Required | Description |
 |-------|----------|-------------|
 | `name` | Yes | Identifier for the skill (lowercase, hyphens allowed) |
-| `description` | Yes | Explains what the skill does — used for discovery |
+| `description` | Yes | Explains what the skill does — used for discovery and auto-triggering |
 
 The markdown body contains the actual instructions your AI assistant follows when the skill is invoked.
 
-## Command Shortcuts
+## Supported Clients
 
-For faster usage, the CLI provides short aliases:
+The CLI automatically detects installed AI coding assistants and offers to install skills for them.
 
-| Shortcut | Full Command |
-|----------|--------------|
-| `npx ctx7 si` | `npx ctx7 skills install` |
-| `npx ctx7 ss` | `npx ctx7 skills search` |
-| `npx ctx7 ssg` | `npx ctx7 skills suggest` |
-| `npx ctx7 skills i` | `npx ctx7 skills install` |
-| `npx ctx7 skills s` | `npx ctx7 skills search` |
-| `npx ctx7 skills ls` | `npx ctx7 skills list` |
-| `npx ctx7 skills rm` | `npx ctx7 skills remove` |
-| `npx ctx7 skills gen` | `npx ctx7 skills generate` |
-| `npx ctx7 skills g` | `npx ctx7 skills generate` |
+| Client | Project Directory | Global Directory |
+|--------|-------------------|------------------|
+| Universal (Amp, Codex, Gemini CLI, GitHub Copilot, OpenCode + more) | `.agents/skills/` | `~/.config/agents/skills/` |
+| Claude Code | `.claude/skills/` | `~/.claude/skills/` |
+| Cursor | `.cursor/skills/` | `~/.cursor/skills/` |
+| Antigravity | `.agent/skills/` | `~/.agent/skills/` |
+
+**Project vs Global:**
+- **Project skills** (default): Installed in your current project directory, available only in that project
+- **Global skills** (`--global`): Installed in your home directory, available across all projects
+
+## Managing Skills
+
+Use the `ctx7` CLI to install, search, generate, and remove skills. See the [CLI reference](/clients/cli#skills) for all commands.
+
+```bash
+# Quick start
+npx ctx7 skills search pdf
+npx ctx7 skills install /anthropics/skills pdf
+```
 
 ## Troubleshooting
 
@@ -339,13 +181,7 @@ For faster usage, the CLI provides short aliases:
 If you see permission errors when installing or removing skills:
 
 ```bash
-# Try with sudo for global installations
-sudo npx ctx7 skills install /anthropics/skills pdf --global
-```
-
-Or fix directory permissions:
-
-```bash
+# Fix directory permissions
 sudo chown -R $(whoami) ~/.claude/skills
 ```
 
@@ -376,35 +212,23 @@ mkdir -p .cursor
 If login fails or tokens expire:
 
 ```bash
-# Clear stored credentials
-npx ctx7 logout
-
-# Log in again
-npx ctx7 login
-```
-
-## Disabling Telemetry
-
-The CLI collects anonymous usage data to help improve the product. To disable telemetry, set the `CTX7_TELEMETRY_DISABLED` environment variable:
-
-```bash
-# For a single command
-CTX7_TELEMETRY_DISABLED=1 npx ctx7 skills search pdf
-
-# Or export in your shell profile (~/.bashrc, ~/.zshrc, etc.)
-export CTX7_TELEMETRY_DISABLED=1
+ctx7 logout
+ctx7 login
 ```
 
 ## Next Steps
 
 <CardGroup cols={2}>
+  <Card title="CLI Reference" icon="terminal" href="/clients/cli">
+    All ctx7 commands for installing, searching, and generating skills
+  </Card>
   <Card title="Browse Skills" icon="magnifying-glass" href="https://context7.com/skills">
     Explore the skills registry
   </Card>
-  <Card title="Claude Code Skills Docs" icon="book" href="https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/skills">
-    Learn more about how skills work in Claude Code
-  </Card>
   <Card title="Agent Skills Spec" icon="code" href="https://agentskills.io">
     Read the open standard specification
+  </Card>
+  <Card title="Claude Code Skills" icon="book" href="https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/skills">
+    Learn more about how skills work in Claude Code
   </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary

- Add dedicated CLI docs page at `docs/clients/cli.mdx` covering installation, library documentation workflow, setup, authentication, and all skills commands
- Trim `docs/skills.mdx` to conceptual content only; add CLI reference link under the Registry section
- Update `references/docs.md` in the ctx7-cli skill to include selection algorithm and query quality guidance from MCP prompts