### PR TITLE
fix(cli): remove default universal selection on skills install

### DIFF
--- a/.changeset/disable-default-universal.md
+++ b/.changeset/disable-default-universal.md
@@ -1,0 +1,5 @@
+---
+"ctx7": patch
+---
+
+Remove default selection of Universal agent target during skills install prompt

--- a/packages/cli/src/utils/ide.ts
+++ b/packages/cli/src/utils/ide.ts
@@ -124,7 +124,7 @@ export async function promptForInstallTargets(options: AddOptions): Promise<Inst
   // Nothing detected — show checkbox to pick
   const universalLabel = `Universal \u2014 ${UNIVERSAL_AGENTS_LABEL} ${pc.dim(`(${universalPath})`)}`;
   const choices: { name: string; value: IDE; checked: boolean }[] = [
-    { name: universalLabel, value: "universal", checked: true },
+    { name: universalLabel, value: "universal", checked: false },
   ];
 
   for (const ide of VENDOR_SPECIFIC_AGENTS) {


### PR DESCRIPTION
## Summary
- Remove the pre-selected "Universal" checkbox when prompting users for install targets during `ctx7 skills install`
- Users must now explicitly select which agent(s) to install to