### PR TITLE
feat(cli): track install count events on setup command

### DIFF
--- a/.changeset/brave-pugs-wink.md
+++ b/.changeset/brave-pugs-wink.md
@@ -1,0 +1,5 @@
+---
+"ctx7": patch
+---
+
+- feat(cli): track install count events when skills are installed via `ctx7 setup`

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -366,6 +366,7 @@ async function setupMcp(agents: SetupAgent[], options: SetupOptions, scope: Scop
   log.blank();
 
   trackEvent("setup", { agents, scope, authMode: auth.mode });
+  trackEvent("install", { skills: ["/upstash/context7/context7-mcp"], ides: agents });
 }
 
 async function setupCli(options: SetupOptions): Promise<void> {
@@ -413,6 +414,7 @@ async function setupCli(options: SetupOptions): Promise<void> {
   log.blank();
 
   trackEvent("setup", { mode: "cli" });
+  trackEvent("install", { skills: ["/upstash/context7/find-docs"], ides: targets.ides });
 }
 
 async function setupCommand(options: SetupOptions): Promise<void> {


### PR DESCRIPTION
## Summary

- Fires an `"install"` event after MCP setup completes, tracking `context7-mcp` skill installs per agent (e.g. `claude`, `cursor`)
- Fires an `"install"` event after CLI setup completes, tracking `find-docs` skill installs per target IDE
- Previously, `ctx7 setup` only sent a `"setup"` event which was not handled by the install count tracking logic on the backend