### PR TITLE
feat(cli): add teamspace name to whoami command

### DIFF
--- a/.changeset/bright-foxes-dance.md
+++ b/.changeset/bright-foxes-dance.md
@@ -1,0 +1,5 @@
+---
+"ctx7": patch
+---
+
+Add active teamspace name to whoami command output

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -15,6 +15,7 @@ import {
 } from "../utils/auth.js";
 
 import { trackEvent } from "../utils/tracking.js";
+import { getBaseUrl } from "../utils/api.js";
 
 const CLI_CLIENT_ID = "2veBSofhicRBguUT";
 
@@ -160,12 +161,15 @@ async function whoamiCommand(): Promise<void> {
   console.log(pc.green("Logged in"));
 
   try {
-    const userInfo = await fetchUserInfo(tokens.access_token);
-    if (userInfo.name) {
-      console.log(`${pc.dim("Name:".padEnd(9))}${userInfo.name}`);
+    const whoami = await fetchWhoami(tokens.access_token);
+    if (whoami.name) {
+      console.log(`${pc.dim("Name:".padEnd(13))}${whoami.name}`);
     }
-    if (userInfo.email) {
-      console.log(`${pc.dim("Email:".padEnd(9))}${userInfo.email}`);
+    if (whoami.email) {
+      console.log(`${pc.dim("Email:".padEnd(13))}${whoami.email}`);
+    }
+    if (whoami.teamspace) {
+      console.log(`${pc.dim("Teamspace:".padEnd(13))}${whoami.teamspace.name}`);
     }
   } catch {
     if (isTokenExpired(tokens) && !tokens.refresh_token) {
@@ -174,15 +178,15 @@ async function whoamiCommand(): Promise<void> {
   }
 }
 
-interface UserInfo {
-  sub?: string;
-  name?: string;
-  email?: string;
-  picture?: string;
+interface WhoamiResponse {
+  success: boolean;
+  name: string | null;
+  email: string | null;
+  teamspace: { id: string; name: string } | null;
 }
 
-async function fetchUserInfo(accessToken: string): Promise<UserInfo> {
-  const response = await fetch("https://clerk.context7.com/oauth/userinfo", {
+async function fetchWhoami(accessToken: string): Promise<WhoamiResponse> {
+  const response = await fetch(`${getBaseUrl()}/api/dashboard/whoami`, {
     headers: {
       Authorization: `Bearer ${accessToken}`,
     },
@@ -192,5 +196,5 @@ async function fetchUserInfo(accessToken: string): Promise<UserInfo> {
     throw new Error("Failed to fetch user info");
   }
 
-  return (await response.json()) as UserInfo;
+  return (await response.json()) as WhoamiResponse;
 }


### PR DESCRIPTION
## Summary
- Replace direct Clerk `/oauth/userinfo` call with new `/api/dashboard/whoami` backend endpoint
- `ctx7 whoami` now displays the active teamspace name alongside name and email
- Works with both OAuth and API key authentication