### PR TITLE
feat(docs): dedicated Docker and Kubernetes deployment guides

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -57,7 +57,13 @@
             "group": "On-Premise",
             "pages": [
               "enterprise/on-premise",
-              "enterprise/deployment"
+              {
+                "group": "Deployment",
+                "pages": [
+                  "enterprise/deployment/kubernetes",
+                  "enterprise/deployment/docker"
+                ]
+              }
             ]
           },
           "resources/security"

--- a/docs/enterprise/deployment/docker.mdx
+++ b/docs/enterprise/deployment/docker.mdx
@@ -1,0 +1,130 @@
+---
+title: "Docker Deployment"
+sidebarTitle: "Docker"
+---
+
+Deploy Context7 On-Premise with Docker Compose. This guide assumes you have completed the [On-Premise setup](/enterprise/on-premise) and have a valid license key.
+
+## Prerequisites
+
+- Docker and Docker Compose installed
+- Context7 license key
+
+## Registry Authentication
+
+Context7 Enterprise images are hosted on `ghcr.io` and require authentication. Log in using your license key:
+
+```bash
+LICENSE_KEY="<your-license-key>"
+
+TOKEN=$(curl -s -H "Authorization: Bearer $LICENSE_KEY" \
+  https://context7.com/api/v1/license/registry-token | jq -r '.token')
+
+docker login ghcr.io -u x-access-token -p $TOKEN
+```
+
+Docker stores these credentials locally. `docker compose` will use them automatically when pulling the image. You can also pull manually:
+
+```bash
+docker pull ghcr.io/context7/enterprise:latest
+```
+
+## Docker Compose
+
+Create a `docker-compose.yml`:
+
+```yaml
+services:
+  context7:
+    image: ghcr.io/context7/enterprise:latest
+    container_name: context7
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    volumes:
+      - context7-data:/data
+    environment:
+      - LICENSE_KEY=${LICENSE_KEY}
+
+volumes:
+  context7-data:
+    driver: local
+```
+
+<Warning>
+The `context7-data` volume is critical. It stores your SQLite database (configuration, credentials, indexed libraries) and all vector embeddings. Without a persistent volume, all data is lost when the container restarts or is recreated. Never run without a volume mount in production.
+</Warning>
+
+Create a `.env` file in the same directory:
+
+```bash
+LICENSE_KEY=ctx7sk-...
+```
+
+Start the service:
+
+```bash
+docker compose up -d
+```
+
+Once the container is running, open `http://localhost:3000` in your browser to complete the setup wizard.
+
+## Operations
+
+### Updating
+
+If your registry login has expired, re-authenticate first:
+
+```bash
+LICENSE_KEY="<your-license-key>"
+
+TOKEN=$(curl -s -H "Authorization: Bearer $LICENSE_KEY" \
+  https://context7.com/api/v1/license/registry-token | jq -r '.token')
+
+docker login ghcr.io -u x-access-token -p $TOKEN
+```
+
+Then pull the latest image and restart the container:
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
+Data persists in the named Docker volume across updates.
+
+### Health Check
+
+```bash
+curl http://localhost:3000/api/health
+```
+
+Example response:
+
+```json
+{
+  "status": "healthy",
+  "version": "1.0.0",
+  "setup": "complete",
+  "license": "configured",
+  "licenseInfo": {
+    "valid": true,
+    "teamSize": 10,
+    "expiresAt": "2026-06-01T00:00:00.000Z"
+  },
+  "repos_parsed": 5,
+  "uptime": 3600,
+  "connectivity": {
+    "llm": "configured",
+    "llm_provider": "openai",
+    "embedding": "configured",
+    "embedding_provider": "openai",
+    "github": "configured",
+    "gitlab": "not configured"
+  }
+}
+```
+
+## Connecting AI Clients
+
+Once deployed, point your MCP clients to your deployment URL. See [Connecting Your AI Client](/enterprise/on-premise#connecting-your-ai-client) for client-specific instructions.

--- a/docs/enterprise/deployment/kubernetes.mdx
+++ b/docs/enterprise/deployment/kubernetes.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Kubernetes Deployment"
-sidebarTitle: "Deployment"
+sidebarTitle: "Kubernetes"
 ---
 
 Deploy Context7 On-Premise on Kubernetes using raw manifests. This guide assumes you have completed the [On-Premise setup](/enterprise/on-premise) and have a valid license key.
@@ -275,6 +275,32 @@ The `/api/health` endpoint returns structured JSON with license status, connecti
 ```bash
 kubectl exec -n context7 context7-0 -- \
   wget -qO- http://localhost:3000/api/health
+```
+
+Example response:
+
+```json
+{
+  "status": "healthy",
+  "version": "1.0.0",
+  "setup": "complete",
+  "license": "configured",
+  "licenseInfo": {
+    "valid": true,
+    "teamSize": 10,
+    "expiresAt": "2026-06-01T00:00:00.000Z"
+  },
+  "repos_parsed": 5,
+  "uptime": 3600,
+  "connectivity": {
+    "llm": "configured",
+    "llm_provider": "openai",
+    "embedding": "configured",
+    "embedding_provider": "openai",
+    "github": "configured",
+    "gitlab": "not configured"
+  }
+}
 ```
 
 ### Logs

--- a/docs/enterprise/on-premise.mdx
+++ b/docs/enterprise/on-premise.mdx
@@ -9,7 +9,7 @@ Context7 On-Premise lets you run the full Context7 stack inside your own infrast
 
 - Full Context7 parsing and indexing pipeline
 - Local vector storage (no external vector DB required)
-- Built-in MCP server — works with any MCP-compatible AI client
+- Built-in MCP server. Works with any MCP-compatible AI client
 - Web UI for managing indexed libraries and configuration
 - REST API compatible with the public Context7 API
 - Private GitHub and GitLab repository ingestion
@@ -24,68 +24,22 @@ Context7 On-Premise lets you run the full Context7 stack inside your own infrast
 
 <Step title="Request a trial">
 
-Go to [context7.com/plans](https://context7.com/plans) and click **On-Premise Trial**. Fill out the request form — no credit card required. You'll receive a 30-day full-featured license key via email once approved.
+Go to [context7.com/plans](https://context7.com/plans) and click **On-Premise Trial**. Fill out the request form. No credit card required. You'll receive a 30-day full-featured license key via email once approved.
 
 </Step>
 
-<Step title="Authenticate with the registry">
+<Step title="Deploy">
 
-Use your license key to get a registry token and log in:
+Follow the deployment guide for your platform:
 
-```bash
-LICENSE_KEY="<your-license-key>"
-
-TOKEN=$(curl -s -H "Authorization: Bearer $LICENSE_KEY" \
-  https://context7.com/api/v1/license/registry-token | jq -r '.token')
-
-docker login ghcr.io -u x-access-token -p $TOKEN
-```
-
-Docker stores these credentials locally — `docker compose` will use them automatically when pulling the image. You can also pull manually:
-
-```bash
-docker pull ghcr.io/context7/enterprise:latest
-```
-
-</Step>
-
-<Step title="Configure and start">
-
-Create a `docker-compose.yml`:
-
-```yaml
-services:
-  context7:
-    image: ghcr.io/context7/enterprise:latest
-    container_name: context7
-    restart: unless-stopped
-    ports:
-      - "3000:3000"
-    volumes:
-      - context7-data:/data
-    environment:
-      - LICENSE_KEY=${LICENSE_KEY}
-
-volumes:
-  context7-data:
-    driver: local
-```
-
-<Warning>
-The `context7-data` volume is critical. It stores your SQLite database (configuration, credentials, indexed libraries) and all vector embeddings. Without a persistent volume, all data is lost when the container restarts or is recreated. Never run without a volume mount in production.
-</Warning>
-
-Create a `.env` file in the same directory:
-
-```bash
-LICENSE_KEY=ctx7sk-...
-```
-
-Start the service:
-
-```bash
-docker compose up -d
-```
+<CardGroup cols={2}>
+  <Card title="Docker" icon="docker" href="/enterprise/deployment/docker">
+    Deploy with Docker Compose
+  </Card>
+  <Card title="Kubernetes" icon="dharmachakra" href="/enterprise/deployment/kubernetes">
+    Deploy on Kubernetes with raw manifests
+  </Card>
+</CardGroup>
 
 </Step>
 
@@ -93,9 +47,9 @@ docker compose up -d
 
 Open `http://localhost:3000` in your browser. On first launch, the setup wizard guides you through configuring:
 
-1. **AI Provider** — Choose OpenAI, Anthropic, Gemini, or a custom OpenAI-compatible endpoint. Enter your API key and model name.
-2. **Embedding Provider** — Use the same provider as your LLM, or configure a separate one for embeddings.
-3. **Git Tokens** — Add a GitHub and/or GitLab token for the platforms you use.
+1. **AI Provider** - Choose OpenAI, Anthropic, Gemini, or a custom OpenAI-compatible endpoint. Enter your API key and model name.
+2. **Embedding Provider** - Use the same provider as your LLM, or configure a separate one for embeddings.
+3. **Git Tokens** - Add a GitHub and/or GitLab token for the platforms you use.
 
 All configuration is stored locally in the embedded database and can be updated later from the Settings page.
 
@@ -222,8 +176,8 @@ Configured via the **Settings** page in the web UI.
 
 | Setting | Description |
 |---|---|
-| GitHub Token | GitHub Personal Access Token — required for GitHub repositories |
-| GitLab Token | GitLab token — required for GitLab repositories |
+| GitHub Token | GitHub Personal Access Token. Required for GitHub repositories |
+| GitLab Token | GitLab token. Required for GitLab repositories |
 
 You only need tokens for the platforms you use. If you only parse GitLab repos, you don't need a GitHub token, and vice versa. Create tokens with `repo` scope (GitHub) or `read_repository` scope (GitLab) for private repository access.
 
@@ -255,59 +209,10 @@ Open your deployment URL in a browser to access the dashboard. From here you can
 
 ## Operations
 
-### Updating the Image
+For updating, health checks, and other operational tasks, see the deployment guide for your platform:
 
-If your registry login has expired, re-authenticate first:
-
-```bash
-LICENSE_KEY="<your-license-key>"
-
-TOKEN=$(curl -s -H "Authorization: Bearer $LICENSE_KEY" \
-  https://context7.com/api/v1/license/registry-token | jq -r '.token')
-
-docker login ghcr.io -u x-access-token -p $TOKEN
-```
-
-Then pull the latest image and restart the container:
-
-```bash
-docker compose pull
-docker compose up -d
-```
-
-Data persists in the named Docker volume across updates.
-
-### Health Check
-
-```bash
-curl http://localhost:3000/api/health
-```
-
-Example response:
-
-```json
-{
-  "status": "healthy",
-  "version": "1.0.0",
-  "setup": "complete",
-  "license": "configured",
-  "licenseInfo": {
-    "valid": true,
-    "teamSize": 10,
-    "expiresAt": "2026-06-01T00:00:00.000Z"
-  },
-  "repos_parsed": 5,
-  "uptime": 3600,
-  "connectivity": {
-    "llm": "configured",
-    "llm_provider": "openai",
-    "embedding": "configured",
-    "embedding_provider": "openai",
-    "github": "configured",
-    "gitlab": "not configured"
-  }
-}
-```
+- [Docker Operations](/enterprise/deployment/docker#operations)
+- [Kubernetes Operations](/enterprise/deployment/kubernetes#operations)
 
 ## Support
 


### PR DESCRIPTION
## Summary
- Split `deployment.mdx` into `deployment/kubernetes.mdx` and `deployment/docker.mdx` so it's clear the app supports both Docker and Kubernetes deployments
- Simplified the on-premise getting started page by replacing inline Docker setup steps with Mintlify cards linking to the deployment guides
- Moved duplicate operations content (updating, health checks) from on-premise into the deployment guides