### PR TITLE
chore: broaden find-docs skill description to cover all developer technologies

### DIFF
--- a/skills/find-docs/SKILL.md
+++ b/skills/find-docs/SKILL.md
@@ -1,6 +1,25 @@
 ---
 name: find-docs
-description: Retrieves and queries up-to-date documentation and code examples from Context7 for any programming library or framework. Use when writing code that depends on external packages, verifying API signatures, looking up usage patterns, generating code with specific libraries, or when training data may be outdated. Covers setup questions, migration guides, and version-specific docs.
+description: >-
+  Retrieves authoritative, up-to-date technical documentation, API references,
+  configuration details, and code examples for any developer technology.
+
+  Use this skill whenever answering technical questions or writing code that
+  interacts with external technologies. This includes libraries, frameworks,
+  programming languages, SDKs, APIs, CLI tools, cloud services, infrastructure
+  tools, and developer platforms.
+
+  Common scenarios:
+  - looking up API endpoints, classes, functions, or method parameters
+  - checking configuration options or CLI commands
+  - answering "how do I" technical questions
+  - generating code that uses a specific library or service
+  - debugging issues related to frameworks, SDKs, or APIs
+  - retrieving setup instructions, examples, or migration guides
+  - verifying version-specific behavior or breaking changes
+
+  Prefer this skill whenever documentation accuracy matters or when model
+  knowledge may be outdated.
 ---
 
 # Documentation Lookup


### PR DESCRIPTION
## Summary
- Expanded the `find-docs` skill description from "programming library or framework" to "any developer technology" (libraries, frameworks, languages, SDKs, APIs, CLI tools, cloud services, infrastructure tools, platforms)
- Added explicit common trigger scenarios (API lookups, CLI commands, "how do I" questions, debugging, migration guides, version-specific behavior) to improve auto-invocation matching
- Added catch-all trigger: "whenever documentation accuracy matters or when model knowledge may be outdated"

## Test plan
- [ ] Verify the skill triggers for library/framework queries (existing behavior)
- [ ] Verify the skill now triggers for CLI tool, cloud service, and platform queries
- [ ] Verify the skill triggers for general "how do I" technical questions

🤖 Generated with [Claude Code](https://claude.com/claude-code)