### PR TITLE
fix(cli): prevent directory traversal in skill file installation

### DIFF
--- a/.changeset/silver-wolves-hunt.md
+++ b/.changeset/silver-wolves-hunt.md
@@ -1,0 +1,5 @@
+---
+"ctx7": patch
+---
+
+Prevent directory traversal in skill file installation by validating resolved paths stay within the target directory

--- a/packages/cli/src/utils/github.ts
+++ b/packages/cli/src/utils/github.ts
@@ -126,6 +126,12 @@ export async function downloadSkillFromGitHub(
       const content = await fileResponse.text();
       const relativePath = item.path.slice(skillPath.length + 1);
 
+      // Reject paths that attempt directory traversal
+      if (relativePath.includes("..")) {
+        console.warn(`Skipping file with unsafe path: ${item.path}`);
+        continue;
+      }
+
       files.push({
         path: relativePath,
         content,

--- a/packages/cli/src/utils/installer.ts
+++ b/packages/cli/src/utils/installer.ts
@@ -1,5 +1,5 @@
 import { mkdir, writeFile, rm, symlink, lstat } from "fs/promises";
-import { join } from "path";
+import { join, resolve, dirname } from "path";
 
 import type { SkillFile } from "../types.js";
 
@@ -8,11 +8,19 @@ export async function installSkillFiles(
   files: SkillFile[],
   targetDir: string
 ): Promise<void> {
-  const skillDir = join(targetDir, skillName);
+  const skillDir = resolve(targetDir, skillName);
 
   for (const file of files) {
-    const filePath = join(skillDir, file.path);
-    const fileDir = join(filePath, "..");
+    const filePath = resolve(skillDir, file.path);
+
+    // Prevent directory traversal — resolved path must stay within skillDir
+    if (!filePath.startsWith(skillDir + "/") && filePath !== skillDir) {
+      throw new Error(
+        `Skill file path "${file.path}" resolves outside the target directory`
+      );
+    }
+
+    const fileDir = dirname(filePath);
 
     await mkdir(fileDir, { recursive: true });
     await writeFile(filePath, file.content);

--- a/packages/cli/src/utils/installer.ts
+++ b/packages/cli/src/utils/installer.ts
@@ -15,9 +15,7 @@ export async function installSkillFiles(
 
     // Prevent directory traversal — resolved path must stay within skillDir
     if (!filePath.startsWith(skillDir + "/") && filePath !== skillDir) {
-      throw new Error(
-        `Skill file path "${file.path}" resolves outside the target directory`
-      );
+      throw new Error(`Skill file path "${file.path}" resolves outside the target directory`);
     }
 
     const fileDir = dirname(filePath);


### PR DESCRIPTION
## Summary

Fixes #2234

- **installer.ts**: Replace `path.join()` with `path.resolve()` and add a boundary check that ensures the resolved file path stays within the skill directory. Throws an error if a path would escape the boundary.
- **github.ts**: Add defense-in-depth check that rejects file paths containing `..` at download time, before they reach the installer.

## Vulnerability Details

`installSkillFiles()` used `path.join(skillDir, file.path)` where `file.path` comes from the GitHub API tree response. A malicious skill repository could include files with `../` path sequences, causing `path.join()` to resolve to locations outside the intended skill directory. This allowed arbitrary file writes as the current user.

## Changes

| File | Change |
|------|--------|
| `packages/cli/src/utils/installer.ts` | Use `resolve()` + boundary check before `writeFile()` |
| `packages/cli/src/utils/github.ts` | Reject paths containing `..` at download time |

## Test Plan

- [ ] `npx tsc --noEmit -p packages/cli/tsconfig.json` passes with zero errors
- [ ] Manual: verify `path.resolve("/base/skill", "../../../etc/passwd")` → `/etc/passwd` which is caught by the `startsWith` guard
- [ ] Manual: verify legitimate skill paths like `src/index.ts` still install correctly
---
*Found by [SpiderShield](https://github.com/teehooai/spidershield) security scanner*