### PR TITLE
fix(cli): reorder setup mode choices to show MCP server first

### DIFF
--- a/.changeset/lucky-wolves-sing.md
+++ b/.changeset/lucky-wolves-sing.md
@@ -1,0 +1,5 @@
+---
+"ctx7": patch
+---
+
+Reorder setup mode choices to show MCP server first

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -134,12 +134,12 @@ async function resolveMode(options: SetupOptions): Promise<SetupMode> {
     message: "How should your agent access Context7?",
     choices: [
       {
-        name: `CLI + Skills\n    ${pc.dim("Installs a find-docs skill that guides your agent to fetch up-to-date library docs using ")}${pc.dim(pc.bold("ctx7"))}${pc.dim(" CLI commands")}`,
-        value: "cli" as SetupMode,
-      },
-      {
         name: `MCP server\n    ${pc.dim("Agent calls Context7 tools via MCP protocol to retrieve up-to-date library docs")}`,
         value: "mcp" as SetupMode,
+      },
+      {
+        name: `CLI + Skills\n    ${pc.dim("Installs a find-docs skill that guides your agent to fetch up-to-date library docs using ")}${pc.dim(pc.bold("ctx7"))}${pc.dim(" CLI commands")}`,
+        value: "cli" as SetupMode,
       },
     ],
     theme: {


### PR DESCRIPTION
## Summary
- Reorders the interactive prompt choices in `ctx7 setup` so "MCP server" appears first (as the default highlighted option) instead of "CLI + Skills"
- Aligns with the existing behavior where `--yes` flag defaults to `mcp` mode