### PR TITLE
fix(docs): reorder deployment menu to show Docker before Kubernetes

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -60,8 +60,8 @@
               {
                 "group": "Deployment",
                 "pages": [
-                  "enterprise/deployment/kubernetes",
-                  "enterprise/deployment/docker"
+                  "enterprise/deployment/docker",
+                  "enterprise/deployment/kubernetes"
                 ]
               }
             ]


### PR DESCRIPTION
## Summary
- Reorders the On-Premise > Deployment sidebar menu so Docker appears before Kubernetes

## Test plan
- [ ] Verify docs sidebar shows Docker before Kubernetes under On-Premise > Deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)