### PR TITLE
docs: clarify headless Claude Code setup

### DIFF
--- a/docs/clients/claude-code.mdx
+++ b/docs/clients/claude-code.mdx
@@ -13,9 +13,19 @@ Run the setup command to configure Context7 for Claude Code:
 npx ctx7 setup --claude
 ```
 
-Authenticates via OAuth, generates an API key, and installs the appropriate skill. You can choose between CLI or MCP mode.
+This flow authenticates via OAuth, generates an API key, and installs the appropriate skill. You can choose between CLI or MCP mode.
 
-For manual MCP installation or other configuration options, see [All MCP Clients](/resources/all-clients).
+<Tip>
+If you're setting up Claude Code on a remote server, headless VM, or over SSH, use an existing API key instead:
+
+```bash
+npx ctx7 setup --claude --api-key YOUR_API_KEY
+```
+
+The default OAuth flow redirects back to `localhost`, which only works when the browser can reach the same machine that's running `ctx7 setup`.
+</Tip>
+
+Create or manage API keys in the [Context7 dashboard](https://context7.com/dashboard). For manual MCP installation or other configuration options, see [All MCP Clients](/resources/all-clients).
 
 ---
 


### PR DESCRIPTION
## Summary
- document the --api-key setup path for Claude Code on remote or headless machines
- explain that the default OAuth flow redirects to localhost, which only works when the browser can reach the same machine running ctx7 setup
- link users to the dashboard to create or manage API keys

Closes #2242.

## Validation
- npx prettier --check docs/clients/claude-code.mdx