### PR TITLE
fix(cli): remove shell:true from spawn in generate command

### DIFF
--- a/.changeset/quiet-tigers-rest.md
+++ b/.changeset/quiet-tigers-rest.md
@@ -1,0 +1,5 @@
+---
+"ctx7": patch
+---
+
+Remove shell:true from spawn call in generate command to prevent command injection via EDITOR env variable

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -437,7 +437,6 @@ async function generateCommand(options: GenerateOptions): Promise<void> {
       await new Promise<void>((resolve) => {
         const child = spawn(editor, [previewFile!], {
           stdio: "inherit",
-          shell: true,
         });
         child.on("close", () => resolve());
       });


### PR DESCRIPTION
## Summary

- Removes `shell: true` from the `child_process.spawn()` call in the `generate` command's "open in editor" flow
- The editor binary and file path are already passed as separate arguments to `spawn()`, so shell interpolation is not needed
- With `shell: true`, a malicious `$EDITOR` value or a crafted file path containing shell metacharacters could execute arbitrary commands

## Details

In `packages/cli/src/commands/generate.ts` line 440, the spawn call uses `shell: true` unnecessarily. Node's `spawn` without `shell: true` executes the binary directly via `execvp`, which safely handles arguments without shell interpretation.

This is a one-line removal. No behavior change for normal editor values like `vim`, `nano`, `code`, or `open`.

Fixes #2240

This contribution was developed with AI assistance (Claude Code).