### PR TITLE
fix(mcp): support NODE_EXTRA_CA_CERTS for enterprise MITM proxies

### DIFF
--- a/.changeset/brave-foxes-dance.md
+++ b/.changeset/brave-foxes-dance.md
@@ -1,0 +1,5 @@
+---
+"@upstash/context7-mcp": patch
+---
+
+Support NODE_EXTRA_CA_CERTS for enterprise MITM proxies by injecting custom CA certificates into undici's global dispatcher at runtime

--- a/packages/mcp/src/lib/api.ts
+++ b/packages/mcp/src/lib/api.ts
@@ -1,7 +1,8 @@
 import { SearchResponse, ContextRequest, ContextResponse } from "./types.js";
 import { ClientContext, generateHeaders } from "./encryption.js";
-import { ProxyAgent, setGlobalDispatcher } from "undici";
+import { Agent, ProxyAgent, setGlobalDispatcher } from "undici";
 import { CONTEXT7_API_BASE_URL } from "./constants.js";
+import { readFileSync } from "fs";
 
 /**
  * Parses error response from the Context7 API
@@ -42,14 +43,39 @@ const PROXY_URL: string | null =
   process.env.http_proxy ??
   null;
 
+const CUSTOM_CA_CERTS: string | undefined = process.env.NODE_EXTRA_CA_CERTS;
+
+function loadCustomCACerts(): Buffer | undefined {
+  if (!CUSTOM_CA_CERTS) return undefined;
+  try {
+    return readFileSync(CUSTOM_CA_CERTS);
+  } catch (error) {
+    console.error(
+      `[Context7] Failed to load custom CA certificates from ${CUSTOM_CA_CERTS}:`,
+      error
+    );
+    return undefined;
+  }
+}
+
 if (PROXY_URL && !PROXY_URL.startsWith("$") && /^(http|https):\/\//i.test(PROXY_URL)) {
   try {
-    setGlobalDispatcher(new ProxyAgent(PROXY_URL));
+    const ca = loadCustomCACerts();
+    setGlobalDispatcher(new ProxyAgent({ uri: PROXY_URL, ...(ca ? { connect: { ca } } : {}) }));
   } catch (error) {
     console.error(
       `[Context7] Failed to configure proxy agent for provided proxy URL: ${PROXY_URL}:`,
       error
     );
+  }
+} else if (CUSTOM_CA_CERTS) {
+  const ca = loadCustomCACerts();
+  if (ca) {
+    try {
+      setGlobalDispatcher(new Agent({ connect: { ca } }));
+    } catch (error) {
+      console.error(`[Context7] Failed to configure custom CA certificates:`, error);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- Reads custom CA certificates from `NODE_EXTRA_CA_CERTS` and injects them into undici's global dispatcher at runtime
- Handles both transparent proxy (no explicit HTTPS_PROXY) and explicit proxy scenarios
- Leverages the existing `setGlobalDispatcher` + `undici` pattern already used for HTTP proxy support

## Problem

Behind enterprise MITM proxies (Zscaler, corporate VPNs), Node's default `fetch()` TLS context does not trust the corporate CA certificate. Even when `NODE_EXTRA_CA_CERTS` is set, many MCP client launchers (npx, background daemons) strip or inject the env var too late for Node to pick it up at startup, causing `UNABLE_TO_VERIFY_LEAF_SIGNATURE` errors.

## Solution

Explicitly read the CA cert file at module load time and pass it to undici's `Agent` or `ProxyAgent` via the `connect.ca` option. This bypasses Node's frozen TLS context and works regardless of when the env var was set.

Three cases are handled:
1. **Explicit proxy + custom CA:** `ProxyAgent` gets both the proxy URI and the CA cert
2. **No proxy + custom CA (transparent MITM):** A plain `Agent` with the CA cert is set as the global dispatcher
3. **No custom CA:** Existing behavior is unchanged

Fixes #2268

This contribution was developed with AI assistance (Claude Code).