### PR TITLE
fix(cli): use ~/.agents/skills for global universal skill installs

### DIFF
--- a/.changeset/warm-eagles-fly.md
+++ b/.changeset/warm-eagles-fly.md
@@ -1,0 +1,5 @@
+---
+"ctx7": patch
+---
+
+Use ~/.agents/skills instead of ~/.config/agents/skills for global universal skill installs

--- a/docs/clients/cli.mdx
+++ b/docs/clients/cli.mdx
@@ -126,7 +126,7 @@ ctx7 setup --opencode
 # Target a specific install location (CLI + Skills mode)
 ctx7 setup --cli --claude       # Claude Code (~/.claude/skills)
 ctx7 setup --cli --cursor       # Cursor (~/.cursor/skills)
-ctx7 setup --cli --universal    # Universal (~/.config/agents/skills)
+ctx7 setup --cli --universal    # Universal (~/.agents/skills)
 ctx7 setup --cli --antigravity  # Antigravity (~/.config/agent/skills)
 
 # Configure for current project only (default is global)

--- a/docs/skills.mdx
+++ b/docs/skills.mdx
@@ -155,7 +155,7 @@ The CLI automatically detects installed AI coding assistants and offers to insta
 
 | Client | Project Directory | Global Directory |
 |--------|-------------------|------------------|
-| Universal (Amp, Codex, Gemini CLI, GitHub Copilot, OpenCode + more) | `.agents/skills/` | `~/.config/agents/skills/` |
+| Universal (Amp, Codex, Gemini CLI, GitHub Copilot, OpenCode + more) | `.agents/skills/` | `~/.agents/skills/` |
 | Claude Code | `.claude/skills/` | `~/.claude/skills/` |
 | Cursor | `.cursor/skills/` | `~/.cursor/skills/` |
 | Antigravity | `.agent/skills/` | `~/.agent/skills/` |

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -165,7 +165,7 @@ export const IDE_GLOBAL_PATHS: Record<IDE, string> = {
   claude: ".claude/skills",
   cursor: ".cursor/skills",
   antigravity: ".agent/skills",
-  universal: ".config/agents/skills",
+  universal: ".agents/skills",
 };
 
 export const IDE_NAMES: Record<IDE, string> = {
@@ -178,7 +178,7 @@ export const IDE_NAMES: Record<IDE, string> = {
 // Universal .agents/skills standard
 // These agents read from .agents/skills/ natively — one install covers all of them.
 export const UNIVERSAL_SKILLS_PATH = ".agents/skills";
-export const UNIVERSAL_SKILLS_GLOBAL_PATH = ".config/agents/skills";
+export const UNIVERSAL_SKILLS_GLOBAL_PATH = ".agents/skills";
 
 // Display label for agents that read .agents/skills/ (includes agents beyond our IDE type)
 export const UNIVERSAL_AGENTS_LABEL = "Amp, Codex, Gemini CLI, GitHub Copilot, OpenCode + more";

--- a/skills/context7-cli/references/setup.md
+++ b/skills/context7-cli/references/setup.md
@@ -19,7 +19,7 @@ ctx7 setup --opencode          # OpenCode only
 # CLI + Skills mode — target a specific install location
 ctx7 setup --cli --claude      # Claude Code (~/.claude/skills)
 ctx7 setup --cli --cursor      # Cursor (~/.cursor/skills)
-ctx7 setup --cli --universal   # Universal (~/.config/agents/skills)
+ctx7 setup --cli --universal   # Universal (~/.agents/skills)
 ctx7 setup --cli --antigravity # Antigravity (~/.config/agent/skills)
 
 ctx7 setup --project           # Configure current project instead of globally


### PR DESCRIPTION
## Summary

- Changes the global universal skills path from `~/.config/agents/skills` to `~/.agents/skills`
- Updates all references in CLI source, docs, and skill references

Fixes #2276