### PR TITLE
feat(mcp): add --version / -v flag to MCP CLI binary

### DIFF
--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -18,6 +18,7 @@ const DEFAULT_PORT = 3000;
 
 // Parse CLI arguments using commander
 const program = new Command()
+  .version(SERVER_VERSION, "-v, --version", "output the current version")
   .option("--transport <stdio|http>", "transport type", "stdio")
   .option("--port <number>", "port for HTTP transport", DEFAULT_PORT.toString())
   .option("--api-key <key>", "API key for authentication (or set CONTEXT7_API_KEY env var)")


### PR DESCRIPTION
## Summary

- Wires commander's `.version()` to `SERVER_VERSION` (already read from `package.json`) so that running `npx @upstash/context7-mcp --version` or `-v` prints the current package version and exits cleanly
- One-line change in `packages/mcp/src/index.ts`

## Test plan

- [ ] `npx @upstash/context7-mcp --version` prints version number and exits
- [ ] `npx @upstash/context7-mcp -v` same behavior
- [ ] Normal MCP server startup is unaffected

Closes #2284

🤖 Generated with [Claude Code](https://claude.com/claude-code)