### PR TITLE
fix(cli): detect .opencode.jsonc config files

### DIFF
--- a/packages/cli/src/__tests__/agents.test.ts
+++ b/packages/cli/src/__tests__/agents.test.ts
@@ -1,0 +1,101 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import { access } from "fs/promises";
+import { join } from "path";
+
+// Mock fs/promises
+vi.mock("fs/promises", () => ({
+  access: vi.fn(),
+}));
+
+// Mock os - need to mock before importing the module that uses it
+vi.mock("os", () => ({
+  homedir: vi.fn(() => "/home/testuser"),
+}));
+
+import { detectAgents, getAgent, ALL_AGENT_NAMES } from "../setup/agents.js";
+
+describe("agent detection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("opencode detection", () => {
+    test("detects opencode from .opencode.json", async () => {
+      vi.mocked(access).mockImplementation(async (path: string) => {
+        if (path === join(process.cwd(), ".opencode.json")) {
+          return undefined; // exists
+        }
+        throw new Error("not found");
+      });
+
+      const detected = await detectAgents("project");
+      expect(detected).toContain("opencode");
+    });
+
+    test("detects opencode from .opencode.jsonc", async () => {
+      vi.mocked(access).mockImplementation(async (path: string) => {
+        if (path === join(process.cwd(), ".opencode.jsonc")) {
+          return undefined; // exists
+        }
+        throw new Error("not found");
+      });
+
+      const detected = await detectAgents("project");
+      expect(detected).toContain("opencode");
+    });
+
+    test("does not detect opencode when neither config file exists", async () => {
+      vi.mocked(access).mockRejectedValue(new Error("not found"));
+
+      const detected = await detectAgents("project");
+      expect(detected).not.toContain("opencode");
+    });
+
+    test("detects opencode globally from config directory", async () => {
+      vi.mocked(access).mockImplementation(async (path: string) => {
+        if (path === join("/home/testuser", ".config", "opencode")) {
+          return undefined; // exists
+        }
+        throw new Error("not found");
+      });
+
+      const detected = await detectAgents("global");
+      expect(detected).toContain("opencode");
+    });
+  });
+
+  describe("getAgent", () => {
+    test("returns correct config for opencode", () => {
+      const agent = getAgent("opencode");
+      expect(agent.name).toBe("opencode");
+      expect(agent.displayName).toBe("OpenCode");
+      expect(agent.detect.projectPaths).toContain(".opencode.json");
+      expect(agent.detect.projectPaths).toContain(".opencode.jsonc");
+    });
+
+    test("returns correct config for claude", () => {
+      const agent = getAgent("claude");
+      expect(agent.name).toBe("claude");
+      expect(agent.displayName).toBe("Claude Code");
+    });
+
+    test("returns correct config for cursor", () => {
+      const agent = getAgent("cursor");
+      expect(agent.name).toBe("cursor");
+      expect(agent.displayName).toBe("Cursor");
+    });
+  });
+
+  describe("ALL_AGENT_NAMES", () => {
+    test("contains all supported agents", () => {
+      expect(ALL_AGENT_NAMES).toContain("claude");
+      expect(ALL_AGENT_NAMES).toContain("cursor");
+      expect(ALL_AGENT_NAMES).toContain("opencode");
+      expect(ALL_AGENT_NAMES).toHaveLength(3);
+    });
+  });
+});

--- a/packages/cli/src/setup/agents.ts
+++ b/packages/cli/src/setup/agents.ts
@@ -136,7 +136,7 @@ const agents: Record<SetupAgent, AgentConfig> = {
         scope === "global" ? join(homedir(), ".agents", "skills") : join(".agents", "skills"),
     },
     detect: {
-      projectPaths: [".opencode.json"],
+      projectPaths: [".opencode.json", ".opencode.jsonc"],
       globalPaths: [join(homedir(), ".config", "opencode")],
     },
   },


### PR DESCRIPTION
## Problem

OpenCode supports both `.opencode.json` and `.opencode.jsonc` (JSON with comments) configuration files. The detection logic in the CLI was only looking for `.opencode.json`, which meant users with `.opencode.jsonc` configs weren't being detected during setup.

## Changes

- Added `.opencode.jsonc` to `projectPaths` in the opencode agent config (`packages/cli/src/setup/agents.ts`)
- Added comprehensive tests for agent detection in `packages/cli/src/__tests__/agents.test.ts`

## Testing

- All 54 tests pass (including 8 new tests for agent detection)
- Verified that both `.opencode.json` and `.opencode.jsonc` files are now properly detected

## Related Issue

Fixes #2313

---

cc @enesakar @fahreddinozcan