### PR TITLE
fix(setup): resolve all OpenCode config variants for MCP setup

### DIFF
--- a/.changeset/opencode-config-variants.md
+++ b/.changeset/opencode-config-variants.md
@@ -1,0 +1,5 @@
+---
+"ctx7": patch
+---
+
+Fix OpenCode MCP setup to resolve all config file variants (opencode.json, opencode.jsonc, .opencode.json, .opencode.jsonc)

--- a/packages/cli/src/__tests__/setup.test.ts
+++ b/packages/cli/src/__tests__/setup.test.ts
@@ -180,22 +180,22 @@ describe("JSONC support", () => {
     expect(result.key).toBe("value");
   });
 
-  test("resolveMcpPath returns .jsonc when it exists", async () => {
+  test("resolveMcpPath returns first existing candidate", async () => {
     const jsoncPath = join(tempDir, "opencode.jsonc");
     await writeFile(jsoncPath, "{}", "utf-8");
-    const resolved = await resolveMcpPath(join(tempDir, "opencode.json"));
+    const resolved = await resolveMcpPath([join(tempDir, "opencode.json"), jsoncPath]);
     expect(resolved).toBe(jsoncPath);
   });
 
-  test("resolveMcpPath falls back to .json when no .jsonc", async () => {
+  test("resolveMcpPath falls back to first candidate when none exist", async () => {
     const jsonPath = join(tempDir, "opencode.json");
-    const resolved = await resolveMcpPath(jsonPath);
+    const resolved = await resolveMcpPath([jsonPath]);
     expect(resolved).toBe(jsonPath);
   });
 
-  test("resolveMcpPath returns non-json paths unchanged", async () => {
+  test("resolveMcpPath returns single candidate unchanged", async () => {
     const tomlPath = join(tempDir, "config.toml");
-    const resolved = await resolveMcpPath(tomlPath);
+    const resolved = await resolveMcpPath([tomlPath]);
     expect(resolved).toBe(tomlPath);
   });
 });

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -174,9 +174,11 @@ async function resolveCliAuth(apiKey?: string): Promise<void> {
 
 async function isAlreadyConfigured(agentName: SetupAgent, scope: Scope): Promise<boolean> {
   const agent = getAgent(agentName);
-  const baseMcpPath =
-    scope === "global" ? agent.mcp.globalPath : join(process.cwd(), agent.mcp.projectPath);
-  const mcpPath = await resolveMcpPath(baseMcpPath);
+  const mcpCandidates =
+    scope === "global"
+      ? agent.mcp.globalPaths
+      : agent.mcp.projectPaths.map((p) => join(process.cwd(), p));
+  const mcpPath = await resolveMcpPath(mcpCandidates);
   try {
     if (mcpPath.endsWith(".toml")) {
       const { readTomlServerExists } = await import("../setup/mcp-writer.js");
@@ -305,9 +307,11 @@ async function setupAgent(
 }> {
   const agent = getAgent(agentName);
 
-  const baseMcpPath =
-    scope === "global" ? agent.mcp.globalPath : join(process.cwd(), agent.mcp.projectPath);
-  const mcpPath = await resolveMcpPath(baseMcpPath);
+  const mcpCandidates =
+    scope === "global"
+      ? agent.mcp.globalPaths
+      : agent.mcp.projectPaths.map((p) => join(process.cwd(), p));
+  const mcpPath = await resolveMcpPath(mcpCandidates);
 
   let mcpStatus: string;
   try {

--- a/packages/cli/src/setup/agents.ts
+++ b/packages/cli/src/setup/agents.ts
@@ -36,8 +36,8 @@ export interface AgentConfig {
   name: SetupAgent;
   displayName: string;
   mcp: {
-    projectPath: string;
-    globalPath: string;
+    projectPaths: string[];
+    globalPaths: string[];
     configKey: string;
     buildEntry: (auth: AuthOptions) => Record<string, unknown>;
   };
@@ -68,8 +68,8 @@ const agents: Record<SetupAgent, AgentConfig> = {
     name: "claude",
     displayName: "Claude Code",
     mcp: {
-      projectPath: ".mcp.json",
-      globalPath: join(homedir(), ".claude.json"),
+      projectPaths: [".mcp.json"],
+      globalPaths: [join(homedir(), ".claude.json")],
       configKey: "mcpServers",
       buildEntry: (auth) => withHeaders({ type: "http", url: mcpUrl(auth) }, auth),
     },
@@ -94,8 +94,8 @@ const agents: Record<SetupAgent, AgentConfig> = {
     name: "cursor",
     displayName: "Cursor",
     mcp: {
-      projectPath: join(".cursor", "mcp.json"),
-      globalPath: join(homedir(), ".cursor", "mcp.json"),
+      projectPaths: [join(".cursor", "mcp.json")],
+      globalPaths: [join(homedir(), ".cursor", "mcp.json")],
       configKey: "mcpServers",
       buildEntry: (auth) => withHeaders({ url: mcpUrl(auth) }, auth),
     },
@@ -120,8 +120,13 @@ const agents: Record<SetupAgent, AgentConfig> = {
     name: "opencode",
     displayName: "OpenCode",
     mcp: {
-      projectPath: "opencode.json",
-      globalPath: join(homedir(), ".config", "opencode", "opencode.json"),
+      projectPaths: ["opencode.json", "opencode.jsonc", ".opencode.json", ".opencode.jsonc"],
+      globalPaths: [
+        join(homedir(), ".config", "opencode", "opencode.json"),
+        join(homedir(), ".config", "opencode", "opencode.jsonc"),
+        join(homedir(), ".config", "opencode", ".opencode.json"),
+        join(homedir(), ".config", "opencode", ".opencode.jsonc"),
+      ],
       configKey: "mcp",
       buildEntry: (auth) => withHeaders({ type: "remote", url: mcpUrl(auth), enabled: true }, auth),
     },
@@ -137,7 +142,7 @@ const agents: Record<SetupAgent, AgentConfig> = {
         scope === "global" ? join(homedir(), ".agents", "skills") : join(".agents", "skills"),
     },
     detect: {
-      projectPaths: [".opencode.json"],
+      projectPaths: ["opencode.json", "opencode.jsonc", ".opencode.json", ".opencode.jsonc"],
       globalPaths: [join(homedir(), ".config", "opencode")],
     },
   },
@@ -146,8 +151,8 @@ const agents: Record<SetupAgent, AgentConfig> = {
     name: "codex",
     displayName: "Codex",
     mcp: {
-      projectPath: join(".codex", "config.toml"),
-      globalPath: join(homedir(), ".codex", "config.toml"),
+      projectPaths: [join(".codex", "config.toml")],
+      globalPaths: [join(homedir(), ".codex", "config.toml")],
       configKey: "mcp_servers",
       buildEntry: (auth) => {
         const entry: Record<string, unknown> = { type: "http", url: mcpUrl(auth) };

--- a/packages/cli/src/setup/mcp-writer.ts
+++ b/packages/cli/src/setup/mcp-writer.ts
@@ -64,17 +64,16 @@ export function mergeServerEntry(
   };
 }
 
-export async function resolveMcpPath(basePath: string): Promise<string> {
-  if (basePath.endsWith(".json")) {
-    const jsoncPath = basePath.replace(/\.json$/, ".jsonc");
+export async function resolveMcpPath(candidates: string[]): Promise<string> {
+  for (const candidate of candidates) {
     try {
-      await access(jsoncPath);
-      return jsoncPath;
+      await access(candidate);
+      return candidate;
     } catch {
-      return basePath;
+      // continue
     }
   }
-  return basePath;
+  return candidates[0];
 }
 
 export async function writeJsonConfig(


### PR DESCRIPTION
## Summary
- OpenCode supports 4 config file names (`opencode.json`, `opencode.jsonc`, `.opencode.json`, `.opencode.jsonc`) but setup only resolved 2, causing missed detection and writes to wrong files
- Changed `mcp.projectPath`/`globalPath` (single string) to `mcp.projectPaths`/`globalPaths` (string array) so agents can declare all valid config paths
- Simplified `resolveMcpPath` to take a candidates array and return the first existing file, falling back to the first entry for creation

Closes #2313