### PR TITLE
docs: add server URL reference to README and all-clients page

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ npx ctx7 setup
 
 Authenticates via OAuth, generates an API key, and installs the appropriate skill. You can choose between CLI + Skills or MCP mode. Use `--cursor`, `--claude`, or `--opencode` to target a specific agent.
 
+To configure manually, use the Context7 server URL `https://mcp.context7.com/mcp` with your MCP client and pass your API key via the `CONTEXT7_API_KEY` header. See the link below for client-specific setup instructions.
+
 **[Manual Installation / Other Clients →](https://context7.com/docs/resources/all-clients)**
 
 ## Important Tips

--- a/docs/resources/all-clients.mdx
+++ b/docs/resources/all-clients.mdx
@@ -3,7 +3,7 @@ title: MCP Clients
 description: Installation examples for MCP clients
 ---
 
-Context7 supports all MCP clients. The server URL is `https://mcp.context7.com/mcp`. Pass your API key via the `CONTEXT7_API_KEY` header. Below are configuration examples for popular clients. If your client isn't listed, use this URL and check its documentation for how to add an MCP server.
+Context7 supports all MCP clients. Below are configuration examples for popular clients. To configure manually, use the Context7 server URL `https://mcp.context7.com/mcp` with your MCP client and pass your API key via the `CONTEXT7_API_KEY` header.
 
 <Tip>
 Looking for the easiest way to get started? Use `npx ctx7 setup` to configure Context7 automatically. See the [CLI docs](/clients/cli) for more details.

--- a/docs/resources/all-clients.mdx
+++ b/docs/resources/all-clients.mdx
@@ -3,7 +3,7 @@ title: MCP Clients
 description: Installation examples for MCP clients
 ---
 
-Context7 supports all MCP clients. Below are configuration examples for popular clients. To configure manually, use the Context7 server URL `https://mcp.context7.com/mcp` with your MCP client and pass your API key via the `CONTEXT7_API_KEY` header.
+Context7 supports all MCP clients. Below are configuration examples for popular clients.  If your client isn't listed, check its documentation for MCP server installation. To configure manually, use the Context7 server URL `https://mcp.context7.com/mcp` with your MCP client and pass your API key via the `CONTEXT7_API_KEY` header.
 
 <Tip>
 Looking for the easiest way to get started? Use `npx ctx7 setup` to configure Context7 automatically. See the [CLI docs](/clients/cli) for more details.

--- a/docs/resources/all-clients.mdx
+++ b/docs/resources/all-clients.mdx
@@ -3,7 +3,7 @@ title: MCP Clients
 description: Installation examples for MCP clients
 ---
 
-Context7 supports all MCP clients. Below are configuration examples for popular clients. If your client isn't listed, check its documentation for MCP server installation.
+Context7 supports all MCP clients. The server URL is `https://mcp.context7.com/mcp`. Pass your API key via the `CONTEXT7_API_KEY` header. Below are configuration examples for popular clients. If your client isn't listed, use this URL and check its documentation for how to add an MCP server.
 
 <Tip>
 Looking for the easiest way to get started? Use `npx ctx7 setup` to configure Context7 automatically. See the [CLI docs](/clients/cli) for more details.


### PR DESCRIPTION
## Summary
- Adds the remote server URL (`https://mcp.context7.com/mcp`) to the README installation section so users can find it without digging through client-specific configs
- Surfaces the server URL in the all-clients docs page intro paragraph

Resolves user feedback that the server URL was not discoverable in the docs.