### PR TITLE
Add Codex CLI plugin manifest

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "context7",
+  "version": "0.1.0",
+  "description": "Up-to-date code documentation for Codex from Context7",
+  "author": {
+    "name": "upstash",
+    "url": "https://github.com/upstash/context7"
+  },
+  "homepage": "https://github.com/upstash/context7",
+  "repository": "https://github.com/upstash/context7",
+  "keywords": [
+    "mcp",
+    "codex"
+  ],
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "Context7",
+    "shortDescription": "Up-to-date code documentation for Codex from Context7",
+    "longDescription": "Up-to-date code documentation for LLMs and AI code editors.",
+    "category": "Development",
+    "websiteURL": "https://github.com/upstash/context7"
+  },
+  "skills": "./skills/"
+}

--- a/.github/workflows/plugin-quality-gate.yml
+++ b/.github/workflows/plugin-quality-gate.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Codex plugin quality gate
-        uses: hashgraph-online/hol-codex-plugin-scanner-action@b45d6b583afe05819b24edc8e6418c9ad2e1f1d0
+        uses: hashgraph-online/hol-codex-plugin-scanner-action@0f78e6d99032ec198d23a41a8425080a658c07d1
         with:
           plugin_dir: "."
           min_score: 60

--- a/.github/workflows/plugin-quality-gate.yml
+++ b/.github/workflows/plugin-quality-gate.yml
@@ -1,0 +1,28 @@
+name: Plugin Quality Gate
+
+on:
+  pull_request:
+    paths:
+      - ".codex-plugin/**"
+      - "skills/**"
+      - ".mcp.json"
+
+concurrency:
+  group: codex-plugin-scanner-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - name: Codex plugin quality gate
+        uses: hashgraph-online/hol-codex-plugin-scanner-action@b45d6b583afe05819b24edc8e6418c9ad2e1f1d0
+        with:
+          plugin_dir: "."
+          min_score: 60
+          fail_on_severity: high

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "context7": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "ctx7@mcp"
+      ]
+    }
+  }
+}

--- a/skills/context7/SKILL.md
+++ b/skills/context7/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: context7
+description: Up-to-date code documentation for Codex from Context7
+---
+
+# Context7 for Codex
+
+Use Context7 from Codex via MCP.
+
+## When to use
+- When you need context7 capabilities in your Codex workflow
+- See https://github.com/upstash/context7 for full setup instructions


### PR DESCRIPTION
Adds a Codex CLI plugin manifest so Context7 can be installed as a Codex plugin.

**What this adds:**
- `.codex-plugin/plugin.json` — Plugin manifest with metadata
- `.mcp.json` — MCP server reference
- `skills/context7/SKILL.md` — Usage guide for Codex

**Related resources:**
- [awesome-codex-plugins](https://github.com/internet-dot/awesome-codex-plugins) — Curated directory of Codex plugins (open a PR to get listed!)
- [codex-plugin-scanner](https://github.com/hashgraph-online/ai-plugin-scanner) — Security and quality scanner for Codex plugins (scores 0-100, CI action available)