### PR TITLE
feat(cli): add Gemini CLI support to setup command

### DIFF
--- a/.changeset/curly-frogs-glow.md
+++ b/.changeset/curly-frogs-glow.md
@@ -1,0 +1,5 @@
+---
+"ctx7": patch
+---
+
+Add Gemini CLI support to setup command

--- a/packages/cli/src/__tests__/setup.test.ts
+++ b/packages/cli/src/__tests__/setup.test.ts
@@ -42,7 +42,7 @@ describe("getRuleContent", () => {
     expect(cursor).toContain("---\nalwaysApply: true\n---");
     expect(cursor).toContain(MOCK_MCP_RULE);
 
-    for (const agent of ["claude", "codex", "opencode"]) {
+    for (const agent of ["claude", "codex", "opencode", "gemini"]) {
       const content = await getRuleContent("mcp", agent);
       expect(content).not.toContain("alwaysApply");
     }
@@ -789,9 +789,77 @@ describe("agent config integration", () => {
     });
   });
 
+  describe("gemini", () => {
+    const agent = getAgent("gemini");
+
+    test("buildEntry with api-key uses httpUrl", () => {
+      const entry = agent.mcp.buildEntry(apiKeyAuth);
+      expect(entry).toEqual({
+        httpUrl: "https://mcp.context7.com/mcp",
+        headers: { CONTEXT7_API_KEY: "sk-test-123" },
+      });
+      expect(entry).not.toHaveProperty("url");
+    });
+
+    test("buildEntry with oauth uses httpUrl without headers", () => {
+      const entry = agent.mcp.buildEntry(oauthAuth);
+      expect(entry).toEqual({
+        httpUrl: "https://mcp.context7.com/mcp/oauth",
+      });
+    });
+
+    test("uses configKey mcpServers", () => {
+      expect(agent.mcp.configKey).toBe("mcpServers");
+    });
+
+    test("merges into settings.json with mcpServers key", async () => {
+      const path = join(tempDir, "settings.json");
+      await writeJsonConfig(path, { theme: "dark" });
+
+      const existing = await readJsonConfig(path);
+      const { config } = mergeServerEntry(
+        existing,
+        agent.mcp.configKey,
+        "context7",
+        agent.mcp.buildEntry(apiKeyAuth)
+      );
+      await writeJsonConfig(path, config);
+
+      const result = await readJsonConfig(path);
+      expect(result.theme).toBe("dark");
+      expect((result.mcpServers as Record<string, unknown>).context7).toEqual({
+        httpUrl: "https://mcp.context7.com/mcp",
+        headers: { CONTEXT7_API_KEY: "sk-test-123" },
+      });
+    });
+
+    test("overwrites existing config in JSON", async () => {
+      const path = join(tempDir, "settings.json");
+      await writeJsonConfig(path, {
+        mcpServers: { context7: { httpUrl: "https://old.com" } },
+      });
+
+      const existing = await readJsonConfig(path);
+      const { config, alreadyExists } = mergeServerEntry(
+        existing,
+        agent.mcp.configKey,
+        "context7",
+        agent.mcp.buildEntry(apiKeyAuth)
+      );
+      expect(alreadyExists).toBe(true);
+      await writeJsonConfig(path, config);
+
+      const result = await readJsonConfig(path);
+      expect((result.mcpServers as Record<string, unknown>).context7).toEqual({
+        httpUrl: "https://mcp.context7.com/mcp",
+        headers: { CONTEXT7_API_KEY: "sk-test-123" },
+      });
+    });
+  });
+
   describe("all agents have consistent config", () => {
     test("all agents are covered", () => {
-      expect(ALL_AGENT_NAMES).toEqual(["claude", "cursor", "opencode", "codex"]);
+      expect(ALL_AGENT_NAMES).toEqual(["claude", "cursor", "opencode", "codex", "gemini"]);
     });
 
     test.each(ALL_AGENT_NAMES)("%s buildEntry returns url for both auth modes", (name) => {
@@ -799,8 +867,9 @@ describe("agent config integration", () => {
       const apiEntry = agent.mcp.buildEntry(apiKeyAuth);
       const oauthEntry = agent.mcp.buildEntry(oauthAuth);
 
-      expect(apiEntry.url).toBe("https://mcp.context7.com/mcp");
-      expect(oauthEntry.url).toBe("https://mcp.context7.com/mcp/oauth");
+      const urlKey = name === "gemini" ? "httpUrl" : "url";
+      expect(apiEntry[urlKey]).toBe("https://mcp.context7.com/mcp");
+      expect(oauthEntry[urlKey]).toBe("https://mcp.context7.com/mcp/oauth");
     });
 
     test.each(ALL_AGENT_NAMES)("%s buildEntry includes headers only for api-key auth", (name) => {

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -41,6 +41,7 @@ interface SetupOptions {
   antigravity?: boolean;
   opencode?: boolean;
   codex?: boolean;
+  gemini?: boolean;
   project?: boolean;
   yes?: boolean;
   apiKey?: string;
@@ -62,6 +63,7 @@ function getSelectedAgents(options: SetupOptions): SetupAgent[] {
   if (options.cursor) agents.push("cursor");
   if (options.opencode) agents.push("opencode");
   if (options.codex) agents.push("codex");
+  if (options.gemini) agents.push("gemini");
   return agents;
 }
 
@@ -75,6 +77,7 @@ export function registerSetupCommand(program: Command): void {
     .option("--antigravity", "Set up for Antigravity (.agent/skills)")
     .option("--opencode", "Set up for OpenCode")
     .option("--codex", "Set up for Codex")
+    .option("--gemini", "Set up for Gemini CLI")
     .option("--mcp", "Set up MCP server mode")
     .option("--cli", "Set up CLI + Skills mode (no MCP server)")
     .option("-p, --project", "Configure for current project instead of globally")
@@ -379,6 +382,11 @@ async function setupMcp(agents: SetupAgent[], options: SetupOptions, scope: Scop
     const skillIcon = r.skillStatus === "installed" ? pc.green("+") : pc.dim("~");
     log.plain(`    ${skillIcon} Skill ${r.skillStatus}`);
     log.plain(`      ${pc.dim(r.skillPath)}`);
+    if (r.skillStatus.includes("EACCES")) {
+      log.plain(
+        `      ${pc.yellow("tip:")} fix permissions with: ${pc.cyan(`sudo chown -R $(whoami) ${dirname(dirname(r.skillPath))}`)}`
+      );
+    }
   }
   log.blank();
 
@@ -461,6 +469,11 @@ async function setupCli(options: SetupOptions): Promise<void> {
     const skillIcon = r.skillStatus === "installed" ? pc.green("+") : pc.dim("~");
     log.plain(`    ${skillIcon} Skill ${r.skillStatus}`);
     log.plain(`      ${pc.dim(r.skillPath)}`);
+    if (r.skillStatus.includes("EACCES")) {
+      log.plain(
+        `      ${pc.yellow("tip:")} fix permissions with: ${pc.cyan(`sudo chown -R $(whoami) ${dirname(dirname(r.skillPath))}`)}`
+      );
+    }
     const ruleIcon =
       r.ruleStatus === "installed" || r.ruleStatus === "updated" ? pc.green("+") : pc.dim("~");
     log.plain(`    ${ruleIcon} Rule ${r.ruleStatus}`);

--- a/packages/cli/src/setup/agents.ts
+++ b/packages/cli/src/setup/agents.ts
@@ -2,7 +2,7 @@ import { access } from "fs/promises";
 import { join } from "path";
 import { homedir } from "os";
 
-export type SetupAgent = "claude" | "cursor" | "opencode" | "codex";
+export type SetupAgent = "claude" | "cursor" | "opencode" | "codex" | "gemini";
 export type AuthMode = "oauth" | "api-key";
 
 export interface AuthOptions {
@@ -15,6 +15,7 @@ export const SETUP_AGENT_NAMES: Record<SetupAgent, string> = {
   cursor: "Cursor",
   opencode: "OpenCode",
   codex: "Codex",
+  gemini: "Gemini CLI",
 };
 
 export const AUTH_MODE_LABELS: Record<AuthMode, string> = {
@@ -175,6 +176,31 @@ const agents: Record<SetupAgent, AgentConfig> = {
     detect: {
       projectPaths: [".codex"],
       globalPaths: [join(homedir(), ".codex")],
+    },
+  },
+
+  gemini: {
+    name: "gemini",
+    displayName: "Gemini CLI",
+    mcp: {
+      projectPaths: [join(".gemini", "settings.json")],
+      globalPaths: [join(homedir(), ".gemini", "settings.json")],
+      configKey: "mcpServers",
+      buildEntry: (auth) => withHeaders({ httpUrl: mcpUrl(auth) }, auth),
+    },
+    rule: {
+      kind: "append",
+      file: (scope) => (scope === "global" ? join(homedir(), ".gemini", "GEMINI.md") : "GEMINI.md"),
+      sectionMarker: "<!-- context7 -->",
+    },
+    skill: {
+      name: "context7-mcp",
+      dir: (scope) =>
+        scope === "global" ? join(homedir(), ".gemini", "skills") : join(".gemini", "skills"),
+    },
+    detect: {
+      projectPaths: [".gemini"],
+      globalPaths: [join(homedir(), ".gemini")],
     },
   },
 };


### PR DESCRIPTION
## Summary

- Adds Gemini CLI as a supported agent in `ctx7 setup --gemini`
- Configures MCP server in `.gemini/settings.json` using `httpUrl` (Gemini's HTTP streaming transport), rules in `GEMINI.md`, and skills in `.gemini/skills/`
- Adds a permission fix tip (`sudo chown -R ...`) when skill installation fails with EACCES errors (applies to all agents)