### PR TITLE
fix(mcp): combine system root CAs with custom CA to prevent TLS errors

### DIFF
--- a/packages/mcp/src/lib/api.ts
+++ b/packages/mcp/src/lib/api.ts
@@ -3,6 +3,7 @@ import { ClientContext, generateHeaders } from "./encryption.js";
 import { Agent, ProxyAgent, setGlobalDispatcher } from "undici";
 import { CONTEXT7_API_BASE_URL } from "./constants.js";
 import { readFileSync } from "fs";
+import tls from "tls";
 
 /**
  * Parses error response from the Context7 API
@@ -45,10 +46,14 @@ const PROXY_URL: string | null =
 
 const CUSTOM_CA_CERTS: string | undefined = process.env.NODE_EXTRA_CA_CERTS;
 
-function loadCustomCACerts(): Buffer | undefined {
+function loadCustomCACerts(): (string | Buffer)[] | undefined {
   if (!CUSTOM_CA_CERTS) return undefined;
   try {
-    return readFileSync(CUSTOM_CA_CERTS);
+    const customCa = readFileSync(CUSTOM_CA_CERTS);
+    if (tls.rootCertificates.length > 0) {
+      return [...tls.rootCertificates, customCa];
+    }
+    return [customCa];
   } catch (error) {
     console.error(
       `[Context7] Failed to load custom CA certificates from ${CUSTOM_CA_CERTS}:`,


### PR DESCRIPTION
## Summary

- `loadCustomCACerts()` now combines `tls.rootCertificates` (system CAs) with the custom CA from `NODE_EXTRA_CA_CERTS`
- Falls back to custom CA only when `tls.rootCertificates` is empty (e.g. Windows)

## Problem

PR #2271 reads `NODE_EXTRA_CA_CERTS` and passes it as `connect.ca` to undici's `Agent`/`ProxyAgent`. However, `connect.ca` **replaces** the entire system CA bundle rather than appending to it. When a custom CA is set (e.g. Laravel Herd, corporate proxies), HTTPS requests to external services like `context7.com` fail with:

```
TypeError: fetch failed
cause: Error: unable to get local issuer certificate (UNABLE_TO_GET_ISSUER_CERT_LOCALLY)
```

## Solution

Use `tls.rootCertificates` to include system root CAs alongside the custom CA, so both are trusted when `setGlobalDispatcher` overrides the global fetch dispatcher.

## Behavior Change

Previously, specifying `NODE_EXTRA_CA_CERTS` replaced the default trust store.
After this change, the custom CA is appended to the system trust store.

This aligns with user expectations but may affect setups that intentionally
relied on strict CA pinning.

Fixes #2426 (follow-up to #2268 / #2271)