### PR TITLE
fix: skill installation path check compatibility for Windows

### DIFF
--- a/.changeset/bright-pants-hug.md
+++ b/.changeset/bright-pants-hug.md
@@ -1,0 +1,5 @@
+---
+"ctx7": patch
+---
+
+Fix skill installation path validation on Windows so valid files inside the target directory are not rejected due to backslash-separated resolved paths.

--- a/packages/cli/src/utils/installer.ts
+++ b/packages/cli/src/utils/installer.ts
@@ -14,7 +14,11 @@ export async function installSkillFiles(
     const filePath = resolve(skillDir, file.path);
 
     // Prevent directory traversal — resolved path must stay within skillDir
-    if (!filePath.startsWith(skillDir + "/") && !filePath.startsWith(skillDir + "\\") && filePath !== skillDir) {
+    if (
+      !filePath.startsWith(skillDir + "/") &&
+      !filePath.startsWith(skillDir + "\\") &&
+      filePath !== skillDir
+    ) {
       throw new Error(`Skill file path "${file.path}" resolves outside the target directory`);
     }
 

--- a/packages/cli/src/utils/installer.ts
+++ b/packages/cli/src/utils/installer.ts
@@ -14,7 +14,7 @@ export async function installSkillFiles(
     const filePath = resolve(skillDir, file.path);
 
     // Prevent directory traversal — resolved path must stay within skillDir
-    if (!filePath.startsWith(skillDir + "/") && filePath !== skillDir) {
+    if (!filePath.startsWith(skillDir + "/") && !filePath.startsWith(skillDir + "\\") && filePath !== skillDir) {
       throw new Error(`Skill file path "${file.path}" resolves outside the target directory`);
     }
 


### PR DESCRIPTION
The path security check in `installSkillFiles` was hardcoded to use forward slashes (`/`). 
On Windows systems, `path.resolve` returns backslashes (`\`), causing valid paths to be 
rejected with an "outside the target directory" error.

This PR adds a check for backslashes to ensure cross-platform compatibility.