### PR TITLE
Handle Codex CLI sandbox DNS failures in setup

### DIFF
--- a/.changeset/five-swans-learn.md
+++ b/.changeset/five-swans-learn.md
@@ -1,0 +1,5 @@
+---
+"ctx7": patch
+---
+
+Add Codex-specific CLI setup guidance so generated rules and the installed `find-docs` skill tell Codex to rerun Context7 CLI requests outside the default sandbox after DNS or network failures.

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -22,7 +22,7 @@ import {
   getAgent,
   detectAgents,
 } from "../setup/agents.js";
-import { getRuleContent } from "../setup/templates.js";
+import { customizeSkillFilesForAgent, getRuleContent } from "../setup/templates.js";
 import {
   readJsonConfig,
   mergeServerEntry,
@@ -407,7 +407,8 @@ async function setupCliAgent(
       : join(process.cwd(), agent.skill.dir("project"));
   let skillStatus: string;
   try {
-    await installSkillFiles("find-docs", downloadData.files, skillDir);
+    const files = customizeSkillFilesForAgent(agentName, "find-docs", downloadData.files);
+    await installSkillFiles("find-docs", files, skillDir);
     skillStatus = "installed";
   } catch (err) {
     skillStatus = `failed: ${err instanceof Error ? err.message : String(err)}`;

--- a/packages/cli/src/setup/templates.ts
+++ b/packages/cli/src/setup/templates.ts
@@ -56,7 +56,7 @@ export async function getRuleContent(mode: RuleMode, agent: string): Promise<str
   let body = await fetchRule(filename, fallback);
 
   if (mode === "cli" && agent === "codex" && !body.includes(CODEX_CLI_SANDBOX_GUIDANCE)) {
-    body += `\n\n${CODEX_CLI_SANDBOX_GUIDANCE}\n`;
+    body = `${body.trimEnd()}\n${CODEX_CLI_SANDBOX_GUIDANCE}\n`;
   }
 
   return agent === "cursor" ? `${CURSOR_FRONTMATTER}${body}` : body;

--- a/packages/cli/src/setup/templates.ts
+++ b/packages/cli/src/setup/templates.ts
@@ -76,7 +76,7 @@ export function customizeSkillFilesForAgent(
       return file;
     }
 
-    const marker = "## Common Mistakes";
+    const marker = "## Step 1: Resolve a Library";
     const guidance = `${CODEX_CLI_SANDBOX_GUIDANCE}\n\n`;
 
     if (file.content.includes(marker)) {

--- a/packages/cli/src/setup/templates.ts
+++ b/packages/cli/src/setup/templates.ts
@@ -34,6 +34,7 @@ If a command fails with a quota error, inform the user and suggest \`npx ctx7@la
 `;
 
 const CURSOR_FRONTMATTER = `---\nalwaysApply: true\n---\n\n`;
+const CODEX_CLI_SANDBOX_GUIDANCE = `Run Context7 CLI requests outside Codex's default sandbox. If a Context7 CLI command fails with DNS or network errors such as ENOTFOUND, host resolution failures, or fetch failed, rerun it outside the sandbox instead of retrying inside the sandbox.`;
 
 export type RuleMode = "mcp" | "cli";
 
@@ -52,6 +53,43 @@ async function fetchRule(filename: string, fallback: string): Promise<string> {
 export async function getRuleContent(mode: RuleMode, agent: string): Promise<string> {
   const [filename, fallback] =
     mode === "mcp" ? ["context7-mcp.md", FALLBACK_MCP] : ["context7-cli.md", FALLBACK_CLI];
-  const body = await fetchRule(filename, fallback);
+  let body = await fetchRule(filename, fallback);
+
+  if (mode === "cli" && agent === "codex" && !body.includes(CODEX_CLI_SANDBOX_GUIDANCE)) {
+    body += `\n\n${CODEX_CLI_SANDBOX_GUIDANCE}\n`;
+  }
+
   return agent === "cursor" ? `${CURSOR_FRONTMATTER}${body}` : body;
+}
+
+export function customizeSkillFilesForAgent(
+  agent: string,
+  skillName: string,
+  files: Array<{ path: string; content: string }>
+): Array<{ path: string; content: string }> {
+  if (agent !== "codex" || skillName !== "find-docs") {
+    return files;
+  }
+
+  return files.map((file) => {
+    if (file.path !== "SKILL.md" || file.content.includes(CODEX_CLI_SANDBOX_GUIDANCE)) {
+      return file;
+    }
+
+    const marker = "## Common Mistakes";
+    const guidance = `${CODEX_CLI_SANDBOX_GUIDANCE}\n\n`;
+
+    if (file.content.includes(marker)) {
+      return {
+        ...file,
+        content: file.content.replace(marker, `${guidance}${marker}`),
+      };
+    }
+
+    const separator = file.content.endsWith("\n") ? "\n" : "\n\n";
+    return {
+      ...file,
+      content: `${file.content}${separator}${CODEX_CLI_SANDBOX_GUIDANCE}\n`,
+    };
+  });
 }


### PR DESCRIPTION
## Summary
- append Codex-specific CLI sandbox networking guidance only for Codex CLI rules
- inject the same guidance into the installed find-docs skill when ctx7 setup targets Codex
- leave MCP guidance and non-Codex agents unchanged

## Testing
- not run (per request: no test-file edits)