### PR TITLE
fix(plugin): add missing name and allowed-tools to docs command frontmatter

### DIFF
--- a/plugins/claude/context7/commands/docs.md
+++ b/plugins/claude/context7/commands/docs.md
@@ -1,6 +1,8 @@
 ---
+name: docs
 description: Look up documentation for any library
 argument-hint: <library> [query]
+allowed-tools: [resolve-library-id, query-docs]
 ---
 
 # /context7:docs


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## What and Why

The \`plugins/claude/context7/commands/docs.md\` frontmatter was missing two fields:

**1. Missing \`name\` field**

Claude Code uses the \`name\` field to register commands in strict plugin systems and to surface them via \`/help\`. Without it, the command is registered by filename inference only — which may fail in future plugin host versions or when multiple plugins define similarly-named commands.

**2. Missing \`allowed-tools\` field**

The command body calls two MCP tools (\`resolve-library-id\` and \`query-docs\`) but declares no \`allowed-tools\` in the frontmatter. Plugin hosts that enforce declared-tool allowlists will reject these calls at runtime, causing the command to silently fail.

## Fix

Added both fields to the frontmatter:

\`\`\`yaml
name: docs
allowed-tools: [resolve-library-id, query-docs]
\`\`\`

No logic changes — this is a pure manifest fix matching the existing style of the frontmatter block.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"BUG-missing-frontmatter","fingerprint":"sha256:de76bede1ce4edcdb14d261df159c1b414d78757f705174626648a9f9ed345d0"},{"rule_id":"BUG-undeclared-tool","fingerprint":"sha256:c2f552d3c220e979d92596e9e0fe52fdeb0436bdcae135c57b8aaccefa15fe33"}]}
nlpm-metadata-end -->