### PR TITLE
fix(mcp): stream tool-call responses so headers flush before 60s

### DIFF
--- a/.changeset/stream-mcp-tool-responses.md
+++ b/.changeset/stream-mcp-tool-responses.md
@@ -2,4 +2,11 @@
 "@upstash/context7-mcp": patch
 ---
 
-Stream tool-call responses over SSE so headers flush before clients hit their fetch timeout. Long-running tools (notably `query-docs` with `researchMode: true`) previously kept the HTTP response buffered until the upstream call finished, causing MCP HTTP clients with a per-request fetch cap (e.g., Claude Code's 60s `wrapFetchWithTimeout`) to give up before headers arrived. Switching `enableJsonResponse` to `false` makes the SDK return the response synchronously after request validation; the body streams while the tool runs.
+Keep long-running MCP tool calls (notably `query-docs` with `researchMode: true`) alive past client timeouts.
+
+Two server-side changes work together:
+
+- **Stream tool responses over SSE.** Switching `enableJsonResponse` to `false` makes the SDK return the HTTP response synchronously after request validation, so headers flush in milliseconds instead of being buffered until the tool completes. Fixes clients that cap the underlying `fetch` waiting for headers (e.g., Claude Code's 60s `wrapFetchWithTimeout`).
+- **Emit periodic `notifications/progress` from `query-docs`.** Resets the JSON-RPC request timer on clients that pass `resetTimeoutOnProgress: true` (e.g., opencode), which would otherwise hit the MCP SDK's default 60s `DEFAULT_REQUEST_TIMEOUT_MSEC` regardless of byte flow.
+
+Clients that don't include a `progressToken` simply never see the notifications — no behavior change for them.

--- a/.changeset/stream-mcp-tool-responses.md
+++ b/.changeset/stream-mcp-tool-responses.md
@@ -1,0 +1,5 @@
+---
+"@upstash/context7-mcp": patch
+---
+
+Stream tool-call responses over SSE so headers flush before clients hit their fetch timeout. Long-running tools (notably `query-docs` with `researchMode: true`) previously kept the HTTP response buffered until the upstream call finished, causing MCP HTTP clients with a per-request fetch cap (e.g., Claude Code's 60s `wrapFetchWithTimeout`) to give up before headers arrived. Switching `enableJsonResponse` to `false` makes the SDK return the response synchronously after request validation; the body streams while the tool runs.

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -403,9 +403,16 @@ async function main() {
           transport: "http",
         };
 
+        // Use SSE responses for tool calls (enableJsonResponse: false). The SDK then
+        // flushes response headers immediately after parsing the request rather than
+        // buffering until the tool returns. This is required for long-running tools
+        // (e.g. researchMode) because some MCP HTTP clients cap the underlying fetch
+        // at 60s waiting for headers, even though the per-tool timeout is much higher.
+        // Note: GET SSE streams remain rejected above — that's the channel the earlier
+        // NGINX-timeout comment is about, not these per-request POST SSE responses.
         const transport = new StreamableHTTPServerTransport({
           sessionIdGenerator: undefined,
-          enableJsonResponse: true,
+          enableJsonResponse: false,
         });
 
         res.on("close", () => {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -274,20 +274,49 @@ Workflow: call first without researchMode. If that doesn't answer the question, 
       readOnlyHint: true,
     },
   },
-  async ({ query, libraryId, researchMode }) => {
-    const response = await fetchLibraryContext(
-      { query, libraryId, researchMode },
-      getClientContext()
-    );
+  async ({ query, libraryId, researchMode }, { sendNotification, _meta }) => {
+    // Emit periodic progress notifications while the upstream call is in flight.
+    // MCP clients that opt into resetTimeoutOnProgress (e.g. opencode) reset their
+    // request timer on each notification, which keeps long-running tools (notably
+    // researchMode) alive past the SDK's default 60s wall-clock timeout. Clients
+    // that don't pass a progressToken simply never see these — no behavior change.
+    const progressToken = _meta?.progressToken;
+    let progressInterval: ReturnType<typeof setInterval> | undefined;
+    if (researchMode && progressToken !== undefined) {
+      let progress = 0;
+      progressInterval = setInterval(() => {
+        progress += 1;
+        sendNotification({
+          method: "notifications/progress",
+          params: {
+            progressToken,
+            progress,
+            message: "Researching documentation…",
+          },
+        }).catch(() => {
+          // Notifications are best-effort; swallow transport errors so the tool
+          // call itself isn't aborted by a notification write failure.
+        });
+      }, 20_000);
+    }
 
-    return {
-      content: [
-        {
-          type: "text",
-          text: response.data,
-        },
-      ],
-    };
+    try {
+      const response = await fetchLibraryContext(
+        { query, libraryId, researchMode },
+        getClientContext()
+      );
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: response.data,
+          },
+        ],
+      };
+    } finally {
+      if (progressInterval) clearInterval(progressInterval);
+    }
   }
 );
 

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -254,7 +254,7 @@ server.registerTool(
 
 You must call 'Resolve Context7 Library ID' tool first to obtain the exact Context7-compatible library ID required to use this tool, UNLESS the user explicitly provides a library ID in the format '/org/project' or '/org/project/version' in their query.
 
-Do not call this tool more than 3 times per question.`,
+Workflow: call first without researchMode. If that doesn't answer the question, retry with researchMode: true. Do not call each tool more than 3 times per question.`,
     inputSchema: {
       libraryId: z
         .string()
@@ -266,6 +266,12 @@ Do not call this tool more than 3 times per question.`,
         .describe(
           "The question or task you need help with. Be specific and include relevant details. Good: 'How to set up authentication with JWT in Express.js' or 'React useEffect cleanup function examples'. Bad: 'auth' or 'hooks'. The query is sent to the Context7 API for processing. Do not include any sensitive or confidential information such as API keys, passwords, credentials, personal data, or proprietary code in your query."
         ),
+      researchMode: z
+        .boolean()
+        .optional()
+        .describe(
+          `Retry the query with deep research: spins up sandboxed agents that read the actual source repos and runs a live web search, then synthesizes a fresh answer. Set true on retry if you weren't satisfied with the first answer and want a more thorough one. Requires an API key. You can get one free at https://context7.com.`
+        ),
     },
     annotations: {
       readOnlyHint: true,
@@ -274,17 +280,49 @@ Do not call this tool more than 3 times per question.`,
       idempotentHint: true,
     },
   },
-  async ({ query, libraryId }) => {
-    const response = await fetchLibraryContext({ query, libraryId }, getClientContext());
+  async ({ query, libraryId, researchMode }, { sendNotification, _meta }) => {
+    // Emit periodic progress notifications while the upstream call is in flight.
+    // MCP clients that opt into resetTimeoutOnProgress (e.g. opencode) reset their
+    // request timer on each notification, which keeps long-running tools (notably
+    // researchMode) alive past the SDK's default 60s wall-clock timeout. Clients
+    // that don't pass a progressToken simply never see these, so behavior is unchanged.
+    const progressToken = _meta?.progressToken;
+    let progressInterval: ReturnType<typeof setInterval> | undefined;
+    if (researchMode && progressToken !== undefined) {
+      let progress = 0;
+      progressInterval = setInterval(() => {
+        progress += 1;
+        sendNotification({
+          method: "notifications/progress",
+          params: {
+            progressToken,
+            progress,
+            message: "Researching documentation...",
+          },
+        }).catch(() => {
+          // Notifications are best-effort; swallow transport errors so the tool
+          // call itself isn't aborted by a notification write failure.
+        });
+      }, 20_000);
+    }
 
-    return {
-      content: [
-        {
-          type: "text",
-          text: response.data,
-        },
-      ],
-    };
+    try {
+      const response = await fetchLibraryContext(
+        { query, libraryId, researchMode },
+        getClientContext()
+      );
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: response.data,
+          },
+        ],
+      };
+    } finally {
+      if (progressInterval) clearInterval(progressInterval);
+    }
   }
 );
 

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -408,8 +408,6 @@ async function main() {
         // buffering until the tool returns. This is required for long-running tools
         // (e.g. researchMode) because some MCP HTTP clients cap the underlying fetch
         // at 60s waiting for headers, even though the per-tool timeout is much higher.
-        // Note: GET SSE streams remain rejected above — that's the channel the earlier
-        // NGINX-timeout comment is about, not these per-request POST SSE responses.
         const transport = new StreamableHTTPServerTransport({
           sessionIdGenerator: undefined,
           enableJsonResponse: false,


### PR DESCRIPTION
## Summary

`StreamableHTTPServerTransport` runs in JSON mode, so tool responses are buffered and headers don't flush until the tool returns. Research-mode `query-docs` calls take 60–250s — clients capping the fetch on header arrival (Claude Code: hardcoded 60s) fail with "operation timed out" even though the server completes the request.

Switching to SSE mode makes the SDK flush headers immediately after request parsing; the body streams while the tool runs. Same total time, but clients see headers in ms.

## Evidence

Production curl, `researchMode: true` on `/vercel/next.js`:

```
start_transfer=124.93s
total=124.93s   (delta ~3ms)
Content-Type: application/json
```

Server is silent for 125s then flushes everything at once. Any client with a fetch-level timeout < 125s fails.