### PR TITLE
chore(mcp): remove researchMode from query-docs tool params

### DIFF
--- a/.changeset/hide-research-mode-from-mcp.md
+++ b/.changeset/hide-research-mode-from-mcp.md
@@ -1,0 +1,5 @@
+---
+"@upstash/context7-mcp": patch
+---
+
+Remove the `researchMode` parameter from the `query-docs` tool's input schema. The underlying API still supports research mode, but several MCP clients hit per-request timeouts (60s defaults) on long-running research calls in ways that can't always be solved server-side. Hiding the parameter prevents agents from invoking it through MCP until the timeout story is reliable across clients.

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -254,7 +254,7 @@ server.registerTool(
 
 You must call 'Resolve Context7 Library ID' tool first to obtain the exact Context7-compatible library ID required to use this tool, UNLESS the user explicitly provides a library ID in the format '/org/project' or '/org/project/version' in their query.
 
-Workflow: call first without researchMode. If that doesn't answer the question, retry with researchMode: true. Do not call each tool more than 3 times per question`,
+Do not call this tool more than 3 times per question.`,
     inputSchema: {
       libraryId: z
         .string()
@@ -266,12 +266,6 @@ Workflow: call first without researchMode. If that doesn't answer the question, 
         .describe(
           "The question or task you need help with. Be specific and include relevant details. Good: 'How to set up authentication with JWT in Express.js' or 'React useEffect cleanup function examples'. Bad: 'auth' or 'hooks'. The query is sent to the Context7 API for processing. Do not include any sensitive or confidential information such as API keys, passwords, credentials, personal data, or proprietary code in your query."
         ),
-      researchMode: z
-        .boolean()
-        .optional()
-        .describe(
-          `Retry the query with deep research: spins up sandboxed agents that read the actual source repos and runs a live web search, then synthesizes a fresh answer. Set true on retry if you weren't satisfied with the first answer and want a more thorough one. Requires an API key — you can get one free at https://context7.com.`
-        ),
     },
     annotations: {
       readOnlyHint: true,
@@ -280,11 +274,8 @@ Workflow: call first without researchMode. If that doesn't answer the question, 
       idempotentHint: true,
     },
   },
-  async ({ query, libraryId, researchMode }) => {
-    const response = await fetchLibraryContext(
-      { query, libraryId, researchMode },
-      getClientContext()
-    );
+  async ({ query, libraryId }) => {
+    const response = await fetchLibraryContext({ query, libraryId }, getClientContext());
 
     return {
       content: [


### PR DESCRIPTION
Hide the `researchMode` parameter from the MCP tool's input schema so agents stop invoking it. The upstream `/api/v2/context` route still accepts and serves the parameter; only the MCP-layer surface is removed. Reasoning: several MCP clients hit per-request timeouts (60s defaults in the SDK and in fetch-wrappers) on long-running research calls in ways that can't all be solved server-side. Until the timeout story is reliable across clients, agents shouldn't be able to call it via MCP.

Updates:
- Drop the `researchMode` field from the `query-docs` input schema.
- Drop the workflow line in the tool description that referenced it.
- Stop forwarding `researchMode` to fetchLibraryContext; the field is optional on ContextRequest, so omitting it is equivalent to false.