### PR TITLE
docs(i18n): sync zh-CN README with current main

### DIFF
--- a/.auto-pr/target-repo.txt
+++ b/.auto-pr/target-repo.txt
@@ -1,0 +1,1 @@
+upstash/context7

--- a/.auto-pr/target-repo.txt
+++ b/.auto-pr/target-repo.txt
@@ -1,1 +1,0 @@
-upstash/context7

--- a/i18n/README.zh-CN.md
+++ b/i18n/README.zh-CN.md
@@ -2,9 +2,9 @@
 
 [![安装 MCP 服务器](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en/install-mcp?name=context7&config=eyJ1cmwiOiJodHRwczovL21jcC5jb250ZXh0Ny5jb20vbWNwIn0%3D)
 
-# Context7 MCP - 最新文档赋能每个提示词
+# Context7 平台 - 最新代码文档赋能每个提示词
 
-[![Website](https://img.shields.io/badge/Website-context7.com-blue)](https://context7.com) [![smithery badge](https://smithery.ai/badge/@upstash/context7-mcp)](https://smithery.ai/server/@upstash/context7-mcp) [![NPM Version](https://img.shields.io/npm/v/%40upstash%2Fcontext7-mcp?color=red)](https://www.npmjs.com/package/@upstash/context7-mcp) [![MIT licensed](https://img.shields.io/npm/l/%40upstash%2Fcontext7-mcp)](./LICENSE)
+[![Website](https://img.shields.io/badge/Website-context7.com-blue)](https://context7.com) [![smithery badge](https://smithery.ai/badge/@upstash/context7-mcp)](https://smithery.ai/server/@upstash/context7-mcp) [![NPM Version](https://img.shields.io/npm/v/%40upstash%2Fcontext7-mcp?color=red)](https://www.npmjs.com/package/@upstash/context7-mcp) [![MIT licensed](https://img.shields.io/npm/l/%40upstash%2Fcontext7-mcp)](../LICENSE)
 
 [![English](https://img.shields.io/badge/docs-English-purple)](../README.md) [![繁體中文](https://img.shields.io/badge/docs-繁體中文-yellow)](./README.zh-TW.md) [![日本語](https://img.shields.io/badge/docs-日本語-b7003a)](./README.ja.md) [![한국어 문서](https://img.shields.io/badge/docs-한국어-green)](./README.ko.md) [![Documentación en Español](https://img.shields.io/badge/docs-Español-orange)](./README.es.md) [![Documentation en Français](https://img.shields.io/badge/docs-Français-blue)](./README.fr.md) [![Documentação em Português (Brasil)](<https://img.shields.io/badge/docs-Português%20(Brasil)-purple>)](./README.pt-BR.md) [![Documentazione in italiano](https://img.shields.io/badge/docs-Italian-red)](./README.it.md) [![Dokumentasi Bahasa Indonesia](https://img.shields.io/badge/docs-Bahasa%20Indonesia-pink)](./README.id-ID.md) [![Dokumentation auf Deutsch](https://img.shields.io/badge/docs-Deutsch-darkgreen)](./README.de.md) [![Документация на русском языке](https://img.shields.io/badge/docs-Русский-darkblue)](./README.ru.md) [![Українська документація](https://img.shields.io/badge/docs-Українська-lightblue)](./README.uk.md) [![Türkçe Doküman](https://img.shields.io/badge/docs-Türkçe-blue)](./README.tr.md) [![Arabic Documentation](https://img.shields.io/badge/docs-Arabic-white)](./README.ar.md) [![Tiếng Việt](https://img.shields.io/badge/docs-Tiếng%20Việt-red)](./README.vi.md)
 
@@ -18,197 +18,107 @@
 
 ## ✅ 使用Context7
 
-Context7 MCP直接从源头获取最新的、特定版本的文档和代码示例——并将它们直接放入你的提示词中。
-
-在你的提示词中附上`用context7`（或[设置规则](#添加规则)自动调用）：
+Context7直接从源头获取最新的、特定版本的文档和代码示例——并将它们直接放入你的提示词中。
 
 ```txt
 创建一个Next.js中间件，检查cookies中的有效JWT，
-并将未认证用户重定向到 `/login`。用context7
+并将未认证用户重定向到 `/login`。use context7
 ```
 
 ```txt
 配置Cloudflare Worker脚本，将JSON API响应
-缓存五分钟。用context7
+缓存五分钟。use context7
+```
+
+```txt
+查看Supabase的邮箱/密码注册Auth API。
 ```
 
 Context7将最新的代码示例和文档直接获取到你的LLM上下文中。无需切换标签页，不会因幻觉产生不存在的API，不会生成过时的代码。
 
+支持两种模式：
+
+- **CLI + Skills** — 安装一个skill，引导你的代理使用 `ctx7` CLI命令获取文档（无需MCP）
+- **MCP** — 注册一个Context7 MCP服务器，使你的代理能够原生调用文档工具
+
 ## 安装
 
 > [!NOTE]
-> **推荐使用API密钥**：在[context7.com/dashboard](https://context7.com/dashboard)s获取免费API密钥，使用秘钥后速率限制更高。
+> **推荐使用API密钥**：在 [context7.com/dashboard](https://context7.com/dashboard) 获取免费API密钥，使用密钥后速率限制更高。
 
-<details>
-<summary><b>在Cursor中安装</b></summary>
+只需一条命令，即可为你的编码代理配置Context7：
 
-前往：`Settings` -> `Cursor Settings` -> `MCP` -> `Add new global MCP server`
-
-推荐将以下配置粘贴到你的Cursor `~/.cursor/mcp.json` 文件中。你也可以通过在项目文件夹中创建 `.cursor/mcp.json` 在特定项目中安装。更多信息请参阅 [Cursor MCP 文档](https://docs.cursor.com/context/model-context-protocol)。
-
-> 自Cursor 1.0起，你可以点击下面的安装按钮一键安装。
-
-#### Cursor远程服务器连接
-
-[![安装 MCP 服务器](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en/install-mcp?name=context7&config=eyJ1cmwiOiJodHRwczovL21jcC5jb250ZXh0Ny5jb20vbWNwIn0%3D)
-
-```json
-{
-  "mcpServers": {
-    "context7": {
-      "url": "https://mcp.context7.com/mcp",
-      "headers": {
-        "CONTEXT7_API_KEY": "YOUR_API_KEY"
-      }
-    }
-  }
-}
+```bash
+npx ctx7 setup
 ```
 
-#### Cursor本地服务器连接
+通过OAuth认证，生成API密钥，并安装相应的skill。你可以选择CLI+Skills模式或MCP模式。使用 `--cursor`、`--claude` 或 `--opencode` 指定目标代理。
 
-[![安装MCP服务器](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en/install-mcp?name=context7&config=eyJjb21tYW5kIjoibnB4IC15IEB1cHN0YXNoL2NvbnRleHQ3LW1jcCJ9)
+如需稍后移除生成的配置，运行 `npx ctx7 remove`。如果通过 `npm install -g ctx7` 全局安装了CLI，需单独运行 `npm uninstall -g ctx7` 卸载该包。
 
-```json
-{
-  "mcpServers": {
-    "context7": {
-      "command": "npx",
-      "args": ["-y", "@upstash/context7-mcp", "--api-key", "YOUR_API_KEY"]
-    }
-  }
-}
-```
+如需手动配置，请将Context7服务器URL `https://mcp.context7.com/mcp` 添加到你的MCP客户端，并通过 `CONTEXT7_API_KEY` 请求头传递API密钥。详见下方链接的各客户端配置说明。
 
-</details>
-
-<details>
-<summary><b>在Claude Code中安装</b></summary>
-
-运行以下命令。更多信息请参见[Claude Code MCP文档](https://code.claude.com/docs/zh-CN/mcp)。
-
-#### Claude Code本地服务器连接
-
-```sh
-claude mcp add --scope user context7 -- npx -y @upstash/context7-mcp --api-key YOUR_API_KEY
-```
-
-#### Claude Code远程服务器连接
-
-```sh
-claude mcp add --scope user --header "CONTEXT7_API_KEY: YOUR_API_KEY" --transport http context7 https://mcp.context7.com/mcp
-```
-
-</details>
-
-<details>
-<summary><b>在Opencode中安装</b></summary>
-
-将此内容添加到你的Opencode配置文件中。更多信息请参见[Opencode MCP 文档](https://opencode.ai/docs/mcp-servers)。
-
-#### Opencode远程服务器连接
-
-```json
-"mcp": {
-  "context7": {
-    "type": "remote",
-    "url": "https://mcp.context7.com/mcp",
-    "headers": {
-      "CONTEXT7_API_KEY": "YOUR_API_KEY"
-    },
-    "enabled": true
-  }
-}
-```
-
-#### Opencode本地服务器连接
-
-```json
-{
-  "mcp": {
-    "context7": {
-      "type": "local",
-      "command": ["npx", "-y", "@upstash/context7-mcp", "--api-key", "YOUR_API_KEY"],
-      "enabled": true
-    }
-  }
-}
-```
-
-</details>
-
-**[其他IDE和客户端 →](https://context7.com/docs/resources/all-clients)**
-
-<details>
-<summary><b>OAuth认证</b></summary>
-
-Context7 MCP服务器支持OAuth 2.0认证，适用于实现了[MCP OAuth规范](https://modelcontextprotocol.io/specification/2025-03-26/basic/authorization)的MCP客户端。
-
-要使用OAuth，请在客户端配置中将端点从`/mcp`更改为`/mcp/oauth`：
-
-```diff
-- "url": "https://mcp.context7.com/mcp"
-+ "url": "https://mcp.context7.com/mcp/oauth"
-```
-
-OAuth仅适用于远程HTTP连接。对于使用stdio传输的本地MCP连接，请改用API密钥认证。
-
-</details>
+**[手动安装 / 其他客户端 →](https://context7.com/docs/resources/all-clients)**
 
 ## 重点技巧
 
-### 添加规则
-
-为避免每次都在提示词中输入`用context7`，你可以在MCP客户端中添加规则，自动为代码相关问题调用 Context7：
-
-- **Cursor**：`Cursor Settings > Rules`
-- **Claude Code**：`CLAUDE.md`
-- 或你的 MCP 客户端中的等效设置
-
-**规则示例：**
-
-```txt
-无需我明确要求，当我需要库或API文档、生成代码、创建项目基架时或配置步骤时，始终使用Context7 MCP。
-```
-
 ### 使用库 ID
 
-如果你已经确切知道要使用哪个库，请将其Context7 ID添加到你的提示词中。这样，Context7 MCP服务器可以跳过库匹配步骤，直接检索文档。
+如果你已经确切知道要使用哪个库，请将其Context7 ID添加到你的提示词中。这样，Context7可以跳过库匹配步骤，直接检索文档。
 
 ```txt
 使用Supabase实现基本身份验证。用/supabase/supabase作为库ID获取API和文档。
 ```
 
-斜杠语法明确告知MCP工具需加载文档的库。
+斜杠语法明确告知Context7需加载文档的库。
 
 ### 指定版本
 
 要获取特定库版本的文档，只需在提示词中提及版本：
 
 ```txt
-如何设置Next.js 14中间件？用context7
+如何设置Next.js 14中间件？use context7
 ```
 
 Context7 将自动匹配适当的版本。
 
+### 添加规则
+
+如果通过 `ctx7 setup` 安装，skill会自动配置，触发Context7响应库相关问题。如需手动添加规则，请在你的编码代理中配置：
+
+- **Cursor**：`Cursor Settings > Rules`
+- **Claude Code**：`CLAUDE.md`
+- 或你的编码代理中的等效设置
+
+**规则示例：**
+
+```txt
+无需我明确要求，当我需要库或API文档、生成代码、设置或配置步骤时，始终使用Context7。
+```
+
 ## 可用工具
 
-Context7 MCP提供以下工具供LLM使用：
+### CLI命令
+
+- `ctx7 library <name> <query>`：按库名在Context7索引中搜索，返回匹配的库及其ID。
+- `ctx7 docs <libraryId> <query>`：使用Context7兼容的库ID获取库文档（例如 `/mongodb/docs`、`/vercel/next.js`）。
+
+### MCP工具
 
 - `resolve-library-id`：将通用库名称解析为Context7兼容的库ID。
   - `query`（必需）：用户的问题或任务（用于按相关性排名结果）
   - `libraryName`（必需）：要搜索的库名称
-
 - `query-docs`：使用Context7兼容的库ID获取库的文档。
   - `libraryId`（必需）：精确的Context7兼容的库ID（例如 `/mongodb/docs`、`/vercel/next.js`）
   - `query`（必需）：用于获取相关文档的问题或任务
 
 ## 更多文档
 
-- [更多MCP客户端](https://context7.com/docs/resources/all-clients) - 30+客户端的安装说明
+- [CLI参考](https://context7.com/docs/clients/cli) - 完整CLI文档
+- [MCP客户端](https://context7.com/docs/resources/all-clients) - 30+客户端的手动MCP安装说明
 - [添加库](https://context7.com/docs/adding-libraries) - 将你的库提交到Context7
 - [故障排除](https://context7.com/docs/resources/troubleshooting) - 常见问题和解决方案
-- [API参考](https://context7.com/docs/api-guide) - REST API 文档
+- [API参考](https://context7.com/docs/api-guide) - REST API文档
 - [开发者指南](https://context7.com/docs/resources/developer) - 本地运行Context7 MCP
 
 ## 免责声明


### PR DESCRIPTION
## Summary

The `i18n/README.zh-CN.md` was significantly out of date with the current `README.md`. This PR syncs it with the following changes:

- **Title**: updated from "Context7 MCP" → "Context7 平台 (Platform)"
- **Installation**: replaced the old per-client JSON config blocks (Cursor / Claude Code / Opencode / OAuth) with the new single-command `npx ctx7 setup` approach
- **Two modes**: added the "CLI + Skills" vs "MCP" description that was missing
- **Prompt examples**: added the third Supabase example; removed the now-outdated inline instruction about appending `用context7`
- **Tips order**: reordered to match main (Use Library Id → Specify a Version → Add a Rule); updated "Add a Rule" copy to mention `ctx7 setup`
- **Available Tools**: added the new CLI Commands subsection (`ctx7 library` / `ctx7 docs`)
- **More Documentation**: added the CLI Reference link; renamed "更多MCP客户端" → "MCP客户端"
- **Bug fix**: corrected the MIT license badge path from `./LICENSE` → `../LICENSE` (the file lives in `i18n/`, so the relative path was broken)

## Test plan

- [ ] Render the Markdown and confirm all badge links, internal anchor links, and external links resolve correctly
- [ ] Verify the `npx ctx7 setup` install command matches the current CLI behavior
- [ ] Spot-check Chinese translations for accuracy