### PR TITLE
fix(cli): respect CLAUDE_CONFIG_DIR for Claude setup

### DIFF
--- a/.changeset/respect-claude-config-dir.md
+++ b/.changeset/respect-claude-config-dir.md
@@ -1,0 +1,5 @@
+---
+"ctx7": patch
+---
+
+Respect `CLAUDE_CONFIG_DIR` env var when resolving Claude Code's global config, rules, skills, and detection paths

--- a/packages/cli/src/__tests__/setup.test.ts
+++ b/packages/cli/src/__tests__/setup.test.ts
@@ -641,6 +641,27 @@ describe("agent config integration", () => {
       });
     });
 
+    test("uses CLAUDE_CONFIG_DIR for global Claude config, rules, skills, and detection", () => {
+      const previous = process.env.CLAUDE_CONFIG_DIR;
+      const customDir = join(tempDir, "xdg", "claude");
+      process.env.CLAUDE_CONFIG_DIR = customDir;
+      try {
+        expect(agent.mcp.globalPaths).toEqual([join(customDir, ".claude.json")]);
+        expect(agent.rule.kind).toBe("file");
+        if (agent.rule.kind === "file") {
+          expect(agent.rule.dir("global")).toBe(join(customDir, "rules"));
+        }
+        expect(agent.skill.dir("global")).toBe(join(customDir, "skills"));
+        expect(agent.detect.globalPaths).toEqual([customDir]);
+      } finally {
+        if (previous === undefined) {
+          delete process.env.CLAUDE_CONFIG_DIR;
+        } else {
+          process.env.CLAUDE_CONFIG_DIR = previous;
+        }
+      }
+    });
+
     test("merges into JSON config with configKey mcpServers", async () => {
       const path = join(tempDir, ".claude.json");
       const existing = await readJsonConfig(path);

--- a/packages/cli/src/setup/agents.ts
+++ b/packages/cli/src/setup/agents.ts
@@ -25,6 +25,17 @@ export const AUTH_MODE_LABELS: Record<AuthMode, string> = {
 
 const MCP_BASE_URL = "https://mcp.context7.com";
 
+function claudeConfigDir(): string {
+  return process.env.CLAUDE_CONFIG_DIR || join(homedir(), ".claude");
+}
+
+function claudeGlobalMcpPath(): string {
+  if (process.env.CLAUDE_CONFIG_DIR) {
+    return join(claudeConfigDir(), ".claude.json");
+  }
+  return join(homedir(), ".claude.json");
+}
+
 export type RuleType =
   | {
       kind: "file";
@@ -70,24 +81,28 @@ const agents: Record<SetupAgent, AgentConfig> = {
     displayName: "Claude Code",
     mcp: {
       projectPaths: [".mcp.json"],
-      globalPaths: [join(homedir(), ".claude.json")],
+      get globalPaths() {
+        return [claudeGlobalMcpPath()];
+      },
       configKey: "mcpServers",
       buildEntry: (auth) => withHeaders({ type: "http", url: mcpUrl(auth) }, auth),
     },
     rule: {
       kind: "file",
       dir: (scope) =>
-        scope === "global" ? join(homedir(), ".claude", "rules") : join(".claude", "rules"),
+        scope === "global" ? join(claudeConfigDir(), "rules") : join(".claude", "rules"),
       filename: "context7.md",
     },
     skill: {
       name: "context7-mcp",
       dir: (scope) =>
-        scope === "global" ? join(homedir(), ".claude", "skills") : join(".claude", "skills"),
+        scope === "global" ? join(claudeConfigDir(), "skills") : join(".claude", "skills"),
     },
     detect: {
       projectPaths: [".mcp.json", ".claude"],
-      globalPaths: [join(homedir(), ".claude")],
+      get globalPaths() {
+        return [claudeConfigDir()];
+      },
     },
   },
 


### PR DESCRIPTION
## Summary
- resolve Claude global setup paths from \\CLAUDE_CONFIG_DIR\\ when it is set
- keep existing defaults when the env var is absent: \\~/.claude.json\\, \\~/.claude/rules\\, and \\~/.claude/skills\\
- cover MCP config, rule path, skill path, and global agent detection in setup tests

Fixes #2553.

## Verification
- RED: \\pnpm --filter ctx7 test -- setup.test.ts\\ failed on the new \\CLAUDE_CONFIG_DIR\\ test before the implementation
- GREEN: \\pnpm --filter ctx7 test -- setup.test.ts\\ -> 82 tests passed
- \\pnpm --filter ctx7 typecheck\\
- \\pnpm --filter ctx7 exec eslint src/setup/agents.ts src/__tests__/setup.test.ts\\
- \\git diff --check\\

## Note
- Full \\pnpm --filter ctx7 lint:check\\ is blocked in this Windows checkout by existing CRLF/Prettier errors across the package; the touched files pass targeted ESLint after Prettier formatting.