### PR TITLE
fix(cli): handle malformed MCP config files in remove detection

### DIFF
--- a/.changeset/handle-mcp-config-detection-errors.md
+++ b/.changeset/handle-mcp-config-detection-errors.md
@@ -1,0 +1,5 @@
+---
+"ctx7": patch
+---
+
+Handle malformed MCP config files gracefully during `ctx7 remove` agent detection. Previously, an unparseable JSON config at any agent's well-known path (e.g. a hand-edited `~/.claude.json`) would crash the command with an unhandled `SyntaxError` before it could do anything. The detector now skips the offending file and logs a warning naming the path and parse error so the user can fix it, while detection continues for the remaining agents.

--- a/packages/cli/src/commands/remove.ts
+++ b/packages/cli/src/commands/remove.ts
@@ -198,7 +198,15 @@ async function hasMcpConfig(agentName: SetupAgent, scope: Scope): Promise<boolea
     return readTomlServerExists(mcpPath, "context7");
   }
 
-  const existing = await readJsonConfig(mcpPath);
+  let existing: Record<string, unknown>;
+  try {
+    existing = await readJsonConfig(mcpPath);
+  } catch (err) {
+    log.warn(
+      `Skipped ${mcpPath}: could not parse (${err instanceof Error ? err.message : String(err)})`
+    );
+    return false;
+  }
   const section = existing[agent.mcp.configKey];
   return (
     !!section && typeof section === "object" && !Array.isArray(section) && "context7" in section


### PR DESCRIPTION
## Summary

`ctx7 remove` crashed with an unhandled `SyntaxError` whenever any of the agents' well-known JSON config paths contained unparseable content (e.g. a hand-edited `~/.claude.json` with a stray comma). `readJsonConfig` only caught file-read errors, not `JSON.parse` errors, and the detection path didn't wrap it.

This patch wraps the `readJsonConfig` call in `hasMcpConfig` with a `try/catch` that logs a warning naming the offending file and parse error, then skips that agent for detection. Detection continues for the remaining agents and the user gets an actionable line instead of a stack trace.

`readJsonConfig` itself stays strict so the write paths (`setup`, `uninstallMcp`) keep surfacing failures through their existing per-agent results-table error handling — silently swallowing parse errors there could risk overwriting a real-but-malformed user config.

### Before
```
$ npx ctx7 remove
SyntaxError: Expected double-quoted property name in JSON at position 703 (line 21 column 25)
    at JSON.parse ()
    at readJsonConfig (...)
    at async hasMcpConfig (...)
    ...
```

### After
```
$ npx ctx7 remove
⚠ Skipped /Users/.../.claude.json: could not parse (Expected double-quoted property name in JSON at position 703 (line 21 column 25))
⚠ No Context7 setup detected. Pass --claude, --cursor, --opencode, --codex, or --gemini.
```

Reported in #2561  where the user's pre-existing malformed `~/.claude.json` (unrelated to ctx7) caused `remove` to crash with no indication of which file was at fault.