### PR TITLE
fix(mcp): exit stdio server when parent closes stdio

### DIFF
--- a/.changeset/mcp-stdio-orphan-exit.md
+++ b/.changeset/mcp-stdio-orphan-exit.md
@@ -1,0 +1,5 @@
+---
+"@upstash/context7-mcp": patch
+---
+
+Exit the stdio MCP server when the parent process closes its stdio. Previously, if the parent (e.g. Claude Code) was force-killed shortly after a tool call, an idle undici keep-alive socket to the Context7 API would keep libuv's event loop alive past stdin EOF, leaving an orphaned `node` process that consumed memory until the kernel tore the socket down (which on Cloudflare-fronted endpoints can take hours). The server now listens for `end`/`close` on stdin and `SIGHUP` and exits cleanly. Fixes #2542.

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -524,6 +524,11 @@ async function main() {
     startServer(initialPort);
   } else {
     stdioApiKey = cliOptions.apiKey || process.env.CONTEXT7_API_KEY;
+
+    process.stdin.on("end", () => process.exit(0));
+    process.stdin.on("close", () => process.exit(0));
+    process.on("SIGHUP", () => process.exit(0));
+
     const transport = new StdioServerTransport();
     const server = createMcpServer();
 


### PR DESCRIPTION
## Summary

Fixes #2542. When the parent process (e.g. Claude Code) is force-killed shortly after a tool call, an orphan `node` process running `@upstash/context7-mcp` keeps running indefinitely. Reproduced and root-caused: an idle undici keep-alive socket to the Context7 API stays on libuv's active-handle list past stdin EOF, so the event loop never drains. On Cloudflare-fronted endpoints the socket can stay open for hours, which matches the 1-day-elapsed orphan in the original report.

The MCP SDK's `StdioServerTransport` only listens for `data` / `error` on stdin, never `end` / `close`, so by default nothing forces an exit on EOF. Adding three lines in the stdio branch of `main()` resolves it: listen for `end` and `close` on stdin and for `SIGHUP`, and call `process.exit(0)`. HTTP transport is unaffected.

## Test plan
- [x] Built dist locally; typecheck and lint pass.
- [x] Repro harness against unfixed v2.2.3 (via npx) caught an orphan in `post-first-call` (kill ~2s after first tool call). `lsof` showed an ESTABLISHED HTTPS socket to a Cloudflare IP for `context7.com`; main thread sample showed `uv__io_poll`. Stdin FD was already closed (`unix ->(none)`), confirming EOF without exit.
- [x] Repro harness against fixed `dist/index.js`: 0 orphans across 18 attempts spanning 6 timing variants (`mid-init`, `post-init`, `mid-first-call`, `post-first-call`, `during-batch`, `long-idle`).
- [x] Manual repro via real Claude Code session: launch claude, trigger a context7 tool call, `kill -9 $(pgrep -f '/claude')`, confirm `pgrep -f 'packages/mcp/dist/index.js'` returns nothing within a few seconds.