### PR TITLE
fix(mcp): rewrite hallucinated tools/call argument names

### DIFF
--- a/.changeset/accept-hallucinated-tool-args.md
+++ b/.changeset/accept-hallucinated-tool-args.md
@@ -1,0 +1,5 @@
+---
+"@upstash/context7-mcp": patch
+---
+
+Accept hallucinated argument names on `tools/call` requests by rewriting them to the canonical names before validation. `context7CompatibleLibraryID` is mapped to `libraryId` and `userQuery` is mapped to `query` on incoming MCP messages. Some LLM clients produce these alternative names — likely echoing phrasing from each tool's description — and previously triggered `Invalid input: expected string, received undefined` errors. Tool input schemas published via `tools/list` are unchanged: canonical names remain the documented required fields, the rewrite is purely a server-side compatibility shim that runs only on `tools/call` and only when the canonical key is absent.

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -2,6 +2,7 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { z } from "zod";
 import { searchLibraries, fetchLibraryContext } from "./lib/api.js";
 import { ClientContext } from "./lib/encryption.js";
@@ -281,6 +282,29 @@ Do not call this tool more than 3 times per question.`,
   return server;
 }
 
+// Rewrite hallucinated argument names on incoming `tools/call` messages so
+// they validate against the canonical tool schema. Install BEFORE
+// `server.connect(transport)`: the SDK's `Protocol.connect()` captures the
+// existing `onmessage` and chains its dispatch handler over it, so our hook
+// runs first on every incoming JSON-RPC message.
+function installTransportArgAliasing(transport: Transport): void {
+  transport.onmessage = (message) => {
+    const msg = message as { method?: string; params?: { arguments?: unknown } };
+    if (msg.method !== "tools/call") return;
+    const args = msg.params?.arguments;
+    if (!args || typeof args !== "object") return;
+    const argsRecord = args as Record<string, unknown>;
+    if ("context7CompatibleLibraryID" in argsRecord && !("libraryId" in argsRecord)) {
+      argsRecord.libraryId = argsRecord.context7CompatibleLibraryID;
+      delete argsRecord.context7CompatibleLibraryID;
+    }
+    if ("userQuery" in argsRecord && !("query" in argsRecord)) {
+      argsRecord.query = argsRecord.userQuery;
+      delete argsRecord.userQuery;
+    }
+  };
+}
+
 async function main() {
   const transportType = TRANSPORT_TYPE;
 
@@ -410,6 +434,7 @@ async function main() {
         });
 
         await requestContext.run(context, async () => {
+          installTransportArgAliasing(transport);
           await server.connect(transport);
           await transport.handleRequest(req, res, req.body);
         });
@@ -544,6 +569,7 @@ async function main() {
       }
     };
 
+    installTransportArgAliasing(transport);
     await server.connect(transport);
 
     console.error(`Context7 Documentation MCP Server v${SERVER_VERSION} running on stdio`);


### PR DESCRIPTION
Some LLM clients send `context7CompatibleLibraryID`/`userQuery` instead of the canonical `libraryId`/`query`, tripping Zod validation before the tool runs. This adds a server-side shim that rewrites those two keys on incoming `tools/call` requests when the canonical key is absent. Published `tools/list` schemas are unchanged.

Hooks `Transport.onmessage` (set before `server.connect()` so the SDK chains its dispatch over it). Gated on `method === "tools/call"` and `typeof arguments === "object"`; canonical wins if both are present.

## Test plan

- [x] `userQuery` only → rewritten, success
- [x] both aliases on `query-docs` → rewritten, success
- [x] canonical `query` only → no regression
- [x] neither canonical nor alias → SDK error preserved
- [x] both present → canonical wins
- [x] malformed `arguments: "string"` → hook bails, SDK returns clean `-32603`
- [x] `tools/list` → canonical schemas only, no aliases leaked
- [x] `tsc --noEmit` and `pnpm run build` clean