### PR TITLE
chore(pnpm): require 7-day minimum release age for installs

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,5 @@ packages:
 
 allowBuilds:
   esbuild: true
+
+minimumReleaseAge: 10080


### PR DESCRIPTION
## Summary

Adds `minimumReleaseAge: 10080` to `pnpm-workspace.yaml` so pnpm refuses to install package versions younger than 7 days. Short-lived supply-chain compromises (hijacked publish tokens, typosquats, Shai-Hulud-style worms) typically get yanked from the registry within hours to days, so a 7-day window catches most of them before they reach us.

Critical hotfixes can be unblocked per-package via `minimumReleaseAgeExclude` in the same file.

Ref: [pnpm blog — npm supply chain security](https://pnpm.io/blog/2025/12/05/newsroom-npm-supply-chain-security)

## Test plan

- [ ] `Test` workflow passes (installs respect the new setting via lockfile, so no behavior change for already-pinned versions)
- [ ] On next `pnpm update`, confirm pnpm refuses bumps to versions published <7 days ago

## Notes

- No effect on the existing lockfile — every version in `pnpm-lock.yaml` is already older than 7 days, so `pnpm install --frozen-lockfile` is unaffected.
- Bites when running `pnpm update` or adding a new dep whose latest version is fresh — pnpm will pick the most recent eligible version instead.
- May need `skip-changeset` label (no published-package impact).