### PR TITLE
fix(cli): declare @inquirer/core as direct dependency

### DIFF
--- a/.changeset/cli-inquirer-core-dep.md
+++ b/.changeset/cli-inquirer-core-dep.md
@@ -1,0 +1,5 @@
+---
+"ctx7": patch
+---
+
+Declare `@inquirer/core` as a direct dependency of the CLI. It was previously imported in `selectOrInput.ts` but only resolvable as a transitive of `@inquirer/prompts`, which caused `ctx7` to fail at startup with `ERR_MODULE_NOT_FOUND` under pnpm's isolated node linker.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,6 +22,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@inquirer/core": "^11.1.1",
     "@inquirer/prompts": "^8.2.0",
     "commander": "^13.1.0",
     "figlet": "^1.9.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
 
   packages/cli:
     dependencies:
+      '@inquirer/core':
+        specifier: ^11.1.1
+        version: 11.1.1(@types/node@22.19.7)
       '@inquirer/prompts':
         specifier: ^8.2.0
         version: 8.2.0(@types/node@22.19.7)


### PR DESCRIPTION
Closes https://github.com/upstash/context7/issues/2651

## Summary
- [packages/cli/src/utils/selectOrInput.ts](packages/cli/src/utils/selectOrInput.ts) imports from `@inquirer/core`, but the package was only present transitively via `@inquirer/prompts`. Under pnpm's isolated node linker the resolution is rejected and `ctx7` crashes at startup with `ERR_MODULE_NOT_FOUND`.
- Adds `@inquirer/core` to `packages/cli/package.json` dependencies (pinned to `^11.1.1`, matching the version already resolved transitively).

## Test plan
- [x] `pnpm --filter ctx7 build`
- [x] `pnpm --filter ctx7 typecheck`
- [x] `pnpm pack` the package, install it into a sandbox with `pnpm add --node-linker=isolated`, and confirm `ctx7 --help` runs cleanly (reproduces the bug report's failure mode pre-fix).