### PR TITLE
docs: fix verification docs typo

### DIFF
--- a/docs/howto/verification.mdx
+++ b/docs/howto/verification.mdx
@@ -151,7 +151,7 @@ Automatic verification is recalculated daily. If your library no longer meets th
 
 ### My library is popular but not verified. Why?
 
-Automatic verification considers multiple factors including trust score, usage statistics, and skill installs. When you apply manually, Context7 also checks quality criterias like GitHub stars, popularity ranking, and referring domains. If you believe your library meets any of these thresholds, please apply manually and the check will run immediately.
+Automatic verification considers multiple factors including trust score, usage statistics, and skill installs. When you apply manually, Context7 also checks quality criteria like GitHub stars, popularity ranking, and referring domains. If you believe your library meets any of these thresholds, please apply manually and the check will run immediately.
 
 ## Need Help?
 


### PR DESCRIPTION
Summary:
- Fixes clear spelling or wording mistakes in documentation.
- Keeps the change text-only with no behavior impact.

Testing:
- `git diff --check`
- `uvx codespell` on the changed files