### PR TITLE
fix(cli): --api-key alone no longer forces MCP mode in setup

### DIFF
--- a/.changeset/cli-api-key-mode-prompt.md
+++ b/.changeset/cli-api-key-mode-prompt.md
@@ -1,0 +1,5 @@
+---
+"ctx7": patch
+---
+
+`ctx7 setup --api-key <KEY>` (without `--cli`, `--mcp`, or `-y`) now prompts to choose between MCP server and CLI + Skills modes. Previously, passing `--api-key` short-circuited to MCP, locking users out of the CLI + Skills option even though that mode also accepts an API key. Explicit `--mcp` / `--cli` / `--stdio` / `--oauth` / `-y` still skip the prompt as before.

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -144,7 +144,7 @@ async function resolveAuth(options: SetupOptions): Promise<AuthOptions | null> {
 
 async function resolveMode(options: SetupOptions): Promise<SetupMode> {
   if (options.cli) return "cli";
-  if (options.mcp || options.yes || options.oauth || options.apiKey || options.stdio) return "mcp";
+  if (options.mcp || options.yes || options.oauth || options.stdio) return "mcp";
 
   return select<SetupMode>({
     message: "How should your agent access Context7?",


### PR DESCRIPTION
## Summary

Fixes part of #2693. `ctx7 setup --api-key <KEY>` (without `--cli`, `--mcp`, or `-y`) was short-circuiting straight to MCP mode, even though `--api-key` is equally valid for CLI + Skills mode (which authenticates the skill download via [resolveCliAuth](packages/cli/src/commands/setup.ts#L171-L187)). Users who wanted the CLI + Skills flow were silently locked out unless they also remembered to pass `--cli`.

Remove `options.apiKey` from the auto-MCP OR-chain in [resolveMode](packages/cli/src/commands/setup.ts#L146). Explicit `--mcp` / `--cli` / `--stdio` / `--oauth` / `-y` still skip the prompt as before.

## Test plan

Verified with the built binary against the four relevant input combinations:

| Command | Expected | Result |
|---|---|---|
| `setup --api-key K` | Prompts for mode | Prompts ✓ |
| `setup --api-key K --cli` | CLI mode, no prompt | CLI ✓ |
| `setup --api-key K -y` | MCP, no prompt (existing) | MCP ✓ |
| `setup --api-key K --mcp` | MCP, no prompt | MCP ✓ |

- [x] `npx vitest run` — 207/207 pass
- [x] `npx tsc --noEmit` clean
- [x] Manual: all four scenarios above

Note: the other parts of #2693 (OAuth flow assuming localhost on remote hosts) need a separate, larger fix — device flow or manual code paste — and are not addressed here.