### PR TITLE
Require JWT bearer auth on /mcp/oauth

### DIFF
--- a/.changeset/oauth-reject-opaque-bearers.md
+++ b/.changeset/oauth-reject-opaque-bearers.md
@@ -1,0 +1,5 @@
+---
+"@upstash/context7-mcp": patch
+---
+
+Require a valid JWT bearer token on the OAuth MCP endpoint before request handling.

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -7,7 +7,11 @@ import { z } from "zod";
 import { searchLibraries, fetchLibraryContext } from "./lib/api.js";
 import type { ClientContext } from "./lib/types.js";
 import { formatSearchResults, extractClientInfoFromUserAgent } from "./lib/utils.js";
-import { isJWT, validateJWT } from "./lib/jwt.js";
+import {
+  extractApiKey,
+  extractHeaderValue,
+  validateRequiredOAuthBearerToken,
+} from "./lib/httpAuth.js";
 import express from "express";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
@@ -364,32 +368,6 @@ async function main() {
       next();
     });
 
-    const extractHeaderValue = (value: string | string[] | undefined): string | undefined => {
-      if (!value) return undefined;
-      return typeof value === "string" ? value : value[0];
-    };
-
-    const extractBearerToken = (authHeader: string | string[] | undefined): string | undefined => {
-      const header = extractHeaderValue(authHeader);
-      if (!header) return undefined;
-
-      if (header.startsWith("Bearer ")) {
-        return header.substring(7).trim();
-      }
-
-      return header;
-    };
-
-    const extractApiKey = (req: express.Request): string | undefined => {
-      return (
-        extractBearerToken(req.headers.authorization) ||
-        extractHeaderValue(req.headers["context7-api-key"]) ||
-        extractHeaderValue(req.headers["x-api-key"]) ||
-        extractHeaderValue(req.headers["context7_api_key"]) ||
-        extractHeaderValue(req.headers["x_api_key"])
-      );
-    };
-
     const sessionStore = createSessionStore();
 
     const handleMcpRequest = async (
@@ -409,7 +387,7 @@ async function main() {
       }
 
       try {
-        const apiKey = extractApiKey(req);
+        let apiKey = extractApiKey(req.headers);
         const resourceUrl = RESOURCE_URL;
         const baseUrl = new URL(resourceUrl).origin;
 
@@ -420,30 +398,18 @@ async function main() {
         );
 
         if (requireAuth) {
-          if (!apiKey) {
+          const authResult = await validateRequiredOAuthBearerToken(req.headers.authorization);
+          if (!authResult.valid) {
             return res.status(401).json({
               jsonrpc: "2.0",
               error: {
                 code: -32001,
-                message: "Authentication required. Please authenticate to use this MCP server.",
+                message: authResult.error,
               },
               id: null,
             });
           }
-
-          if (isJWT(apiKey)) {
-            const validationResult = await validateJWT(apiKey);
-            if (!validationResult.valid) {
-              return res.status(401).json({
-                jsonrpc: "2.0",
-                error: {
-                  code: -32001,
-                  message: validationResult.error || "Invalid token. Please re-authenticate.",
-                },
-                id: null,
-              });
-            }
-          }
+          apiKey = authResult.token;
         }
 
         const context: ClientContext = {

--- a/packages/mcp/src/lib/httpAuth.ts
+++ b/packages/mcp/src/lib/httpAuth.ts
@@ -1,0 +1,77 @@
+import { isJWT, validateJWT } from "./jwt.js";
+
+type HeaderValue = string | string[] | undefined;
+
+interface AuthHeaders {
+  authorization?: HeaderValue;
+  "context7-api-key"?: HeaderValue;
+  "x-api-key"?: HeaderValue;
+  context7_api_key?: HeaderValue;
+  x_api_key?: HeaderValue;
+}
+
+type AuthValidationResult = { valid: true; token: string } | { valid: false; error: string };
+
+const AUTHENTICATION_REQUIRED =
+  "Authentication required. Please authenticate to use this MCP server.";
+const INVALID_TOKEN = "Invalid token. Please re-authenticate.";
+
+export function extractHeaderValue(value: HeaderValue): string | undefined {
+  if (!value) return undefined;
+  return typeof value === "string" ? value : value[0];
+}
+
+export function extractBearerToken(authHeader: HeaderValue): string | undefined {
+  const header = extractHeaderValue(authHeader);
+  if (!header) return undefined;
+
+  if (header.startsWith("Bearer ")) {
+    return header.substring(7).trim();
+  }
+
+  return header;
+}
+
+export function extractApiKey(headers: AuthHeaders): string | undefined {
+  return (
+    extractBearerToken(headers.authorization) ||
+    extractHeaderValue(headers["context7-api-key"]) ||
+    extractHeaderValue(headers["x-api-key"]) ||
+    extractHeaderValue(headers.context7_api_key) ||
+    extractHeaderValue(headers.x_api_key)
+  );
+}
+
+async function validateRequiredOAuthToken(
+  token: string | undefined
+): Promise<AuthValidationResult> {
+  if (!token) {
+    return { valid: false, error: AUTHENTICATION_REQUIRED };
+  }
+
+  if (!isJWT(token)) {
+    return { valid: false, error: INVALID_TOKEN };
+  }
+
+  const validationResult = await validateJWT(token);
+  if (!validationResult.valid) {
+    return { valid: false, error: validationResult.error || INVALID_TOKEN };
+  }
+
+  return { valid: true, token };
+}
+
+export async function validateRequiredOAuthBearerToken(
+  authHeader: HeaderValue
+): Promise<AuthValidationResult> {
+  const header = extractHeaderValue(authHeader);
+  if (!header) {
+    return { valid: false, error: AUTHENTICATION_REQUIRED };
+  }
+
+  if (!header.startsWith("Bearer ")) {
+    return { valid: false, error: INVALID_TOKEN };
+  }
+
+  return validateRequiredOAuthToken(header.substring(7).trim());
+}


### PR DESCRIPTION
## Summary
- Reject opaque or non-Bearer values on the OAuth MCP endpoint before request handling.
- Keep API-key extraction for the non-OAuth path, while `/mcp/oauth` now only accepts valid JWT bearer tokens.
- Add a small auth helper to centralize bearer parsing and JWT validation.
