### PR TITLE
fix(cli): recover library ID mangled by Git Bash on Windows

### DIFF
--- a/.changeset/git-bash-library-id.md
+++ b/.changeset/git-bash-library-id.md
@@ -1,0 +1,5 @@
+---
+"ctx7": patch
+---
+
+Recover Context7 library IDs that Git Bash mangles on Windows. Git Bash rewrites a leading-slash argument like `/facebook/react` into a Windows path under the Git install dir (`C:/Program Files/Git/facebook/react`), causing `ctx7 docs` to reject it as invalid; this mainly affected users running ctx7 through Claude Code. The CLI now detects and undoes the conversion before validation, accepts the `//owner/repo` escape, and points users at that workaround for install layouts it can't auto-detect.

--- a/packages/cli/src/__tests__/library-id.test.ts
+++ b/packages/cli/src/__tests__/library-id.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "vitest";
+
+import { recoverLibraryId } from "../utils/library-id.js";
+
+describe("recoverLibraryId", () => {
+  test("passes through a normal library ID unchanged", () => {
+    expect(recoverLibraryId("/facebook/react")).toBe("/facebook/react");
+    expect(recoverLibraryId("/vercel/next.js/v15.1.8")).toBe("/vercel/next.js/v15.1.8");
+  });
+
+  test("recovers a Git Bash mangled path (default install dir)", () => {
+    expect(recoverLibraryId("C:/Program Files/Git/facebook/react")).toBe("/facebook/react");
+  });
+
+  test("recovers a mangled path with backslashes", () => {
+    expect(recoverLibraryId("C:\\Program Files\\Git\\facebook\\react")).toBe("/facebook/react");
+  });
+
+  test("preserves a version segment", () => {
+    expect(recoverLibraryId("C:/Program Files/Git/vercel/next.js/v15.1.8")).toBe(
+      "/vercel/next.js/v15.1.8"
+    );
+  });
+
+  test("recovers from a portable Git install", () => {
+    expect(recoverLibraryId("D:/tools/PortableGit/facebook/react")).toBe("/facebook/react");
+  });
+
+  test("recovers an owner that looks like a system dir", () => {
+    expect(recoverLibraryId("C:/Program Files/Git/usr/some-repo")).toBe("/usr/some-repo");
+  });
+
+  test("collapses the leading double-slash workaround", () => {
+    expect(recoverLibraryId("//facebook/react")).toBe("/facebook/react");
+  });
+
+  test("leaves a non-Windows-path argument untouched", () => {
+    expect(recoverLibraryId("facebook/react")).toBe("facebook/react");
+  });
+
+  test("leaves an unrecognized Windows path untouched", () => {
+    expect(recoverLibraryId("C:/Users/me/project")).toBe("C:/Users/me/project");
+  });
+});

--- a/packages/cli/src/commands/docs.ts
+++ b/packages/cli/src/commands/docs.ts
@@ -3,6 +3,7 @@ import pc from "picocolors";
 import ora from "ora";
 
 import { resolveLibrary, getLibraryContext } from "../utils/api.js";
+import { recoverLibraryId } from "../utils/library-id.js";
 import { log } from "../utils/logger.js";
 import { trackEvent } from "../utils/tracking.js";
 import { loadTokens, isTokenExpired } from "../utils/auth.js";
@@ -120,10 +121,18 @@ async function queryCommand(
 ): Promise<void> {
   trackEvent("command", { name: "docs" });
 
+  // Git Bash on Windows rewrites "/owner/repo" into a Windows path; recover it.
+  libraryId = recoverLibraryId(libraryId);
+
   if (!libraryId.startsWith("/") || !/^\/[^/]+\/[^/]/.test(libraryId)) {
     log.error(`Invalid library ID: "${libraryId}"`);
     log.info(`Expected format: /owner/repo or /owner/repo/version (e.g., /facebook/react)`);
     log.info(`Run "ctx7 library <name>" to find the correct ID`);
+    if (process.platform === "win32") {
+      log.info(
+        `On Git Bash, prefix the ID with an extra slash to avoid path conversion: ctx7 docs "//facebook/react" "<your question>"`
+      );
+    }
     process.exitCode = 1;
     return;
   }

--- a/packages/cli/src/utils/library-id.ts
+++ b/packages/cli/src/utils/library-id.ts
@@ -1,0 +1,22 @@
+/**
+ * Recover a library ID that Git Bash mangled on Windows.
+ *
+ * Git Bash rewrites a leading-slash argument like "/facebook/react" into a
+ * Windows path under the Git install dir, e.g. "C:/Program Files/Git/facebook/react".
+ * We undo that so the "/owner/repo" format still works.
+ */
+export function recoverLibraryId(input: string): string {
+  // "//owner/repo" is the Git Bash escape that skips conversion; collapse it.
+  if (input.startsWith("//")) return input.replace(/^\/+/, "/");
+
+  // Normal library ID, nothing to recover.
+  if (input.startsWith("/")) return input;
+
+  // Only a drive-letter path (e.g. "C:/...") can be a mangled ID.
+  if (!/^[A-Za-z]:[\\/]/.test(input)) return input;
+
+  // Strip the Git install dir, keeping the "/owner/repo[/version]" tail.
+  const normalized = input.replace(/\\/g, "/");
+  const match = normalized.match(/^[A-Za-z]:\/.*?\/(?:Git|PortableGit|git-bash)\/(.+)$/i);
+  return match ? `/${match[1]}` : input;
+}


### PR DESCRIPTION
Fixes #2277.

Git Bash on Windows POSIX-converts a leading-slash argument like `/facebook/react` into a Windows path under the Git install dir (`C:/Program Files/Git/facebook/react`) before the CLI runs, so `ctx7 docs` rejected it as an invalid library ID. This mainly hit users running ctx7 through Claude Code.

- Add `recoverLibraryId()` that detects a drive-letter-rooted argument and strips the Git install prefix to restore `/owner/repo` (version segments preserved).
- Collapse the `//owner/repo` Git Bash escape so the documented workaround resolves correctly.
- Call it in `docs` before validation; show the `//owner/repo` hint on Windows for install layouts that aren't auto-detected.
- Add unit tests covering mangled paths, backslashes, versions, portable installs, and pass-through of valid IDs.

Only input that the old validation already rejected can be transformed; valid `/owner/repo` IDs return untouched, so existing users are unaffected.