### PR TITLE
docs: document Docker MCP Toolkit stdio transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,23 +60,6 @@ To configure manually, use the Context7 server URL `https://mcp.context7.com/mcp
 
 **[Manual Installation / Other Clients →](https://context7.com/docs/resources/all-clients)**
 
-### Docker MCP Toolkit
-
-When using the Docker MCP Toolkit image (`mcp/context7`) with a stdio-based client such as VS Code, Cline, Roo Code, or Claude Desktop, set `MCP_TRANSPORT=stdio` so the container starts with stdio transport instead of its HTTP default:
-
-```json
-{
-  "mcpServers": {
-    "context7": {
-      "command": "docker",
-      "args": ["run", "-i", "--rm", "-e", "MCP_TRANSPORT=stdio", "mcp/context7"]
-    }
-  }
-}
-```
-
-Keep using the remote server URL above for HTTP-based clients.
-
 ## Important Tips
 
 ### Use Library Id

--- a/README.md
+++ b/README.md
@@ -60,6 +60,23 @@ To configure manually, use the Context7 server URL `https://mcp.context7.com/mcp
 
 **[Manual Installation / Other Clients →](https://context7.com/docs/resources/all-clients)**
 
+### Docker MCP Toolkit
+
+When using the Docker MCP Toolkit image (`mcp/context7`) with a stdio-based client such as VS Code, Cline, Roo Code, or Claude Desktop, set `MCP_TRANSPORT=stdio` so the container starts with stdio transport instead of its HTTP default:
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "-e", "MCP_TRANSPORT=stdio", "mcp/context7"]
+    }
+  }
+}
+```
+
+Keep using the remote server URL above for HTTP-based clients.
+
 ## Important Tips
 
 ### Use Library Id

--- a/docs/resources/all-clients.mdx
+++ b/docs/resources/all-clients.mdx
@@ -959,7 +959,7 @@ qwen mcp add context7 npx -y @upstash/context7-mcp --api-key YOUR_API_KEY
 FROM node:18-alpine
 WORKDIR /app
 RUN npm install -g @upstash/context7-mcp
-CMD ["context7-mcp"]
+CMD ["context7-mcp", "--transport", "stdio"]
 ```
 
 2. Build the image:
@@ -982,12 +982,26 @@ docker build -t context7-mcp .
 }
 ```
 
-If you use the Docker MCP Toolkit image (`mcp/context7`) with a stdio-based client such as VS Code, Cline, Roo Code, or Claude Desktop, set `MCP_TRANSPORT=stdio` so the container starts with stdio transport instead of its HTTP default:
+If you use the Docker MCP Toolkit image (`mcp/context7`) with a stdio-based client, set `MCP_TRANSPORT=stdio` so the container starts with stdio transport instead of its HTTP default. For Cline, Roo Code, and Claude Desktop, use:
 
 ```json
 {
   "mcpServers": {
     "context7": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "-e", "MCP_TRANSPORT=stdio", "mcp/context7"]
+    }
+  }
+}
+```
+
+For VS Code, use the same Docker command in the `servers` format:
+
+```json
+{
+  "servers": {
+    "context7": {
+      "type": "stdio",
       "command": "docker",
       "args": ["run", "-i", "--rm", "-e", "MCP_TRANSPORT=stdio", "mcp/context7"]
     }

--- a/docs/resources/all-clients.mdx
+++ b/docs/resources/all-clients.mdx
@@ -982,6 +982,21 @@ docker build -t context7-mcp .
 }
 ```
 
+If you use the Docker MCP Toolkit image (`mcp/context7`) with a stdio-based client such as VS Code, Cline, Roo Code, or Claude Desktop, set `MCP_TRANSPORT=stdio` so the container starts with stdio transport instead of its HTTP default:
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "-e", "MCP_TRANSPORT=stdio", "mcp/context7"]
+    }
+  }
+}
+```
+
+Keep using the remote server URL for HTTP-based clients.
+
 </Accordion>
 
 <Accordion title="Windows">

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -897,6 +897,23 @@ If you prefer to run the MCP server in a Docker container:
 
    _Note: This is an example configuration. Please refer to the specific examples for your MCP client (like Cursor, VS Code, etc.) earlier in this README to adapt the structure (e.g., `mcpServers` vs `servers`). Also, ensure the image name in `args` matches the tag used during the `docker build` command._
 
+   If you use the Docker MCP Toolkit image (`mcp/context7`) with a stdio-based client such
+   as VS Code, Cline, Roo Code, or Claude Desktop, set `MCP_TRANSPORT=stdio` so the
+   container starts with stdio transport instead of its HTTP default:
+
+   ```json
+   {
+     "mcpServers": {
+       "context7": {
+         "command": "docker",
+         "args": ["run", "-i", "--rm", "-e", "MCP_TRANSPORT=stdio", "mcp/context7"]
+       }
+     }
+   }
+   ```
+
+   Keep using the remote server URL for HTTP-based clients.
+
 </details>
 
 <details>

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -863,7 +863,7 @@ If you prefer to run the MCP server in a Docker container:
    # EXPOSE 3000
 
    # Default command to run the server
-   CMD ["context7-mcp"]
+   CMD ["context7-mcp", "--transport", "stdio"]
    ```
 
    </details>
@@ -897,14 +897,28 @@ If you prefer to run the MCP server in a Docker container:
 
    _Note: This is an example configuration. Please refer to the specific examples for your MCP client (like Cursor, VS Code, etc.) earlier in this README to adapt the structure (e.g., `mcpServers` vs `servers`). Also, ensure the image name in `args` matches the tag used during the `docker build` command._
 
-   If you use the Docker MCP Toolkit image (`mcp/context7`) with a stdio-based client such
-   as VS Code, Cline, Roo Code, or Claude Desktop, set `MCP_TRANSPORT=stdio` so the
-   container starts with stdio transport instead of its HTTP default:
+   If you use the Docker MCP Toolkit image (`mcp/context7`) with a stdio-based client,
+   set `MCP_TRANSPORT=stdio` so the container starts with stdio transport instead of its
+   HTTP default. For Cline, Roo Code, and Claude Desktop, use:
 
    ```json
    {
      "mcpServers": {
        "context7": {
+         "command": "docker",
+         "args": ["run", "-i", "--rm", "-e", "MCP_TRANSPORT=stdio", "mcp/context7"]
+       }
+     }
+   }
+   ```
+
+   For VS Code, use the same Docker command in the `servers` format:
+
+   ```json
+   {
+     "servers": {
+       "context7": {
+         "type": "stdio",
          "command": "docker",
          "args": ["run", "-i", "--rm", "-e", "MCP_TRANSPORT=stdio", "mcp/context7"]
        }


### PR DESCRIPTION
Fixes #300

## Summary
- Add a README note for the Docker MCP Toolkit `mcp/context7` image.
- Document setting `MCP_TRANSPORT=stdio` for stdio-based clients such as VS Code, Cline, Roo Code, and Claude Desktop.
- Leave the Dockerfile, server defaults, and runtime behavior unchanged so HTTP and Smithery-oriented flows are not affected.

## Verification
- `rg "MCP_TRANSPORT|stdio|Docker" README.md docs -n`
- `pnpm exec prettier --check README.md`
- `git diff --check`

## Notes
- `pnpm format:check` was run after installing dependencies, but it fails on pre-existing formatting warnings in package files outside this README diff (`packages/cli`, `packages/mcp`, and `packages/pi`).
- Full tests were not run because this is a documentation-only README change.