### PR TITLE
ci: update GitHub Actions to current major versions

### DIFF
--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -21,7 +21,7 @@ jobs:
           ref: ${{ inputs.branch || github.ref }}
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
 

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 0
 
       - name: Check for changeset
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const { execSync } = require('child_process');

--- a/.github/workflows/ecr-deploy.yml
+++ b/.github/workflows/ecr-deploy.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/mcp-registry.yml
+++ b/.github/workflows/mcp-registry.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
 


### PR DESCRIPTION
Combines the two open GitHub Actions update PRs into one. CI-only change; no application code touched.

- \`actions/setup-node\` v4 → v6 — test, release, canary-release, mcp-registry
- \`actions/github-script\` v7 → v8 — changeset-check
- \`aws-actions/configure-aws-credentials\` v5 → v6 — ecr-deploy

Each major bump's only breaking change is moving to the node24 runtime, which requires runner >= v2.327.1 — always satisfied by GitHub-hosted runners. setup-node's v5/v6 auto-caching change does not apply (repo uses pnpm, has no \`packageManager\` field, and workflows set no \`cache:\` input). No config changes needed.

Supersedes #1698 (by @pgoslatara) and #2062.