### PR TITLE
fix(sdk): retry transient HTTP errors and guard missing response fields

### DIFF
--- a/.changeset/sdk-retry-and-null-guards.md
+++ b/.changeset/sdk-retry-and-null-guards.md
@@ -1,0 +1,5 @@
+---
+"@upstash/context7-sdk": patch
+---
+
+Retry transient HTTP errors and harden response parsing. `HttpClient` now retries `429` (respecting the `Retry-After` header) and `5xx` responses using the configured backoff, and `retry: false` now performs exactly one attempt. `searchLibrary` and `getContext` tolerate missing array fields in the API response instead of throwing.

--- a/packages/sdk/src/commands/get-context/index.test.ts
+++ b/packages/sdk/src/commands/get-context/index.test.ts
@@ -3,8 +3,13 @@ import { GetContextCommand } from "./index";
 import { newHttpClient } from "../../utils/test-utils";
 import { Context7 } from "../../client";
 import type { Documentation } from "@commands/types";
+import type { Requester } from "@http";
 
 const httpClient = newHttpClient();
+
+function mockRequester(result: unknown): Requester {
+  return { request: () => Promise.resolve({ result }) } as Requester;
+}
 
 describe("GetContextCommand", () => {
   test("should get library context as JSON (default)", async () => {
@@ -63,5 +68,19 @@ describe("GetContextCommand", () => {
     expect(result).toBeDefined();
     expect(typeof result).toBe("string");
     expect(result.length).toBeGreaterThan(0);
+  });
+});
+
+describe("GetContextCommand defensive handling", () => {
+  test("returns an empty array when snippet fields are missing", async () => {
+    const command = new GetContextCommand("query", "/facebook/react");
+    const result = await command.exec(mockRequester({}));
+    expect(result).toEqual([]);
+  });
+
+  test("returns an empty array when snippet fields are null", async () => {
+    const command = new GetContextCommand("query", "/facebook/react");
+    const result = await command.exec(mockRequester({ codeSnippets: null, infoSnippets: null }));
+    expect(result).toEqual([]);
   });
 });

--- a/packages/sdk/src/commands/get-context/index.ts
+++ b/packages/sdk/src/commands/get-context/index.ts
@@ -41,8 +41,8 @@ export class GetContextCommand extends Command<Documentation[] | string> {
     }
 
     const apiResult = result as ApiContextJsonResponse;
-    const codeDocs = apiResult.codeSnippets.map(formatCodeSnippet);
-    const infoDocs = apiResult.infoSnippets.map(formatInfoSnippet);
+    const codeDocs = (apiResult.codeSnippets ?? []).map(formatCodeSnippet);
+    const infoDocs = (apiResult.infoSnippets ?? []).map(formatInfoSnippet);
 
     return [...codeDocs, ...infoDocs];
   }

--- a/packages/sdk/src/commands/search-library/index.test.ts
+++ b/packages/sdk/src/commands/search-library/index.test.ts
@@ -2,8 +2,13 @@ import { describe, test, expect } from "vitest";
 import { SearchLibraryCommand } from "./index";
 import { newHttpClient } from "../../utils/test-utils";
 import { Context7 } from "../../client";
+import type { Requester } from "@http";
 
 const httpClient = newHttpClient();
+
+function mockRequester(result: unknown): Requester {
+  return { request: () => Promise.resolve({ result }) } as Requester;
+}
 
 describe("SearchLibraryCommand", () => {
   test("should search for a library", async () => {
@@ -41,5 +46,19 @@ describe("SearchLibraryCommand", () => {
     expect(library).toHaveProperty("totalSnippets");
     expect(library).toHaveProperty("trustScore");
     expect(library).toHaveProperty("benchmarkScore");
+  });
+});
+
+describe("SearchLibraryCommand defensive handling", () => {
+  test("returns an empty array when results field is missing", async () => {
+    const command = new SearchLibraryCommand("query", "react");
+    const result = await command.exec(mockRequester({}));
+    expect(result).toEqual([]);
+  });
+
+  test("returns an empty array when results is null", async () => {
+    const command = new SearchLibraryCommand("query", "react");
+    const result = await command.exec(mockRequester({ results: null }));
+    expect(result).toEqual([]);
   });
 });

--- a/packages/sdk/src/commands/search-library/index.ts
+++ b/packages/sdk/src/commands/search-library/index.ts
@@ -36,7 +36,7 @@ export class SearchLibraryCommand extends Command<Library[] | string> {
       throw new Context7Error("Request did not return a result");
     }
 
-    const libraries = result.results.map(formatLibrary);
+    const libraries = (result.results ?? []).map(formatLibrary);
 
     if (this.responseType === "txt") {
       return formatLibrariesAsText(libraries);

--- a/packages/sdk/src/http/index.test.ts
+++ b/packages/sdk/src/http/index.test.ts
@@ -79,3 +79,95 @@ describe("HttpClient error handling", () => {
     expect(error.message).toBe("Service Unavailable");
   });
 });
+
+function newRetryClient(): HttpClient {
+  return new HttpClient({
+    baseUrl: "https://example.com/api",
+    retry: { retries: 2, backoff: () => 0 },
+  });
+}
+
+function mockFetchSequence(responses: Response[]) {
+  const fetchMock = vi.fn();
+  for (const response of responses) {
+    fetchMock.mockResolvedValueOnce(response);
+  }
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+function jsonOk(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function errorResponse(status: number, headers?: Record<string, string>): Response {
+  return new Response("error", { status, headers });
+}
+
+describe("HttpClient retry on transient HTTP errors", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test("retries on 429 then succeeds", async () => {
+    const fetchMock = mockFetchSequence([errorResponse(429), jsonOk({ ok: true })]);
+
+    const { result } = await newRetryClient().request({ path: ["search"] });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ ok: true });
+  });
+
+  test("retries on 5xx server errors then succeeds", async () => {
+    const fetchMock = mockFetchSequence([errorResponse(503), jsonOk({ ok: true })]);
+
+    const { result } = await newRetryClient().request({ path: ["search"] });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ ok: true });
+  });
+
+  test("does not retry on 4xx client errors", async () => {
+    const fetchMock = mockFetchSequence([errorResponse(400), jsonOk({ ok: true })]);
+
+    await expect(newRetryClient().request({ path: ["search"] })).rejects.toBeInstanceOf(
+      Context7Error
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("exhausts retries on persistent 500", async () => {
+    const fetchMock = mockFetchSequence([
+      errorResponse(500),
+      errorResponse(500),
+      errorResponse(500),
+    ]);
+
+    await expect(newRetryClient().request({ path: ["search"] })).rejects.toBeInstanceOf(
+      Context7Error
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(3); // initial + 2 retries
+  });
+
+  test("respects Retry-After header on 429", async () => {
+    const fetchMock = mockFetchSequence([
+      errorResponse(429, { "retry-after": "0" }),
+      jsonOk({ ok: true }),
+    ]);
+
+    const { result } = await newRetryClient().request({ path: ["search"] });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ ok: true });
+  });
+
+  test("retry: false performs a single attempt", async () => {
+    const fetchMock = mockFetchSequence([errorResponse(500), jsonOk({ ok: true })]);
+
+    await expect(newClient().request({ path: ["search"] })).rejects.toBeInstanceOf(Context7Error);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/sdk/src/http/index.ts
+++ b/packages/sdk/src/http/index.ts
@@ -112,7 +112,7 @@ export class HttpClient implements Requester {
     this.retry =
       typeof config?.retry === "boolean" && config?.retry === false
         ? {
-            attempts: 1,
+            attempts: 0,
             backoff: () => 0,
           }
         : {
@@ -153,7 +153,6 @@ export class HttpClient implements Requester {
     for (let i = 0; i <= this.retry.attempts; i++) {
       try {
         res = await fetch(url, requestOptions as RequestInit);
-        break;
       } catch (error_) {
         if (requestOptions.signal?.aborted) {
           throw error_;
@@ -162,7 +161,20 @@ export class HttpClient implements Requester {
         if (i < this.retry.attempts) {
           await new Promise((r) => setTimeout(r, this.retry.backoff(i)));
         }
+        continue;
       }
+
+      // Retry transient HTTP errors: 429 (rate limit) and 5xx (server errors).
+      const retryable = res.status === 429 || res.status >= 500;
+      if (retryable && i < this.retry.attempts) {
+        // Respect the Retry-After header (delta-seconds) when present, else back off.
+        const retryAfter = Number(res.headers.get("retry-after"));
+        const delay = retryAfter > 0 ? retryAfter * 1000 : this.retry.backoff(i);
+        await new Promise((r) => setTimeout(r, delay));
+        continue;
+      }
+
+      break;
     }
     if (!res) {
       throw error ?? new Error("Exhausted all retries");


### PR DESCRIPTION
Two SDK robustness fixes, implemented fresh on current master. Adds mocked unit tests (no API key/network needed).

- `HttpClient` retries `429` (respecting the `Retry-After` header) and `5xx` responses using the configured backoff; non-retryable `4xx` errors still throw immediately.
- `retry: false` now performs exactly one attempt (was 2 due to an off-by-one).
- `searchLibrary` and `getContext` tolerate missing/null array fields in the API response instead of throwing `TypeError`.

Reimplements the still-relevant parts of #1734 (the non-JSON error-body fix it also contained already landed in #2732). Scoped intentionally small.