### PR TITLE
feat(copilot-plugin): pass CONTEXT7_API_KEY from environment to MCP server

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "context7",
       "source": "./plugins/copilot/context7",
       "description": "Up-to-date documentation lookup. Pull version-specific documentation and code examples directly from source repositories into your LLM context.",
-      "version": "1.0.1"
+      "version": "1.0.2"
     }
   ]
 }

--- a/plugins/copilot/context7/.mcp.json
+++ b/plugins/copilot/context7/.mcp.json
@@ -2,7 +2,10 @@
   "mcpServers": {
     "context7": {
       "type": "http",
-      "url": "https://mcp.context7.com/mcp"
+      "url": "https://mcp.context7.com/mcp",
+      "headers": {
+        "CONTEXT7_API_KEY": "${CONTEXT7_API_KEY:-}"
+      }
     }
   }
 }

--- a/plugins/copilot/context7/README.md
+++ b/plugins/copilot/context7/README.md
@@ -20,6 +20,17 @@ copilot plugin marketplace add upstash/context7
 copilot plugin install context7@context7-marketplace
 ```
 
+## API Key (Recommended)
+
+Without an API key, the plugin connects anonymously and shares the anonymous rate limits. To use your own plan, create an API key in the [Context7 dashboard](https://context7.com/dashboard) and export it as an environment variable before launching Copilot CLI:
+
+```bash
+# e.g. in ~/.zshrc or ~/.bashrc
+export CONTEXT7_API_KEY="your-api-key"
+```
+
+The plugin's MCP server configuration picks up `CONTEXT7_API_KEY` automatically. Restart Copilot CLI after setting it, then verify the key is being used by checking your usage in the [dashboard](https://context7.com/dashboard).
+
 ## Available Tools
 
 ### resolve-library-id

--- a/plugins/copilot/context7/plugin.json
+++ b/plugins/copilot/context7/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "context7",
   "description": "Upstash Context7 MCP server for up-to-date documentation lookup. Pull version-specific documentation and code examples directly from source repositories into your LLM context.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": {
     "name": "Upstash"
   },


### PR DESCRIPTION
The Copilot CLI plugin connected to mcp.context7.com anonymously with no way to attach an API key. Add a CONTEXT7_API_KEY header sourced from the environment so plugin users are billed against their own plan.

Uses the ${VAR:-} fallback form: verified on copilot 1.0.61 that plain ${VAR} passes the literal placeholder through when the variable is unset (causing 'Invalid API key' errors), while ${VAR:-} expands to an empty header, which the server treats as anonymous.