### PR TITLE
fix: restore Node 18 support for context7 mcp

### DIFF
--- a/.changeset/node18-context7-mcp.md
+++ b/.changeset/node18-context7-mcp.md
@@ -1,0 +1,5 @@
+---
+"@upstash/context7-mcp": patch
+---
+
+Restore Node 18 support by pinning undici to ^6.26.0 and commander to ^13.1.0, which dropped the Node 20+ engine requirements that caused a "File is not defined" crash on startup.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -48,10 +48,10 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@types/express": "^5.0.4",
     "@upstash/redis": "^1.38.0",
-    "commander": "^14.0.0",
+    "commander": "^13.1.0",
     "express": "^5.1.0",
     "jose": "^6.1.3",
-    "undici": "^7.27.0",
+    "undici": "^6.26.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,8 +119,8 @@ importers:
         specifier: ^1.38.0
         version: 1.38.0
       commander:
-        specifier: ^14.0.0
-        version: 14.0.2
+        specifier: ^13.1.0
+        version: 13.1.0
       express:
         specifier: ^5.1.0
         version: 5.1.0
@@ -128,8 +128,8 @@ importers:
         specifier: ^6.1.3
         version: 6.1.3
       undici:
-        specifier: ^7.27.0
-        version: 7.27.0
+        specifier: ^6.26.0
+        version: 6.26.0
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -1675,6 +1675,10 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  commander@13.1.0:
+    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
+    engines: {node: '>=18'}
+
   commander@14.0.2:
     resolution: {integrity: sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==}
     engines: {node: '>=20'}
@@ -2950,9 +2954,9 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@7.27.0:
-    resolution: {integrity: sha512-+t2Z/GwkZQDtu00813aP66ygViGtPHKhhoFZpQKpKrE+9jIgES+Zw+mFNaDWOVRKiuJjuqKHzD3B1sfGg8+ZOQ==}
-    engines: {node: '>=20.18.1'}
+  undici@6.26.0:
+    resolution: {integrity: sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==}
+    engines: {node: '>=18.17'}
 
   undici@8.3.0:
     resolution: {integrity: sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==}
@@ -4709,6 +4713,8 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  commander@13.1.0: {}
+
   commander@14.0.2: {}
 
   commander@15.0.0: {}
@@ -6030,7 +6036,7 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@7.27.0: {}
+  undici@6.26.0: {}
 
   undici@8.3.0: {}
 


### PR DESCRIPTION
## Summary
- pin @upstash/context7-mcp runtime dependencies to Node 18-compatible major versions
- update the lockfile so Node 18 does not load undici 7 at startup

Closes #2761

## Validation
- pnpm install --filter @upstash/context7-mcp --frozen-lockfile
- pnpm --filter @upstash/context7-mcp build
- pnpm --filter @upstash/context7-mcp typecheck
- pnpm --filter @upstash/context7-mcp test
- pnpm --filter @upstash/context7-mcp lint:check
- NPM_CONFIG_CACHE=/tmp/context7-node18-npm-cache npm exec --package node@18.20.8 -- node packages/mcp/dist/index.js --version