### PR TITLE
fix(cli): surface GitHub API error details when skill download fails

### DIFF
--- a/.changeset/slow-adults-bet.md
+++ b/.changeset/slow-adults-bet.md
@@ -1,0 +1,13 @@
+---
+"ctx7": patch
+---
+
+Surface GitHub API error details when skill download fails (#2363)
+
+Previously, any GitHub API failure during `ctx7 setup` or `ctx7 setup --cli` produced the opaque message "GitHub API error", making it impossible to distinguish a 403 rate-limit from a 401 bad token or a 404 wrong branch.
+
+Changes:
+- `fetchRepoTree` and `fetchDefaultBranch` now extract the HTTP status and GitHub error body, returning descriptive strings like `"HTTP 403: API rate limit exceeded"`
+- `listSkillsFromGitHub` distinguishes a true 404 (repo not found) from other errors (rate-limit, bad credentials) that previously all collapsed into the same silent result
+- When a request fails unauthenticated with a 403/429, a hint is shown: `run \`gh auth login\` or set the GITHUB_TOKEN env var to increase rate limits`
+- Failed skill entries in the setup results table now show a red `✖` with the error detail on its own line instead of embedding it in the status string

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -384,6 +384,21 @@ async function setupAgent(
   };
 }
 
+function logSkillStatus(skillStatus: string, skillPath: string): void {
+  const skillFailed = skillStatus.startsWith("failed:");
+  const skillIcon = skillStatus === "installed" ? pc.green("+") : skillFailed ? pc.red("✖") : pc.dim("~");
+  log.plain(`    ${skillIcon} Skill ${skillFailed ? "failed" : skillStatus}`);
+  log.plain(`      ${pc.dim(skillPath)}`);
+  if (skillFailed) {
+    log.plain(`      ${pc.red(skillStatus.slice("failed: ".length))}`);
+    if (skillStatus.includes("EACCES")) {
+      log.plain(
+        `      ${pc.yellow("tip:")} fix permissions with: ${pc.cyan(`sudo chown -R $(whoami) ${dirname(dirname(skillPath))}`)}`
+      );
+    }
+  }
+}
+
 async function setupMcp(agents: SetupAgent[], options: SetupOptions, scope: Scope): Promise<void> {
   const transport = resolveTransport(options);
   if (transport === "stdio" && options.oauth) {
@@ -420,14 +435,7 @@ async function setupMcp(agents: SetupAgent[], options: SetupOptions, scope: Scop
     const ruleIcon = r.ruleStatus === "installed" ? pc.green("+") : pc.dim("~");
     log.plain(`    ${ruleIcon} Rule ${r.ruleStatus}`);
     log.plain(`      ${pc.dim(r.rulePath)}`);
-    const skillIcon = r.skillStatus === "installed" ? pc.green("+") : pc.dim("~");
-    log.plain(`    ${skillIcon} Skill ${r.skillStatus}`);
-    log.plain(`      ${pc.dim(r.skillPath)}`);
-    if (r.skillStatus.includes("EACCES")) {
-      log.plain(
-        `      ${pc.yellow("tip:")} fix permissions with: ${pc.cyan(`sudo chown -R $(whoami) ${dirname(dirname(r.skillPath))}`)}`
-      );
-    }
+    logSkillStatus(r.skillStatus, r.skillPath);
   }
   log.blank();
 
@@ -498,9 +506,10 @@ async function setupCli(options: SetupOptions): Promise<void> {
   }> = [];
 
   for (const agentName of agents) {
-    installSpinner.text = `Setting up ${getAgent(agentName).displayName}...`;
+    const agentDef = getAgent(agentName);
+    installSpinner.text = `Setting up ${agentDef.displayName}...`;
     const r = await setupCliAgent(agentName, scope, downloadData);
-    results.push({ agent: getAgent(agentName).displayName, ...r });
+    results.push({ agent: agentDef.displayName, ...r });
   }
 
   installSpinner.succeed("Context7 CLI setup complete");
@@ -508,14 +517,7 @@ async function setupCli(options: SetupOptions): Promise<void> {
   log.blank();
   for (const r of results) {
     log.plain(`  ${pc.bold(r.agent)}`);
-    const skillIcon = r.skillStatus === "installed" ? pc.green("+") : pc.dim("~");
-    log.plain(`    ${skillIcon} Skill ${r.skillStatus}`);
-    log.plain(`      ${pc.dim(r.skillPath)}`);
-    if (r.skillStatus.includes("EACCES")) {
-      log.plain(
-        `      ${pc.yellow("tip:")} fix permissions with: ${pc.cyan(`sudo chown -R $(whoami) ${dirname(dirname(r.skillPath))}`)}`
-      );
-    }
+    logSkillStatus(r.skillStatus, r.skillPath);
     const ruleIcon =
       r.ruleStatus === "installed" || r.ruleStatus === "updated" ? pc.green("+") : pc.dim("~");
     log.plain(`    ${ruleIcon} Rule ${r.ruleStatus}`);

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -386,7 +386,8 @@ async function setupAgent(
 
 function logSkillStatus(skillStatus: string, skillPath: string): void {
   const skillFailed = skillStatus.startsWith("failed:");
-  const skillIcon = skillStatus === "installed" ? pc.green("+") : skillFailed ? pc.red("✖") : pc.dim("~");
+  const skillIcon =
+    skillStatus === "installed" ? pc.green("+") : skillFailed ? pc.red("✖") : pc.dim("~");
   log.plain(`    ${skillIcon} Skill ${skillFailed ? "failed" : skillStatus}`);
   log.plain(`      ${pc.dim(skillPath)}`);
   if (skillFailed) {

--- a/packages/cli/src/utils/github.ts
+++ b/packages/cli/src/utils/github.ts
@@ -152,15 +152,24 @@ function getGitHubHeaders(): Record<string, string> {
   };
 }
 
+async function extractGitHubError(response: Response): Promise<string> {
+  let detail = `HTTP ${response.status}`;
+  try {
+    const body = (await response.json()) as { message?: string };
+    if (body.message) detail += `: ${body.message}`;
+  } catch {}
+  return detail;
+}
+
 async function fetchRepoTree(
   owner: string,
   repo: string,
   branch: string,
   headers: Record<string, string>
-): Promise<GitHubTreeResponse | null> {
+): Promise<GitHubTreeResponse | { error: string }> {
   const treeUrl = `${GITHUB_API}/repos/${owner}/${repo}/git/trees/${branch}?recursive=1`;
   const response = await fetch(treeUrl, { headers });
-  if (!response.ok) return null;
+  if (!response.ok) return { error: await extractGitHubError(response) };
   return (await response.json()) as GitHubTreeResponse;
 }
 
@@ -168,9 +177,9 @@ async function fetchDefaultBranch(
   owner: string,
   repo: string,
   headers: Record<string, string>
-): Promise<{ branch: string } | { status: number }> {
+): Promise<{ branch: string } | { error: string; status: number }> {
   const response = await fetch(`${GITHUB_API}/repos/${owner}/${repo}`, { headers });
-  if (!response.ok) return { status: response.status };
+  if (!response.ok) return { error: await extractGitHubError(response), status: response.status };
   const data = (await response.json()) as { default_branch: string };
   return { branch: data.default_branch };
 }
@@ -190,10 +199,13 @@ export async function listSkillsFromGitHub(project: string): Promise<GitHubSkill
 
     const headers = getGitHubHeaders();
     const branchResult = await fetchDefaultBranch(owner, repo, headers);
-    if ("status" in branchResult) return { status: "repo_not_found" };
+    if ("error" in branchResult) {
+      if (branchResult.status === 404) return { status: "repo_not_found" };
+      return { status: "error", error: branchResult.error };
+    }
 
     const treeData = await fetchRepoTree(owner, repo, branchResult.branch, headers);
-    if (!treeData) return { status: "error", error: "Could not fetch repository tree" };
+    if ("error" in treeData) return { status: "error", error: treeData.error };
 
     const skillMdFiles = treeData.tree.filter(
       (item) => item.type === "blob" && item.path.toLowerCase().endsWith("skill.md")
@@ -250,8 +262,12 @@ export async function downloadSkillFromGitHub(
     const ghHeaders = getGitHubHeaders();
 
     const treeData = await fetchRepoTree(owner, repo, branch, ghHeaders);
-    if (!treeData) {
-      return { files: [], error: `GitHub API error` };
+    if ("error" in treeData) {
+      const hint =
+        !ghHeaders["Authorization"] && /403|429|rate/.test(treeData.error)
+          ? " — set GITHUB_TOKEN env var to increase rate limits"
+          : "";
+      return { files: [], error: `GitHub API error: ${treeData.error}${hint}` };
     }
 
     const skillFiles = treeData.tree.filter(

--- a/packages/cli/src/utils/github.ts
+++ b/packages/cli/src/utils/github.ts
@@ -265,7 +265,7 @@ export async function downloadSkillFromGitHub(
     if ("error" in treeData) {
       const hint =
         !ghHeaders["Authorization"] && /403|429|rate/.test(treeData.error)
-          ? " — set GITHUB_TOKEN env var to increase rate limits"
+          ? " — run `gh auth login` or set the GITHUB_TOKEN env var to increase rate limits"
           : "";
       return { files: [], error: `GitHub API error: ${treeData.error}${hint}` };
     }


### PR DESCRIPTION
## Problem

Closes #2363

`ctx7 setup` and `ctx7 setup --cli` swallowed all GitHub API errors into a single opaque message:

```
✖ Failed to download find-docs skill: GitHub API error
```

This made it impossible for users to self-diagnose whether the failure was a 403 rate-limit, a 401 bad/expired token, or a 404 wrong branch. Users with `GITHUB_TOKEN` already set in their environment had no way to know their token was being accepted or rejected.

The original missing `Authorization` header bug was already fixed in source, but the unhelpful error messages kept users confused (see the ongoing thread in #2363).

## What changed

### `packages/cli/src/utils/github.ts`

- **`extractGitHubError(response)`** — new private helper that reads the HTTP status and GitHub's JSON error body (`{ message }`) into a single descriptive string (e.g. `"HTTP 403: API rate limit exceeded for 1.2.3.4"`). Both fetch helpers now use it instead of duplicating the logic.
- **`fetchRepoTree`** — returns `{ error: string }` with the full detail instead of bare `null`.
- **`fetchDefaultBranch`** — now also extracts the error body (previously discarded it). Returns `{ error: string; status: number }` so callers can distinguish a true 404 (repo not found) from a 403/429 rate-limit — both of which previously collapsed into the same silent `repo_not_found` result.
- **`listSkillsFromGitHub`** — updated to propagate the richer error and only return `repo_not_found` on HTTP 404.
- **`downloadSkillFromGitHub`** — appends an actionable hint when the request was unauthenticated and the status is 403/429:
  ```
  GitHub API error: HTTP 403: API rate limit exceeded — set GITHUB_TOKEN env var to increase rate limits
  ```

### `packages/cli/src/commands/setup.ts`

- **`logSkillStatus(skillStatus, skillPath)`** — extracted shared helper that was copy-pasted identically in both `setupMcp` and `setupCli` render loops. Both loops now call it in one line.
- Failed skill entries now show a red `✖` icon with the error detail on its own sub-line, matching the style of the CLI flow's `spinner.fail(...)`:
  ```
  ✖ Skill failed
    ~/.claude/skills/context7-mcp
    GitHub API error: HTTP 401: Bad credentials
  ```
- The `EACCES` permissions tip is now correctly guarded inside the `skillFailed` branch.

## Test plan

- [ ] `ctx7 setup` with a valid token → skill installs, no change in happy path output
- [ ] `ctx7 setup` with an expired/invalid token → `✖ Skill failed` + `HTTP 401: Bad credentials`
- [ ] `ctx7 setup --cli` with no token, rate limited → `✖ Failed to download find-docs skill: GitHub API error: HTTP 403: ... — set GITHUB_TOKEN env var to increase rate limits`
- [ ] `ctx7 setup --cli` with `GITHUB_TOKEN` set → token is included in request, 403 hint does not appear
- [ ] `ctx7 skills install <skill>` from a non-existent repo → `repo_not_found` (404 path unchanged)
- [ ] `ctx7 skills install <skill>` from a repo that triggers a 403 → surfaces the error string instead of `repo_not_found`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)