### PR TITLE
fix(claude-plugin): restrict docs-researcher to Context7 tools

### DIFF
--- a/plugins/claude/context7/agents/docs-researcher.md
+++ b/plugins/claude/context7/agents/docs-researcher.md
@@ -2,6 +2,16 @@
 name: docs-researcher
 description: Lightweight agent for fetching library documentation without cluttering your main conversation context.
 model: sonnet
+# Restrict to the two Context7 tools so the agent cannot inherit the Agent/Task
+# tool and recursively spawn subagents. Both identifier forms are listed because
+# plugin MCP tools are namespaced as mcp__plugin_<plugin>_<server>__<tool> when
+# installed via the marketplace, but as mcp__<server>__<tool> when loaded via
+# --plugin-dir. Non-matching entries are harmless no-ops.
+tools:
+  - mcp__plugin_context7_context7__resolve-library-id
+  - mcp__plugin_context7_context7__query-docs
+  - mcp__context7__resolve-library-id
+  - mcp__context7__query-docs
 ---
 
 You are a documentation researcher specializing in fetching up-to-date library and framework documentation from Context7.


### PR DESCRIPTION
Adds a `tools:` allowlist to the bundled `docs-researcher` Claude Code agent so it can only call the two Context7 MCP tools.

- Without `tools:`, the agent inherits the full main-thread toolset, including the `Agent`/`Task` tool, allowing recursive subagent spawning (observed in #2790 climbing past 100 agents with no self-termination).
- Restricting the allowlist removes `Agent`/`Task` (plus unnecessary Bash/Write/Edit), making recursive spawning structurally impossible.
- Both identifier forms are listed: plugin MCP tools resolve as `mcp__plugin_<plugin>_<server>__<tool>` on a marketplace install, but as `mcp__<server>__<tool>` when loaded via `--plugin-dir`. Unmatched entries are harmless no-ops, so listing both keeps the agent working under either load path.

Verified: with the allowlist, a spawned `docs-researcher` no longer has the `Agent`/`Task` tool and loads without error under both load paths; without it, the agent reports `Agent` in its toolset.

Fixes #2790