### PR TITLE
Add MCP Observatory CI check

### DIFF
--- a/.github/workflows/mcp-observatory.yml
+++ b/.github/workflows/mcp-observatory.yml
@@ -1,0 +1,18 @@
+name: MCP Observatory
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  mcp-observatory:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: KryptosAI/mcp-observatory/action@main
+        with:
+          target: mcp-observatory.target.json
+          deep: true
+          security: true
+          comment-on-pr: true

--- a/mcp-observatory.target.json
+++ b/mcp-observatory.target.json
@@ -1,0 +1,13 @@
+{
+  "targetId": "mcp-server",
+  "adapter": "local-process",
+  "command": "npx",
+  "args": [
+    "-y",
+    "@upstash/context7-mcp@latest"
+  ],
+  "timeoutMs": 15000,
+  "metadata": {
+    "observatory": "generated-by-init-ci"
+  }
+}


### PR DESCRIPTION
This adds a lightweight MCP Observatory check for the Context7 MCP server.\n\nWhy it helps:\n\n- verifies MCP tools still respond correctly\n- catches schema drift and common security footguns before release\n- posts a readable PR report for maintainers\n- gives users a compatibility signal when evaluating MCP servers\n\nI validated the target locally with:\n\n```bash\nnpx @kryptosai/mcp-observatory@latest test --target mcp-observatory.target.json --security --deep\n```\n\nResult: passed, with 2 tools detected from `npx -y @upstash/context7-mcp@latest`.\n\nIt runs in GitHub Actions and does not require an MCP Observatory account. If the check is too strict for this repo, the workflow can be adjusted while keeping the report visible.