### PR TITLE
fix: normalize context library IDs in clients

### DIFF
--- a/packages/cli/src/__tests__/library-id.test.ts
+++ b/packages/cli/src/__tests__/library-id.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 
-import { recoverLibraryId } from "../utils/library-id.js";
+import { normalizeLibraryId, recoverLibraryId } from "../utils/library-id.js";
 
 describe("recoverLibraryId", () => {
   test("passes through a normal library ID unchanged", () => {
@@ -40,5 +40,22 @@ describe("recoverLibraryId", () => {
 
   test("leaves an unrecognized Windows path untouched", () => {
     expect(recoverLibraryId("C:/Users/me/project")).toBe("C:/Users/me/project");
+  });
+});
+
+describe("normalizeLibraryId", () => {
+  test("lowercases case-insensitive library ID segments", () => {
+    expect(normalizeLibraryId("/ClickHouse/ClickHouse")).toBe("/clickhouse/clickhouse");
+    expect(normalizeLibraryId("/websites/Example_COM")).toBe("/websites/example_com");
+  });
+
+  test("preserves version suffix casing", () => {
+    expect(normalizeLibraryId("/Vercel/Next.js/v15.1.8-CANARY")).toBe(
+      "/vercel/next.js/v15.1.8-CANARY"
+    );
+  });
+
+  test("leaves invalid IDs untouched", () => {
+    expect(normalizeLibraryId("facebook/react")).toBe("facebook/react");
   });
 });

--- a/packages/cli/src/commands/docs.ts
+++ b/packages/cli/src/commands/docs.ts
@@ -3,7 +3,7 @@ import pc from "picocolors";
 import ora from "ora";
 
 import { resolveLibrary, getLibraryContext } from "../utils/api.js";
-import { recoverLibraryId } from "../utils/library-id.js";
+import { normalizeLibraryId, recoverLibraryId } from "../utils/library-id.js";
 import { log } from "../utils/logger.js";
 import { trackEvent } from "../utils/tracking.js";
 import { loadTokens, isTokenExpired } from "../utils/auth.js";
@@ -122,7 +122,7 @@ async function queryCommand(
   trackEvent("command", { name: "docs" });
 
   // Git Bash on Windows rewrites "/owner/repo" into a Windows path; recover it.
-  libraryId = recoverLibraryId(libraryId);
+  libraryId = normalizeLibraryId(recoverLibraryId(libraryId));
 
   if (!libraryId.startsWith("/") || !/^\/[^/]+\/[^/]/.test(libraryId)) {
     log.error(`Invalid library ID: "${libraryId}"`);

--- a/packages/cli/src/utils/library-id.ts
+++ b/packages/cli/src/utils/library-id.ts
@@ -20,3 +20,12 @@ export function recoverLibraryId(input: string): string {
   const match = normalized.match(/^[A-Za-z]:\/.*?\/(?:Git|PortableGit|git-bash)\/(.+)$/i);
   return match ? `/${match[1]}` : input;
 }
+
+export function normalizeLibraryId(input: string): string {
+  const parts = input.split("/");
+  if (parts[0] !== "" || parts.length < 3) return input;
+
+  parts[1] = parts[1].toLowerCase();
+  parts[2] = parts[2].toLowerCase();
+  return parts.join("/");
+}

--- a/packages/mcp/src/lib/api.ts
+++ b/packages/mcp/src/lib/api.ts
@@ -100,6 +100,15 @@ function readPromptSignal(response: Response, context: ClientContext): void {
   }
 }
 
+function normalizeLibraryId(input: string): string {
+  const parts = input.split("/");
+  if (parts[0] !== "" || parts.length < 3) return input;
+
+  parts[1] = parts[1].toLowerCase();
+  parts[2] = parts[2].toLowerCase();
+  return parts.join("/");
+}
+
 /**
  * Searches for libraries matching the given query
  * @param query The user's question or task (used for LLM relevance ranking)
@@ -148,7 +157,7 @@ export async function fetchLibraryContext(
   try {
     const url = new URL(`${CONTEXT7_API_BASE_URL}/v2/context`);
     url.searchParams.set("query", request.query);
-    url.searchParams.set("libraryId", request.libraryId);
+    url.searchParams.set("libraryId", normalizeLibraryId(request.libraryId));
 
     const headers = generateHeaders(context);
 


### PR DESCRIPTION
## Summary
- normalize the case-insensitive library ID segments before CLI docs lookups
- normalize the same segments before MCP context requests
- keep version/tag suffix casing unchanged

Addresses the CLI/MCP client side of #2811.

## Test
- pnpm --filter ctx7 test -- library-id.test.ts
- pnpm --filter ctx7 typecheck
- pnpm --filter @upstash/context7-mcp typecheck
- pnpm --filter ctx7 format:check
- pnpm --filter @upstash/context7-mcp format:check
- git diff --check