### PR TITLE
CTX7-1760: group on-prem feature pages under a Features nav section

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -87,9 +87,14 @@
                   "enterprise/deployment/kubernetes"
                 ]
               },
-              "enterprise/backup-restore",
-              "enterprise/library-import",
-              "enterprise/gitops",
+              {
+                "group": "Features",
+                "pages": [
+                  "enterprise/library-import",
+                  "enterprise/gitops",
+                  "enterprise/backup-restore"
+                ]
+              },
               {
                 "group": "API Reference",
                 "pages": [


### PR DESCRIPTION
Groups the On-Premise feature pages under a single **Features** sidebar section instead of listing them flat, matching the existing Security and Deployment sub-groups.

- New `Features` group contains Library Import, GitOps, and Backup & Restore.
- Nav-only change in `docs.json`; no files moved, so all page URLs are unchanged.

Stacked on the GitOps docs PR (#2816) because it references the `enterprise/gitops` page introduced there. GitHub will retarget the base to `master` automatically once #2816 merges.