### PR TITLE
docs: update Docker MCP Toolkit to remote server (fixes #790)

### DIFF
--- a/docs/resources/all-clients.mdx
+++ b/docs/resources/all-clients.mdx
@@ -996,34 +996,29 @@ docker build -t context7-mcp .
 }
 ```
 
-If you use the Docker MCP Toolkit image (`mcp/context7`) with a stdio-based client, set `MCP_TRANSPORT=stdio` so the container starts with stdio transport instead of its HTTP default. For Cline, Roo Code, and Claude Desktop, use:
+</Accordion>
+
+<Accordion title="Docker MCP Toolkit">
+
+Context7 is available in the [Docker MCP Catalog](https://hub.docker.com/mcp/server/context7/overview) as a **remote** server, so you don't need to build, pull, or run a local image. The MCP Toolkit connects to the hosted endpoint for you.
+
+1. In Docker Desktop, open **MCP Toolkit → Catalog**, search for **Context7**, and enable it.
+2. (Optional) In the server's **Config** tab, set your Context7 API key (`CONTEXT7_API_KEY`) for higher rate limits. The server also works without one.
+3. Connect your MCP client to Docker's MCP gateway. Either run `docker mcp client connect <client>` (for example `vscode`, `cursor`, or `claude-desktop`), or add the gateway to your client config manually:
 
 ```json
 {
   "mcpServers": {
-    "context7": {
+    "MCP_DOCKER": {
       "command": "docker",
-      "args": ["run", "-i", "--rm", "-e", "MCP_TRANSPORT=stdio", "mcp/context7"]
+      "args": ["mcp", "gateway", "run"],
+      "type": "stdio"
     }
   }
 }
 ```
 
-For VS Code, use the same Docker command in the `servers` format:
-
-```json
-{
-  "servers": {
-    "context7": {
-      "type": "stdio",
-      "command": "docker",
-      "args": ["run", "-i", "--rm", "-e", "MCP_TRANSPORT=stdio", "mcp/context7"]
-    }
-  }
-}
-```
-
-Keep using the remote server URL for HTTP-based clients.
+The gateway exposes every server you've enabled in the MCP Toolkit, including Context7. Tools appear under the `MCP_DOCKER` server in your client.
 
 </Accordion>
 


### PR DESCRIPTION
## What

Updates the Docker MCP Toolkit instructions in `docs/resources/all-clients.mdx` to match the new Docker MCP Catalog entry.

## Why

The Docker MCP Catalog entry for Context7 was migrated from a local container image (`mcp/context7`, pinned to **v1.0.14**) to the hosted **remote** server in [docker/mcp-registry#3916](https://github.com/docker/mcp-registry/pull/3916) (merged). The old pinned image was stale and timed out on startup (`MCP error -32001: Request timed out`) — exactly the bug reported in #790.

Our docs still instructed users to `docker run -i --rm -e MCP_TRANSPORT=stdio mcp/context7`, i.e. to run that same stale image, so they no longer match how the Toolkit serves Context7.

## Changes

- Removed the outdated `mcp/context7` stdio-image config blocks.
- Added a dedicated **"Docker MCP Toolkit"** accordion: enable Context7 from the catalog in Docker Desktop, optionally set the `CONTEXT7_API_KEY` secret, and connect clients via the Docker MCP gateway (`MCP_DOCKER` / `docker mcp client connect <client>`).
- Left the self-build **"Using Docker"** accordion (build-your-own image) unchanged.

Gateway commands and the `MCP_DOCKER` config were verified against Docker's official MCP Catalog & Toolkit docs.

Fixes #790

🤖 Generated with [Claude Code](https://claude.com/claude-code)