### PR TITLE
docs(ai-sdk): clarify multi-source library selection

### DIFF
--- a/packages/tools-ai-sdk/src/index.test.ts
+++ b/packages/tools-ai-sdk/src/index.test.ts
@@ -223,6 +223,7 @@ describe("@upstash/context7-tools-ai-sdk", () => {
       expect(RESOLVE_LIBRARY_ID_DESCRIPTION).toBeDefined();
       expect(typeof RESOLVE_LIBRARY_ID_DESCRIPTION).toBe("string");
       expect(RESOLVE_LIBRARY_ID_DESCRIPTION).toContain("library");
+      expect(RESOLVE_LIBRARY_ID_DESCRIPTION).toContain("docs site");
     });
   });
 });

--- a/packages/tools-ai-sdk/src/prompts/system.ts
+++ b/packages/tools-ai-sdk/src/prompts/system.ts
@@ -61,6 +61,8 @@ Selection Process:
 - Documentation coverage (prioritize libraries with higher Code Snippet counts)
 - Source reputation (consider libraries with High or Medium reputation more authoritative)
 - Benchmark Score: Quality indicator (100 is the highest score)
+- Source type fit: some projects have separate repo and docs site entries; choose the source that best matches the user's question
+- If one source lacks the needed API reference, examples, or guide content, try the other available source before concluding the docs are missing
 
 Response Format:
 - Return the selected library ID in a clearly marked section


### PR DESCRIPTION
## Summary

- clarify that Context7 can return separate repo and docs-site entries for the same project
- tell agents to pick the source that best fits the user query
- tell agents to try the sibling source before concluding docs are missing

Related to #2069.

## Testing

- `corepack pnpm --filter @upstash/context7-sdk build`
- `corepack pnpm --filter @upstash/context7-tools-ai-sdk typecheck`
- `corepack pnpm --filter @upstash/context7-tools-ai-sdk build`
- `corepack pnpm --filter @upstash/context7-tools-ai-sdk exec vitest run src/index.test.ts -t "should export RESOLVE_LIBRARY_ID_DESCRIPTION"`
- `corepack pnpm --filter @upstash/context7-tools-ai-sdk exec prettier --check src/prompts/system.ts src/index.test.ts`
- `git diff --check`

## Notes

AI-assisted: yes. I manually reviewed the diff and test output before opening this PR.

Full `corepack pnpm --filter @upstash/context7-tools-ai-sdk test` was not run to completion because the existing Bedrock-backed tests require `AWS_REGION` / `AWS_BEARER_TOKEN_BEDROCK` in the local environment. The targeted non-Bedrock regression test above passed.
