### PR TITLE
docs(enterprise): document programmatic library import/export API

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -120,6 +120,7 @@
                       "enterprise/api/parse/parse-a-git-repository",
                       "enterprise/api/parse/parse-an-openapi-spec-by-url",
                       "enterprise/api/parse/upload-an-openapi-spec-file",
+                      "enterprise/api/parse/import-libraries",
                       "enterprise/api/parse/parse-a-website",
                       "enterprise/api/parse/refresh-a-library",
                       "enterprise/api/parse/get-parse-status"

--- a/docs/enterprise/api/parse/import-libraries.mdx
+++ b/docs/enterprise/api/parse/import-libraries.mdx
@@ -1,0 +1,5 @@
+---
+title: "Import a library bundle"
+description: "Import pre-parsed libraries into an airgapped on-premise install, as a JSON body or a Context7 Cloud export file"
+openapi: "openapi-enterprise.json POST /import-libraries"
+---

--- a/docs/enterprise/library-import.mdx
+++ b/docs/enterprise/library-import.mdx
@@ -123,19 +123,18 @@ Re-importing a library you already have does nothing unless **Overwrite existing
 
 ## Automating with the API
 
-Beyond the dashboard flow, both sides expose an API so you can script imports — for example, to sync a fixed set of libraries into on-premise on a schedule through a bridge host that can reach both networks.
+Besides the dashboard flow, both sides expose an API so you can script imports. For example, you can sync a fixed set of libraries into on-premise on a schedule from a bridge host that can reach both networks.
 
 <Steps>
 
 <Step title="Export from Context7 Cloud">
 
-Call the cloud export endpoint with your **enterprise license key**. It returns one library's full structured content (every code and info snippet, no embeddings), shaped to feed straight into the import endpoint.
+Call the cloud export endpoint and pass your **enterprise license key** in the request body. It returns one library's full content (every code and info snippet, without embeddings), already shaped for the import endpoint.
 
 ```bash
-curl -X POST https://context7.com/api/v1/license/export \
-  -H "Authorization: Bearer $CONTEXT7_LICENSE_KEY" \
+curl -X POST https://context7.com/api/v1/enterprise/export \
   -H "Content-Type: application/json" \
-  -d '{"library":"vercel/next.js"}'
+  -d '{"licenseKey":"YOUR_LICENSE_KEY","library":"vercel/next.js"}'
 ```
 
 Only public libraries can be exported this way.
@@ -144,11 +143,11 @@ Only public libraries can be exported this way.
 
 <Step title="Import into your on-premise install">
 
-POST that JSON to your install's [import endpoint](/enterprise/api/parse/import-libraries), authenticated with a [personal API key](/enterprise/api/authentication#creating-an-api-key). The body is `{ "libraries": [...], "force": false }` — exactly the export response shape.
+Post that JSON to your install's [import endpoint](/enterprise/api/parse/import-libraries), authenticated with a [personal API key](/enterprise/api/authentication#creating-an-api-key). The body is `{ "libraries": [...], "force": false }`, which is exactly the export response shape.
 
 ```bash
 curl -X POST https://your-instance.example.com/api/import-libraries \
-  -H "Authorization: Bearer $ONPREM_API_KEY" \
+  -H "Authorization: Bearer YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   --data @library.json
 ```
@@ -157,20 +156,19 @@ curl -X POST https://your-instance.example.com/api/import-libraries \
 
 </Steps>
 
-From a host that can reach both — a bridge or import gateway — the two calls chain directly:
+From a host that can reach both networks, such as a bridge or import gateway, the two calls chain directly:
 
 ```bash
-curl -sf -X POST https://context7.com/api/v1/license/export \
-  -H "Authorization: Bearer $CONTEXT7_LICENSE_KEY" \
+curl -sf -X POST https://context7.com/api/v1/enterprise/export \
   -H "Content-Type: application/json" \
-  -d '{"library":"vercel/next.js"}' \
+  -d '{"licenseKey":"YOUR_LICENSE_KEY","library":"vercel/next.js"}' \
 | curl -X POST https://your-instance.example.com/api/import-libraries \
-  -H "Authorization: Bearer $ONPREM_API_KEY" \
+  -H "Authorization: Bearer YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   --data-binary @-
 ```
 
-For a strictly airgapped install, save the export response to a file, transfer it the same way you would the `.zip`, then import it. The import endpoint also accepts the dashboard `.zip` bundle as a `multipart/form-data` upload (field `bundleFile`) — see the [endpoint reference](/enterprise/api/parse/import-libraries).
+For a strictly airgapped install, save the export response to a file, transfer it the same way you would the `.zip`, then import it. The import endpoint also accepts the dashboard `.zip` bundle as a `multipart/form-data` upload (field `bundleFile`). See the [endpoint reference](/enterprise/api/parse/import-libraries) for details.
 
 <Note>
 The import endpoint is available only on offline-license installs, the same gate as the dashboard flow. Imported libraries are skipped unless `force` is set, and the response lists what it queued and skipped.

--- a/docs/enterprise/library-import.mdx
+++ b/docs/enterprise/library-import.mdx
@@ -173,7 +173,7 @@ curl -sf -X POST https://context7.com/api/v1/enterprise/export \
 For a strictly airgapped install, save the export response to a file, transfer it the same way you would the `.zip`, then import it. The import endpoint also accepts the dashboard `.zip` bundle as a `multipart/form-data` upload (field `bundleFile`). See the [endpoint reference](/enterprise/api/parse/import-libraries) for details.
 
 <Note>
-The import endpoint is available only on offline-license installs, the same gate as the dashboard flow. Imported libraries are skipped unless `force` is set, and the response lists what it queued and skipped.
+The import endpoint is available only on offline-license installs, the same gate as the dashboard flow. A library that already exists is skipped unless you overwrite it with `force`, either as a `?force=true` query param (handy when piping the export straight through) or a `"force": true` field in a JSON body. The response lists what it queued and skipped.
 </Note>
 
 ## Limits

--- a/docs/enterprise/library-import.mdx
+++ b/docs/enterprise/library-import.mdx
@@ -121,6 +121,61 @@ Because your install didn't parse these libraries from source, it can't refresh 
 Re-importing a library you already have does nothing unless **Overwrite existing libraries** is checked. The import skips libraries that already exist and tells you which ones it skipped.
 </Note>
 
+## Automating with the API
+
+Beyond the dashboard flow, both sides expose an API so you can script imports — for example, to sync a fixed set of libraries into on-premise on a schedule through a bridge host that can reach both networks.
+
+<Steps>
+
+<Step title="Export from Context7 Cloud">
+
+Call the cloud export endpoint with your **enterprise license key**. It returns one library's full structured content (every code and info snippet, no embeddings), shaped to feed straight into the import endpoint.
+
+```bash
+curl -X POST https://context7.com/api/v1/license/export \
+  -H "Authorization: Bearer $CONTEXT7_LICENSE_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"library":"vercel/next.js"}'
+```
+
+Only public libraries can be exported this way.
+
+</Step>
+
+<Step title="Import into your on-premise install">
+
+POST that JSON to your install's [import endpoint](/enterprise/api/parse/import-libraries), authenticated with a [personal API key](/enterprise/api/authentication#creating-an-api-key). The body is `{ "libraries": [...], "force": false }` — exactly the export response shape.
+
+```bash
+curl -X POST https://your-instance.example.com/api/import-libraries \
+  -H "Authorization: Bearer $ONPREM_API_KEY" \
+  -H "Content-Type: application/json" \
+  --data @library.json
+```
+
+</Step>
+
+</Steps>
+
+From a host that can reach both — a bridge or import gateway — the two calls chain directly:
+
+```bash
+curl -sf -X POST https://context7.com/api/v1/license/export \
+  -H "Authorization: Bearer $CONTEXT7_LICENSE_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"library":"vercel/next.js"}' \
+| curl -X POST https://your-instance.example.com/api/import-libraries \
+  -H "Authorization: Bearer $ONPREM_API_KEY" \
+  -H "Content-Type: application/json" \
+  --data-binary @-
+```
+
+For a strictly airgapped install, save the export response to a file, transfer it the same way you would the `.zip`, then import it. The import endpoint also accepts the dashboard `.zip` bundle as a `multipart/form-data` upload (field `bundleFile`) — see the [endpoint reference](/enterprise/api/parse/import-libraries).
+
+<Note>
+The import endpoint is available only on offline-license installs, the same gate as the dashboard flow. Imported libraries are skipped unless `force` is set, and the response lists what it queued and skipped.
+</Note>
+
 ## Limits
 
 - Up to 50 libraries per export.

--- a/docs/enterprise/library-import.mdx
+++ b/docs/enterprise/library-import.mdx
@@ -129,12 +129,13 @@ Besides the dashboard flow, both sides expose an API so you can script imports. 
 
 <Step title="Export from Context7 Cloud">
 
-Call the cloud export endpoint and pass your **enterprise license key** in the request body. It returns one library's full content (every code and info snippet, without embeddings), already shaped for the import endpoint.
+Call the cloud export endpoint with your **enterprise license key** in the `Authorization` header. It returns one library's full content (every code and info snippet, without embeddings), already shaped for the import endpoint.
 
 ```bash
 curl -X POST https://context7.com/api/v1/enterprise/export \
+  -H "Authorization: Bearer YOUR_LICENSE_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"licenseKey":"YOUR_LICENSE_KEY","library":"vercel/next.js"}'
+  -d '{"library":"vercel/next.js"}'
 ```
 
 Only public libraries can be exported this way.
@@ -160,8 +161,9 @@ From a host that can reach both networks, such as a bridge or import gateway, th
 
 ```bash
 curl -sf -X POST https://context7.com/api/v1/enterprise/export \
+  -H "Authorization: Bearer YOUR_LICENSE_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"licenseKey":"YOUR_LICENSE_KEY","library":"vercel/next.js"}' \
+  -d '{"library":"vercel/next.js"}' \
 | curl -X POST https://your-instance.example.com/api/import-libraries \
   -H "Authorization: Bearer YOUR_API_KEY" \
   -H "Content-Type: application/json" \

--- a/docs/openapi-enterprise.json
+++ b/docs/openapi-enterprise.json
@@ -315,6 +315,15 @@
         "description": "Import pre-parsed libraries into an airgapped on-premise install. Accepts either a Context7 Cloud export `.zip` (`multipart/form-data`) or a JSON body (`application/json`) for programmatic clients. Requires a personal API key (or an admin session). Each library is queued as its own job and its snippets are re-embedded locally with this install's configured provider. Available only on installs running an **offline (airgapped) license**.",
         "operationId": "importLibraries",
         "tags": ["Parse"],
+        "parameters": [
+          {
+            "name": "force",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "boolean", "default": false },
+            "description": "Overwrite libraries that already exist. Handy when posting a piped export body, which carries no `force` field. Without it, existing libraries are skipped."
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {

--- a/docs/openapi-enterprise.json
+++ b/docs/openapi-enterprise.json
@@ -309,6 +309,63 @@
         ]
       }
     },
+    "/import-libraries": {
+      "post": {
+        "summary": "Import a library bundle",
+        "description": "Import pre-parsed libraries into an airgapped on-premise install. Accepts either a Context7 Cloud export `.zip` (`multipart/form-data`) or a JSON body (`application/json`) for programmatic clients. Each library is queued as its own job and its snippets are re-embedded locally with this install's configured provider. Available only on installs running an **offline (airgapped) license**.",
+        "operationId": "importLibraries",
+        "tags": ["Parse"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImportLibrariesRequest"
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "required": ["bundleFile"],
+                "properties": {
+                  "bundleFile": {
+                    "type": "string",
+                    "format": "binary",
+                    "description": "A Context7 Cloud `context7-libraries.zip` export (up to 100 MB)"
+                  },
+                  "force": {
+                    "type": "boolean",
+                    "description": "Overwrite libraries that already exist on this install",
+                    "default": false
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "$ref": "#/components/responses/LibrariesImported"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequestError"
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthorizedError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenError"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        },
+        "security": [
+          {},
+          { "bearerAuth": [] }
+        ]
+      }
+    },
     "/parse-website": {
       "post": {
         "summary": "Parse a website",
@@ -581,6 +638,111 @@
         },
         "required": ["message", "project", "queueId"]
       },
+      "ImportLibrariesRequest": {
+        "type": "object",
+        "required": ["libraries"],
+        "properties": {
+          "libraries": {
+            "type": "array",
+            "description": "The libraries to import. Each carries its full snippet content; embeddings are recomputed on this install.",
+            "items": {
+              "$ref": "#/components/schemas/ImportLibrary"
+            }
+          },
+          "force": {
+            "type": "boolean",
+            "description": "Overwrite libraries that already exist on this install",
+            "default": false
+          }
+        }
+      },
+      "ImportLibrary": {
+        "type": "object",
+        "required": ["project", "codeSnippets", "infoSnippets"],
+        "properties": {
+          "project": {
+            "type": "string",
+            "description": "Library identifier, e.g. `/your-org/your-repo`",
+            "example": "/vercel/next.js"
+          },
+          "title": { "type": "string" },
+          "description": { "type": "string" },
+          "type": {
+            "type": "string",
+            "description": "Source type of the library (e.g. `repo`, `website`, `openapi`)"
+          },
+          "language": { "type": "string", "example": "English" },
+          "branch": { "type": "string" },
+          "docsRepoUrl": { "type": "string" },
+          "docsSiteUrl": { "type": "string" },
+          "totalTokens": { "type": "integer" },
+          "codeSnippets": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": { "type": "string" },
+                "title": { "type": "string" },
+                "description": { "type": "string" },
+                "language": { "type": "string" },
+                "codeList": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "language": { "type": "string" },
+                      "code": { "type": "string" }
+                    }
+                  }
+                },
+                "tokens": { "type": "integer" }
+              }
+            }
+          },
+          "infoSnippets": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": { "type": "string" },
+                "content": { "type": "string" },
+                "breadcrumb": { "type": "string" },
+                "tokens": { "type": "integer" }
+              }
+            }
+          }
+        }
+      },
+      "LibrariesImportedResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "example": "Queued 2 libraries for import"
+          },
+          "queued": {
+            "type": "array",
+            "description": "Library identifiers queued for import",
+            "items": { "type": "string" },
+            "example": ["/vercel/next.js", "/facebook/react"]
+          },
+          "skipped": {
+            "type": "array",
+            "description": "Libraries that were not imported, with a reason",
+            "items": {
+              "type": "object",
+              "properties": {
+                "project": { "type": "string" },
+                "reason": {
+                  "type": "string",
+                  "example": "already exists"
+                }
+              }
+            }
+          }
+        },
+        "required": ["message", "queued", "skipped"]
+      },
       "ParseRepoRequest": {
         "type": "object",
         "required": ["repoUrl"],
@@ -681,6 +843,25 @@
             "schema": {
               "$ref": "#/components/schemas/ParseQueuedResponse"
             }
+          }
+        }
+      },
+      "LibrariesImported": {
+        "description": "Libraries accepted and queued for import",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/LibrariesImportedResponse"
+            }
+          }
+        }
+      },
+      "ForbiddenError": {
+        "description": "Forbidden - the action is not permitted for this install or user",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" },
+            "example": { "error": "Library import is available only with an offline license." }
           }
         }
       },

--- a/docs/openapi-enterprise.json
+++ b/docs/openapi-enterprise.json
@@ -312,7 +312,7 @@
     "/import-libraries": {
       "post": {
         "summary": "Import a library bundle",
-        "description": "Import pre-parsed libraries into an airgapped on-premise install. Accepts either a Context7 Cloud export `.zip` (`multipart/form-data`) or a JSON body (`application/json`) for programmatic clients. Each library is queued as its own job and its snippets are re-embedded locally with this install's configured provider. Available only on installs running an **offline (airgapped) license**.",
+        "description": "Import pre-parsed libraries into an airgapped on-premise install. Accepts either a Context7 Cloud export `.zip` (`multipart/form-data`) or a JSON body (`application/json`) for programmatic clients. Requires a personal API key (or an admin session). Each library is queued as its own job and its snippets are re-embedded locally with this install's configured provider. Available only on installs running an **offline (airgapped) license**.",
         "operationId": "importLibraries",
         "tags": ["Parse"],
         "requestBody": {
@@ -360,10 +360,7 @@
             "$ref": "#/components/responses/InternalServerError"
           }
         },
-        "security": [
-          {},
-          { "bearerAuth": [] }
-        ]
+        "security": [{ "bearerAuth": [] }]
       }
     },
     "/parse-website": {


### PR DESCRIPTION
Documents the programmatic import/export path added in context7parser#535 and context7app#767.

- New endpoint reference `POST /import-libraries` (OpenAPI operation + schemas in `openapi-enterprise.json`, page under API Reference then Parse). Requires an API key.
- Adds an "Automating with the API" section to the Library Import feature doc: the cloud export (`POST /api/v1/enterprise/export`, license key in the `Authorization` header) and the on-prem JSON import, with the chained curl pipeline.