### PR TITLE
feat(cli): store credentials in system keyring with JSON fallback

### DIFF
--- a/.changeset/keyring-credentials.md
+++ b/.changeset/keyring-credentials.md
@@ -1,0 +1,7 @@
+---
+"ctx7": minor
+---
+
+Store CLI credentials in the system keyring when available, with automatic migration from plaintext JSON and a JSON fallback for headless environments. Supports `CTX7_CREDENTIAL_STORE=auto|json|keyring`.
+
+Fixes #2639

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,6 +29,7 @@
     "figlet": "^1.9.4",
     "open": "^10.1.0",
     "ora": "^9.4.0",
+    "keytar": "^7.9.0",
     "picocolors": "^1.1.1"
   },
   "devDependencies": {

--- a/packages/cli/src/__tests__/auth-utils.test.ts
+++ b/packages/cli/src/__tests__/auth-utils.test.ts
@@ -27,6 +27,8 @@ import {
   pollDeviceToken,
   type TokenData,
 } from "../utils/auth.js";
+import { resetCredentialStoreForTests } from "../utils/credential-store/index.js";
+import { resetKeytarCacheForTests } from "../utils/credential-store/keyring-store.js";
 
 const mfs = vi.mocked(fs);
 const CREDENTIALS_PATH = "/fake-home/.config/context7/credentials.json";
@@ -35,13 +37,13 @@ const CONFIG_DIR_PATH = "/fake-home/.config/context7";
 
 beforeEach(() => {
   vi.clearAllMocks();
-  // os.homedir() reads $HOME first on POSIX, so stubbing the env var pins the
-  // home directory deterministically without mocking the `os` builtin (which
-  // resolves unreliably across Node versions / worker pooling in CI).
+  resetCredentialStoreForTests();
+  resetKeytarCacheForTests();
   vi.stubEnv("HOME", "/fake-home");
   vi.stubEnv("XDG_CONFIG_HOME", undefined);
   vi.stubEnv("XDG_STATE_HOME", undefined);
   vi.stubEnv("XDG_CACHE_HOME", undefined);
+  vi.stubEnv("CTX7_CREDENTIAL_STORE", "json");
   vi.stubGlobal(
     "fetch",
     vi.fn(() => {
@@ -53,40 +55,42 @@ beforeEach(() => {
 afterEach(() => {
   vi.unstubAllGlobals();
   vi.unstubAllEnvs();
+  resetCredentialStoreForTests();
+  resetKeytarCacheForTests();
 });
 
 describe("saveTokens", () => {
-  test("creates config directory if it does not exist", () => {
+  test("creates config directory if it does not exist", async () => {
     mfs.existsSync.mockReturnValue(false);
-    saveTokens({ access_token: "tok", token_type: "bearer" });
+    await saveTokens({ access_token: "tok", token_type: "bearer" });
     expect(mfs.mkdirSync).toHaveBeenCalledWith(CONFIG_DIR_PATH, { recursive: true, mode: 0o700 });
   });
 
-  test("skips directory creation if it already exists", () => {
+  test("skips directory creation if it already exists", async () => {
     mfs.existsSync.mockReturnValue(true);
-    saveTokens({ access_token: "tok", token_type: "bearer" });
+    await saveTokens({ access_token: "tok", token_type: "bearer" });
     expect(mfs.mkdirSync).not.toHaveBeenCalled();
   });
 
-  test("writes credentials file with 0o600 permissions", () => {
+  test("writes credentials file with 0o600 permissions", async () => {
     mfs.existsSync.mockReturnValue(true);
-    saveTokens({ access_token: "tok", token_type: "bearer" });
+    await saveTokens({ access_token: "tok", token_type: "bearer" });
     expect(mfs.writeFileSync).toHaveBeenCalledWith(CREDENTIALS_PATH, expect.any(String), {
       mode: 0o600,
     });
   });
 
-  test("enforces 0o600 even when the credentials file already exists", () => {
-    // writeFileSync's mode is ignored for an existing file, so chmod must run.
+  test("enforces 0o600 even when the credentials file already exists", async () => {
     mfs.existsSync.mockReturnValue(true);
-    saveTokens({ access_token: "tok", token_type: "bearer" });
+    await saveTokens({ access_token: "tok", token_type: "bearer" });
     expect(mfs.chmodSync).toHaveBeenCalledWith(CREDENTIALS_PATH, 0o600);
   });
 
-  test("honors XDG_CONFIG_HOME for credentials", () => {
+  test("honors XDG_CONFIG_HOME for credentials", async () => {
     vi.stubEnv("XDG_CONFIG_HOME", "/custom-config");
+    resetCredentialStoreForTests();
     mfs.existsSync.mockReturnValue(false);
-    saveTokens({ access_token: "tok", token_type: "bearer" });
+    await saveTokens({ access_token: "tok", token_type: "bearer" });
 
     expect(mfs.mkdirSync).toHaveBeenCalledWith("/custom-config/context7", {
       recursive: true,
@@ -99,37 +103,42 @@ describe("saveTokens", () => {
     );
   });
 
-  test("computes expires_at from expires_in when expires_at is absent", () => {
+  test("computes expires_at from expires_in when expires_at is absent", async () => {
     mfs.existsSync.mockReturnValue(true);
     const now = 1000000;
     vi.spyOn(Date, "now").mockReturnValue(now);
-    saveTokens({ access_token: "tok", token_type: "bearer", expires_in: 3600 });
+    await saveTokens({ access_token: "tok", token_type: "bearer", expires_in: 3600 });
     const written = JSON.parse(mfs.writeFileSync.mock.calls[0][1] as string);
     expect(written.expires_at).toBe(now + 3600 * 1000);
   });
 
-  test("preserves existing expires_at if already set", () => {
+  test("preserves existing expires_at if already set", async () => {
     mfs.existsSync.mockReturnValue(true);
-    saveTokens({ access_token: "tok", token_type: "bearer", expires_at: 999, expires_in: 3600 });
+    await saveTokens({
+      access_token: "tok",
+      token_type: "bearer",
+      expires_at: 999,
+      expires_in: 3600,
+    });
     const written = JSON.parse(mfs.writeFileSync.mock.calls[0][1] as string);
     expect(written.expires_at).toBe(999);
   });
 });
 
 describe("loadTokens", () => {
-  test("returns null when credentials file does not exist", () => {
+  test("returns null when credentials file does not exist", async () => {
     mfs.existsSync.mockReturnValue(false);
-    expect(loadTokens()).toBeNull();
+    expect(await loadTokens()).toBeNull();
   });
 
-  test("returns parsed TokenData when file exists", () => {
+  test("returns parsed TokenData when file exists", async () => {
     const tokens: TokenData = { access_token: "tok", token_type: "bearer" };
     mfs.existsSync.mockReturnValue(true);
     mfs.readFileSync.mockReturnValue(JSON.stringify(tokens));
-    expect(loadTokens()).toEqual(tokens);
+    expect(await loadTokens()).toEqual(tokens);
   });
 
-  test("migrates credentials from the legacy ~/.context7 path before reading", () => {
+  test("migrates credentials from the legacy ~/.context7 path before reading", async () => {
     const tokens: TokenData = { access_token: "tok", token_type: "bearer" };
     let migrated = false;
     mfs.existsSync.mockImplementation((filePath) =>
@@ -142,44 +151,41 @@ describe("loadTokens", () => {
     });
     mfs.readFileSync.mockReturnValue(JSON.stringify(tokens));
 
-    expect(loadTokens()).toEqual(tokens);
+    expect(await loadTokens()).toEqual(tokens);
     expect(mfs.renameSync).toHaveBeenCalledWith(LEGACY_CREDENTIALS_PATH, CREDENTIALS_PATH);
-    // rename preserves the legacy mode, so migration must re-assert 0o600.
     expect(mfs.chmodSync).toHaveBeenCalledWith(CREDENTIALS_PATH, 0o600);
     expect(mfs.readFileSync).toHaveBeenCalledWith(CREDENTIALS_PATH, "utf-8");
   });
 
-  test("returns null on malformed JSON", () => {
+  test("returns null on malformed JSON", async () => {
     mfs.existsSync.mockReturnValue(true);
     mfs.readFileSync.mockReturnValue("not json");
-    expect(loadTokens()).toBeNull();
+    expect(await loadTokens()).toBeNull();
   });
 
-  test("falls back to the legacy file (no throw) when migration fails", () => {
+  test("falls back to the legacy file (no throw) when migration fails", async () => {
     const tokens: TokenData = { access_token: "tok", token_type: "bearer" };
-    // Only the legacy file exists; the rename fails (e.g. EXDEV / EACCES).
     mfs.existsSync.mockImplementation((filePath) => filePath === LEGACY_CREDENTIALS_PATH);
     mfs.renameSync.mockImplementation(() => {
       throw new Error("EXDEV: cross-device link not permitted");
     });
     mfs.readFileSync.mockReturnValue(JSON.stringify(tokens));
 
-    expect(() => loadTokens()).not.toThrow();
-    expect(loadTokens()).toEqual(tokens);
+    await expect(loadTokens()).resolves.toEqual(tokens);
     expect(mfs.readFileSync).toHaveBeenCalledWith(LEGACY_CREDENTIALS_PATH, "utf-8");
   });
 });
 
 describe("clearTokens", () => {
-  test("deletes file and returns true when it exists", () => {
+  test("deletes file and returns true when it exists", async () => {
     mfs.existsSync.mockReturnValue(true);
-    expect(clearTokens()).toBe(true);
+    expect(await clearTokens()).toBe(true);
     expect(mfs.unlinkSync).toHaveBeenCalledWith(CREDENTIALS_PATH);
   });
 
-  test("returns false when file does not exist", () => {
+  test("returns false when file does not exist", async () => {
     mfs.existsSync.mockReturnValue(false);
-    expect(clearTokens()).toBe(false);
+    expect(await clearTokens()).toBe(false);
     expect(mfs.unlinkSync).not.toHaveBeenCalled();
   });
 });
@@ -344,8 +350,6 @@ describe("startDeviceAuthorization", () => {
     expect(url).toBe("https://t.example/api/oauth/device/code");
     expect(init.method).toBe("POST");
     expect(init.headers).toEqual({ "Content-Type": "application/x-www-form-urlencoded" });
-    // Body is form-encoded; hostname is appended best-effort and varies by
-    // machine, so assert on the parsed client_id rather than the exact string.
     expect(new URLSearchParams(init.body as string).get("client_id")).toBe("test-client");
   });
 

--- a/packages/cli/src/__tests__/credential-store.test.ts
+++ b/packages/cli/src/__tests__/credential-store.test.ts
@@ -1,0 +1,130 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import {
+  resolveCredentialStore,
+  resetCredentialStoreForTests,
+} from "../utils/credential-store/index.js";
+import { JsonCredentialStore, normalizeTokenData } from "../utils/credential-store/json-store.js";
+import {
+  isKeyringAvailable,
+  KeyringCredentialStore,
+  resetKeytarCacheForTests,
+} from "../utils/credential-store/keyring-store.js";
+
+vi.mock("fs", () => {
+  const fns = {
+    existsSync: vi.fn(),
+    mkdirSync: vi.fn(),
+    writeFileSync: vi.fn(),
+    readFileSync: vi.fn(),
+    unlinkSync: vi.fn(),
+    renameSync: vi.fn(),
+    chmodSync: vi.fn(),
+  };
+  return { ...fns, default: fns };
+});
+
+const mockKeytar = {
+  getPassword: vi.fn(),
+  setPassword: vi.fn(),
+  deletePassword: vi.fn(),
+  findPassword: vi.fn(),
+};
+
+vi.mock("keytar", () => ({
+  default: mockKeytar,
+  ...mockKeytar,
+}));
+
+const mfs = vi.mocked(fs);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetCredentialStoreForTests();
+  resetKeytarCacheForTests();
+  vi.stubEnv("HOME", "/fake-home");
+  vi.stubEnv("XDG_CONFIG_HOME", undefined);
+  vi.stubEnv("CTX7_CREDENTIAL_STORE", undefined);
+  mockKeytar.findPassword.mockResolvedValue(null);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  resetCredentialStoreForTests();
+  resetKeytarCacheForTests();
+});
+
+describe("normalizeTokenData", () => {
+  test("computes expires_at from expires_in", () => {
+    const now = 1_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    const normalized = normalizeTokenData({
+      access_token: "tok",
+      token_type: "bearer",
+      expires_in: 120,
+    });
+    expect(normalized.expires_at).toBe(now + 120_000);
+  });
+});
+
+describe("resolveCredentialStore", () => {
+  test("uses json store when CTX7_CREDENTIAL_STORE=json", async () => {
+    vi.stubEnv("CTX7_CREDENTIAL_STORE", "json");
+    const store = await resolveCredentialStore();
+    expect(store.backend).toBe("json");
+  });
+
+  test("uses keyring store when CTX7_CREDENTIAL_STORE=keyring and keyring is available", async () => {
+    vi.stubEnv("CTX7_CREDENTIAL_STORE", "keyring");
+    const store = await resolveCredentialStore();
+    expect(store.backend).toBe("keyring");
+  });
+
+  test("throws when keyring mode is forced but unavailable", async () => {
+    vi.stubEnv("CTX7_CREDENTIAL_STORE", "keyring");
+    mockKeytar.findPassword.mockRejectedValue(new Error("no keyring"));
+    resetKeytarCacheForTests();
+    await expect(resolveCredentialStore()).rejects.toThrow(/not available/i);
+  });
+
+  test("falls back to json when auto mode and keyring is unavailable", async () => {
+    mockKeytar.findPassword.mockRejectedValue(new Error("no keyring"));
+    resetKeytarCacheForTests();
+    const store = await resolveCredentialStore();
+    expect(store.backend).toBe("json");
+  });
+
+  test("migrates json credentials into keyring on first resolve in auto mode", async () => {
+    const tokens = { access_token: "ctx7sk-test", token_type: "bearer" };
+    mfs.existsSync.mockReturnValue(true);
+    mfs.readFileSync.mockReturnValue(JSON.stringify(tokens));
+
+    const store = await resolveCredentialStore();
+    expect(store.backend).toBe("keyring");
+    expect(mockKeytar.setPassword).toHaveBeenCalled();
+    expect(mfs.unlinkSync).toHaveBeenCalled();
+  });
+});
+
+describe("KeyringCredentialStore", () => {
+  test("round-trips token data", async () => {
+    const tokens = { access_token: "ctx7sk-test", token_type: "bearer", expires_at: 123 };
+    mockKeytar.getPassword.mockResolvedValue(JSON.stringify(tokens));
+
+    const store = new KeyringCredentialStore();
+    await expect(store.load()).resolves.toEqual(tokens);
+  });
+
+  test("reports availability via isKeyringAvailable", async () => {
+    await expect(isKeyringAvailable()).resolves.toBe(true);
+  });
+});
+
+describe("JsonCredentialStore", () => {
+  test("writes normalized token data", async () => {
+    mfs.existsSync.mockReturnValue(false);
+    const store = new JsonCredentialStore();
+    await store.save({ access_token: "tok", token_type: "bearer", expires_in: 60 });
+    expect(mfs.writeFileSync).toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -34,8 +34,8 @@ export function registerAuthCommands(program: Command): void {
   program
     .command("logout")
     .description("Log out of Context7")
-    .action(() => {
-      logoutCommand();
+    .action(async () => {
+      await logoutCommand();
     });
 
   program
@@ -153,7 +153,7 @@ export async function performLogin(openBrowser = true): Promise<string | null> {
     try {
       const result = await pollDeviceToken(baseUrl, CLI_CLIENT_ID, authorization.device_code);
       if (result.status === "approved" && result.tokens) {
-        saveTokens(result.tokens);
+        await saveTokens(result.tokens);
         const successText = await announceIdentity(result.tokens.access_token);
         waitingSpinner.succeed(pc.green(successText));
         return result.tokens.access_token;
@@ -197,7 +197,7 @@ async function loginCommand(options: { browser: boolean }): Promise<void> {
     console.log(pc.dim("Run 'ctx7 logout' first if you want to log in with a different account."));
     return;
   }
-  clearTokens();
+  await clearTokens();
 
   const token = await performLogin(options.browser);
   if (!token) {
@@ -207,9 +207,9 @@ async function loginCommand(options: { browser: boolean }): Promise<void> {
   console.log(pc.dim("You can now use authenticated Context7 features."));
 }
 
-function logoutCommand(): void {
+async function logoutCommand(): Promise<void> {
   trackEvent("command", { name: "logout" });
-  if (clearTokens()) {
+  if (await clearTokens()) {
     console.log(pc.green("Logged out successfully."));
   } else {
     console.log(pc.yellow("You are not logged in."));

--- a/packages/cli/src/commands/docs.ts
+++ b/packages/cli/src/commands/docs.ts
@@ -6,7 +6,7 @@ import { resolveLibrary, getLibraryContext } from "../utils/api.js";
 import { recoverLibraryId } from "../utils/library-id.js";
 import { log } from "../utils/logger.js";
 import { trackEvent } from "../utils/tracking.js";
-import { loadTokens, isTokenExpired } from "../utils/auth.js";
+import { getStoredAccessToken } from "../utils/auth.js";
 import type { LibrarySearchResult, ContextResponse } from "../types.js";
 
 const isTTY = process.stdout.isTTY;
@@ -18,10 +18,8 @@ function getReputationLabel(score: number | undefined): "High" | "Medium" | "Low
   return "Low";
 }
 
-function getAccessToken(): string | undefined {
-  const tokens = loadTokens();
-  if (!tokens || isTokenExpired(tokens)) return undefined;
-  return tokens.access_token;
+async function getAccessToken(): Promise<string | undefined> {
+  return getStoredAccessToken();
 }
 
 function formatLibraryResult(lib: LibrarySearchResult, index: number): string {
@@ -57,7 +55,7 @@ async function resolveCommand(
   trackEvent("command", { name: "library" });
 
   const spinner = isTTY ? ora(`Searching for "${library}"...`).start() : null;
-  const accessToken = getAccessToken();
+  const accessToken = await getAccessToken();
 
   let data;
   try {
@@ -137,7 +135,7 @@ async function queryCommand(
     return;
   }
 
-  const accessToken = getAccessToken();
+  const accessToken = await getAccessToken();
 
   const spinner = isTTY ? ora(`Fetching docs for "${libraryId}"...`).start() : null;
   const outputType = options.json ? "json" : "txt";

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -13,7 +13,7 @@ import {
   generateSkillStructured,
   getSkillQuota,
 } from "../utils/api.js";
-import { loadTokens, isTokenExpired } from "../utils/auth.js";
+import { getValidAccessToken } from "../utils/auth.js";
 import { performLogin } from "./auth.js";
 import { log } from "../utils/logger.js";
 import { promptForInstallTargets, getTargetDirs } from "../utils/ide.js";
@@ -60,11 +60,8 @@ async function generateCommand(options: GenerateOptions): Promise<void> {
   trackEvent("command", { name: "generate" });
   log.blank();
 
-  let accessToken: string | null = null;
-  const tokens = loadTokens();
-  if (tokens && !isTokenExpired(tokens)) {
-    accessToken = tokens.access_token;
-  } else {
+  let accessToken = await getValidAccessToken();
+  if (!accessToken) {
     log.info("Authentication required. Logging in...");
     log.blank();
     accessToken = await performLogin();

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -169,7 +169,7 @@ async function resolveMode(options: SetupOptions): Promise<SetupMode> {
 
 async function resolveCliAuth(apiKey?: string): Promise<void> {
   if (apiKey) {
-    saveTokens({ access_token: apiKey, token_type: "bearer" });
+    await saveTokens({ access_token: apiKey, token_type: "bearer" });
     log.blank();
     log.plain(`${pc.green("✔")} Authenticated`);
     return;

--- a/packages/cli/src/commands/skill.ts
+++ b/packages/cli/src/commands/skill.ts
@@ -55,7 +55,7 @@ import {
 } from "../types.js";
 import { homedir } from "os";
 import { detectProjectDependencies } from "../utils/deps.js";
-import { loadTokens, isTokenExpired } from "../utils/auth.js";
+import { getStoredAccessToken } from "../utils/auth.js";
 
 const SKILL_HUB_DEPRECATION_WARNING =
   "Warning: Skill commands are deprecated and will stop working in the next major release.";
@@ -843,8 +843,7 @@ async function suggestCommand(options: SuggestOptions): Promise<void> {
   // Step 2: Single API call to backend
   const searchSpinner = ora("Finding matching skills...").start();
 
-  const tokens = loadTokens();
-  const accessToken = tokens && !isTokenExpired(tokens) ? tokens.access_token : undefined;
+  const accessToken = await getStoredAccessToken();
 
   let data;
   try {

--- a/packages/cli/src/utils/auth.ts
+++ b/packages/cli/src/utils/auth.ts
@@ -1,80 +1,27 @@
-import * as fs from "fs";
 import * as os from "os";
 import { CLI_CLIENT_ID } from "../constants.js";
 import { getBaseUrl } from "./api.js";
-import {
-  CREDENTIALS_FILE_NAME,
-  getConfigDir,
-  getCredentialsFilePath,
-  getLegacyFilePath,
-  migrateLegacyFileSync,
-  resolveReadPathSync,
-} from "./storage-paths.js";
+import { resolveCredentialStore } from "./credential-store/index.js";
+import type { TokenData } from "./credential-store/types.js";
 
-export interface TokenData {
-  access_token: string;
-  refresh_token?: string;
-  token_type: string;
-  expires_in?: number;
-  expires_at?: number;
-  scope?: string;
+export type { TokenData } from "./credential-store/types.js";
+
+export async function saveTokens(tokens: TokenData): Promise<void> {
+  const store = await resolveCredentialStore();
+  await store.save(tokens);
 }
 
-function ensureConfigDir(): void {
-  const configDir = getConfigDir();
-  if (!fs.existsSync(configDir)) {
-    fs.mkdirSync(configDir, { recursive: true, mode: 0o700 });
-  }
+export async function loadTokens(): Promise<TokenData | null> {
+  const store = await resolveCredentialStore();
+  return store.load();
 }
 
-// Credentials must never be group/world-readable, even if a migrated or
-// pre-existing file carried looser permissions.
-const CREDENTIALS_MODE = 0o600;
-
-export function saveTokens(tokens: TokenData): void {
-  const credentialsFile = getCredentialsFilePath();
-  migrateLegacyFileSync(CREDENTIALS_FILE_NAME, credentialsFile, CREDENTIALS_MODE);
-  ensureConfigDir();
-  const data = {
-    ...tokens,
-    expires_at:
-      tokens.expires_at ?? (tokens.expires_in ? Date.now() + tokens.expires_in * 1000 : undefined),
-  };
-  fs.writeFileSync(credentialsFile, JSON.stringify(data, null, 2), { mode: CREDENTIALS_MODE });
-  // `mode` is ignored when the file already exists; enforce it explicitly.
-  fs.chmodSync(credentialsFile, CREDENTIALS_MODE);
-}
-
-export function loadTokens(): TokenData | null {
-  const credentialsFile = resolveReadPathSync(
-    CREDENTIALS_FILE_NAME,
-    getCredentialsFilePath(),
-    CREDENTIALS_MODE
-  );
-  if (!fs.existsSync(credentialsFile)) {
-    return null;
-  }
-  try {
-    const data = JSON.parse(fs.readFileSync(credentialsFile, "utf-8"));
-    return data as TokenData;
-  } catch {
-    return null;
-  }
-}
-
-export function clearTokens(): boolean {
-  const credentialsFile = getCredentialsFilePath();
-  let removed = false;
-  if (fs.existsSync(credentialsFile)) {
-    fs.unlinkSync(credentialsFile);
-    removed = true;
-  }
-  const legacyCredentialsFile = getLegacyFilePath(CREDENTIALS_FILE_NAME);
-  if (fs.existsSync(legacyCredentialsFile)) {
-    fs.unlinkSync(legacyCredentialsFile);
-    removed = true;
-  }
-  return removed;
+export async function clearTokens(): Promise<boolean> {
+  const { JsonCredentialStore } = await import("./credential-store/json-store.js");
+  const { KeyringCredentialStore } = await import("./credential-store/keyring-store.js");
+  const jsonRemoved = await new JsonCredentialStore().clear();
+  const keyringRemoved = await new KeyringCredentialStore().clear();
+  return jsonRemoved || keyringRemoved;
 }
 
 export function isTokenExpired(tokens: TokenData): boolean {
@@ -82,6 +29,18 @@ export function isTokenExpired(tokens: TokenData): boolean {
     return false;
   }
   return Date.now() > tokens.expires_at - 60000;
+}
+
+/**
+ * Returns a stored access token when present and not expired. Does not refresh
+ * OAuth tokens — use getValidAccessToken for that.
+ */
+export async function getStoredAccessToken(): Promise<string | undefined> {
+  const tokens = await loadTokens();
+  if (!tokens || isTokenExpired(tokens)) {
+    return undefined;
+  }
+  return tokens.access_token;
 }
 
 async function refreshAccessToken(refreshToken: string): Promise<TokenData> {
@@ -110,7 +69,7 @@ async function refreshAccessToken(refreshToken: string): Promise<TokenData> {
  * expire and skip the refresh path entirely.
  */
 export async function getValidAccessToken(): Promise<string | null> {
-  const tokens = loadTokens();
+  const tokens = await loadTokens();
   if (!tokens) return null;
 
   if (!isTokenExpired(tokens)) {
@@ -123,7 +82,7 @@ export async function getValidAccessToken(): Promise<string | null> {
 
   try {
     const newTokens = await refreshAccessToken(tokens.refresh_token);
-    saveTokens(newTokens);
+    await saveTokens(newTokens);
     return newTokens.access_token;
   } catch {
     return null;

--- a/packages/cli/src/utils/credential-store/index.ts
+++ b/packages/cli/src/utils/credential-store/index.ts
@@ -1,0 +1,100 @@
+import pc from "picocolors";
+import { JsonCredentialStore, jsonCredentialsExist } from "./json-store.js";
+import { isKeyringAvailable, KeyringCredentialStore } from "./keyring-store.js";
+import type { CredentialStore, CredentialStoreMode } from "./types.js";
+
+export type { CredentialStore, CredentialStoreMode, TokenData } from "./types.js";
+export { JsonCredentialStore, jsonCredentialsExist, normalizeTokenData } from "./json-store.js";
+export {
+  isKeyringAvailable,
+  KeyringCredentialStore,
+  KEYRING_ACCOUNT,
+  KEYRING_SERVICE,
+  resetKeytarCacheForTests,
+} from "./keyring-store.js";
+
+let cachedStore: CredentialStore | null = null;
+let migrationDone = false;
+let migrationNotified = false;
+
+function getConfiguredMode(): CredentialStoreMode {
+  const value = process.env.CTX7_CREDENTIAL_STORE?.trim().toLowerCase();
+  if (value === "json" || value === "keyring" || value === "auto") {
+    return value;
+  }
+  return "auto";
+}
+
+function notifyMigration(): void {
+  if (migrationNotified) {
+    return;
+  }
+  migrationNotified = true;
+  if (process.stderr.isTTY) {
+    process.stderr.write(`${pc.dim("Migrated credentials to system keyring.")}\n`);
+  }
+}
+
+async function migrateJsonToKeyring(store: KeyringCredentialStore): Promise<void> {
+  if (!jsonCredentialsExist()) {
+    return;
+  }
+
+  const jsonStore = new JsonCredentialStore();
+  const tokens = await jsonStore.load();
+  if (!tokens) {
+    await jsonStore.clear();
+    return;
+  }
+
+  const existing = await store.load();
+  if (!existing) {
+    await store.save(tokens);
+    notifyMigration();
+  }
+
+  await jsonStore.clear();
+}
+
+async function createStore(mode: CredentialStoreMode): Promise<CredentialStore> {
+  if (mode === "json") {
+    return new JsonCredentialStore();
+  }
+
+  const keyringAvailable = await isKeyringAvailable();
+  if (mode === "keyring") {
+    if (!keyringAvailable) {
+      throw new Error(
+        "CTX7_CREDENTIAL_STORE=keyring was set, but the system keyring is not available."
+      );
+    }
+    return new KeyringCredentialStore();
+  }
+
+  if (keyringAvailable) {
+    return new KeyringCredentialStore();
+  }
+  return new JsonCredentialStore();
+}
+
+export async function resolveCredentialStore(): Promise<CredentialStore> {
+  if (cachedStore) {
+    return cachedStore;
+  }
+
+  const store = await createStore(getConfiguredMode());
+  if (store.backend === "keyring" && !migrationDone) {
+    migrationDone = true;
+    await migrateJsonToKeyring(store as KeyringCredentialStore);
+  }
+
+  cachedStore = store;
+  return store;
+}
+
+/** Test hook to reset cached store selection and migration state. */
+export function resetCredentialStoreForTests(): void {
+  cachedStore = null;
+  migrationDone = false;
+  migrationNotified = false;
+}

--- a/packages/cli/src/utils/credential-store/json-store.ts
+++ b/packages/cli/src/utils/credential-store/json-store.ts
@@ -1,0 +1,84 @@
+import * as fs from "fs";
+import {
+  CREDENTIALS_FILE_NAME,
+  getConfigDir,
+  getCredentialsFilePath,
+  getLegacyFilePath,
+  migrateLegacyFileSync,
+  resolveReadPathSync,
+} from "../storage-paths.js";
+import type { CredentialStore, TokenData } from "./types.js";
+
+const CREDENTIALS_MODE = 0o600;
+
+function ensureConfigDir(): void {
+  const configDir = getConfigDir();
+  if (!fs.existsSync(configDir)) {
+    fs.mkdirSync(configDir, { recursive: true, mode: 0o700 });
+  }
+}
+
+export function normalizeTokenData(tokens: TokenData): TokenData {
+  return {
+    ...tokens,
+    expires_at:
+      tokens.expires_at ?? (tokens.expires_in ? Date.now() + tokens.expires_in * 1000 : undefined),
+  };
+}
+
+export function jsonCredentialsExist(): boolean {
+  const credentialsFile = resolveReadPathSync(
+    CREDENTIALS_FILE_NAME,
+    getCredentialsFilePath(),
+    CREDENTIALS_MODE
+  );
+  if (fs.existsSync(credentialsFile)) {
+    return true;
+  }
+  return fs.existsSync(getLegacyFilePath(CREDENTIALS_FILE_NAME));
+}
+
+export class JsonCredentialStore implements CredentialStore {
+  readonly backend = "json" as const;
+
+  async load(): Promise<TokenData | null> {
+    const credentialsFile = resolveReadPathSync(
+      CREDENTIALS_FILE_NAME,
+      getCredentialsFilePath(),
+      CREDENTIALS_MODE
+    );
+    if (!fs.existsSync(credentialsFile)) {
+      return null;
+    }
+    try {
+      const data = JSON.parse(fs.readFileSync(credentialsFile, "utf-8"));
+      return data as TokenData;
+    } catch {
+      return null;
+    }
+  }
+
+  async save(tokens: TokenData): Promise<void> {
+    const credentialsFile = getCredentialsFilePath();
+    migrateLegacyFileSync(CREDENTIALS_FILE_NAME, credentialsFile, CREDENTIALS_MODE);
+    ensureConfigDir();
+    const data = normalizeTokenData(tokens);
+    fs.writeFileSync(credentialsFile, JSON.stringify(data, null, 2), { mode: CREDENTIALS_MODE });
+    fs.chmodSync(credentialsFile, CREDENTIALS_MODE);
+  }
+
+  async clear(): Promise<boolean> {
+    const credentialsFile = getCredentialsFilePath();
+    let removed = false;
+    if (fs.existsSync(credentialsFile)) {
+      fs.unlinkSync(credentialsFile);
+      removed = true;
+    }
+    const legacyCredentialsFile = getLegacyFilePath(CREDENTIALS_FILE_NAME);
+    if (fs.existsSync(legacyCredentialsFile)) {
+      fs.unlinkSync(legacyCredentialsFile);
+      removed = true;
+    }
+    return removed;
+  }
+}

--- a/packages/cli/src/utils/credential-store/keyring-store.ts
+++ b/packages/cli/src/utils/credential-store/keyring-store.ts
@@ -1,0 +1,84 @@
+import type { CredentialStore, TokenData } from "./types.js";
+import { normalizeTokenData } from "./json-store.js";
+
+export const KEYRING_SERVICE = "context7-cli";
+export const KEYRING_ACCOUNT = "default";
+
+type KeytarModule = typeof import("keytar");
+
+let keytarModule: KeytarModule | null | undefined;
+
+async function loadKeytar(): Promise<KeytarModule | null> {
+  if (keytarModule !== undefined) {
+    return keytarModule;
+  }
+  try {
+    keytarModule = await import("keytar");
+    return keytarModule;
+  } catch {
+    keytarModule = null;
+    return null;
+  }
+}
+
+export async function isKeyringAvailable(): Promise<boolean> {
+  const keytar = await loadKeytar();
+  if (!keytar) {
+    return false;
+  }
+  try {
+    await keytar.findPassword(KEYRING_SERVICE);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export class KeyringCredentialStore implements CredentialStore {
+  readonly backend = "keyring" as const;
+
+  async load(): Promise<TokenData | null> {
+    const keytar = await loadKeytar();
+    if (!keytar) {
+      return null;
+    }
+    try {
+      const payload = await keytar.getPassword(KEYRING_SERVICE, KEYRING_ACCOUNT);
+      if (!payload) {
+        return null;
+      }
+      return JSON.parse(payload) as TokenData;
+    } catch {
+      return null;
+    }
+  }
+
+  async save(tokens: TokenData): Promise<void> {
+    const keytar = await loadKeytar();
+    if (!keytar) {
+      throw new Error("System keyring is not available on this machine.");
+    }
+    await keytar.setPassword(
+      KEYRING_SERVICE,
+      KEYRING_ACCOUNT,
+      JSON.stringify(normalizeTokenData(tokens))
+    );
+  }
+
+  async clear(): Promise<boolean> {
+    const keytar = await loadKeytar();
+    if (!keytar) {
+      return false;
+    }
+    try {
+      return await keytar.deletePassword(KEYRING_SERVICE, KEYRING_ACCOUNT);
+    } catch {
+      return false;
+    }
+  }
+}
+
+/** Test hook to reset the lazy keytar import cache. */
+export function resetKeytarCacheForTests(): void {
+  keytarModule = undefined;
+}

--- a/packages/cli/src/utils/credential-store/types.ts
+++ b/packages/cli/src/utils/credential-store/types.ts
@@ -1,0 +1,19 @@
+export interface TokenData {
+  access_token: string;
+  refresh_token?: string;
+  token_type: string;
+  expires_in?: number;
+  expires_at?: number;
+  scope?: string;
+}
+
+export type CredentialBackend = "keyring" | "json";
+
+export type CredentialStoreMode = "auto" | "json" | "keyring";
+
+export interface CredentialStore {
+  readonly backend: CredentialBackend;
+  load(): Promise<TokenData | null>;
+  save(tokens: TokenData): Promise<void>;
+  clear(): Promise<boolean>;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       figlet:
         specifier: ^1.9.4
         version: 1.9.4
+      keytar:
+        specifier: ^7.9.0
+        version: 7.9.0
       open:
         specifier: ^10.1.0
         version: 10.2.0
@@ -1563,6 +1566,9 @@ packages:
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
   body-parser@2.2.0:
     resolution: {integrity: sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==}
     engines: {node: '>=18'}
@@ -1594,6 +1600,9 @@ packages:
 
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -1647,6 +1656,9 @@ packages:
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
   ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
@@ -1741,6 +1753,14 @@ packages:
       supports-color:
         optional: true
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -1762,6 +1782,10 @@ packages:
 
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
+    engines: {node: '>=8'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
   diff@8.0.4:
@@ -1795,6 +1819,9 @@ packages:
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
@@ -1914,6 +1941,10 @@ packages:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
 
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
@@ -2027,6 +2058,9 @@ packages:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
 
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
     engines: {node: '>=6 <7 || >=8'}
@@ -2065,6 +2099,9 @@ packages:
 
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -2155,6 +2192,9 @@ packages:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -2173,6 +2213,9 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
   ip-address@10.2.0:
     resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
@@ -2287,6 +2330,9 @@ packages:
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
+  keytar@7.9.0:
+    resolution: {integrity: sha512-VPD8mtVtm5JNtA2AErl6Chp06JBfy7diFQ7TQQhdpWOl6MrCRB+eRbvAZUsbGQS9kiMq0coJsy0W0vHpDCkWsQ==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -2370,6 +2416,10 @@ packages:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
 
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -2381,9 +2431,15 @@ packages:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
@@ -2407,12 +2463,22 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
+
+  node-abi@3.93.0:
+    resolution: {integrity: sha512-Cu6yUpX5Iavugm8BeX7c0wgU9CvOqfd1yM6A1d2q2ZMjym7GjpASv2GdRcTq3Fx+Sb5OgBkEEpw4VnAbY6Y5RA==}
+    engines: {node: '>=10'}
+
+  node-addon-api@4.3.0:
+    resolution: {integrity: sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==}
 
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
@@ -2592,6 +2658,12 @@ packages:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -2621,6 +2693,9 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -2647,9 +2722,17 @@ packages:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
 
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
+
   read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
     engines: {node: '>=6'}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
 
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
@@ -2763,6 +2846,12 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -2807,6 +2896,9 @@ packages:
     resolution: {integrity: sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==}
     engines: {node: '>=20'}
 
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -2818,6 +2910,10 @@ packages:
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
+
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -2838,6 +2934,13 @@ packages:
   synckit@0.11.13:
     resolution: {integrity: sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==}
     engines: {node: ^14.18.0 || >=16.0.0}
+
+  tar-fs@2.1.5:
+    resolution: {integrity: sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
 
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
@@ -2919,6 +3022,9 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -2979,6 +3085,9 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -4609,6 +4718,12 @@ snapshots:
 
   bignumber.js@9.3.1: {}
 
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
   body-parser@2.2.0:
     dependencies:
       bytes: 3.1.2
@@ -4669,6 +4784,11 @@ snapshots:
 
   buffer-equal-constant-time@1.0.1: {}
 
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.1.0
@@ -4710,6 +4830,8 @@ snapshots:
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
+
+  chownr@1.1.4: {}
 
   ci-info@3.9.0: {}
 
@@ -4770,6 +4892,12 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
+  deep-extend@0.6.0: {}
+
   deep-is@0.1.4: {}
 
   default-browser-id@5.0.1: {}
@@ -4784,6 +4912,8 @@ snapshots:
   depd@2.0.0: {}
 
   detect-indent@6.1.0: {}
+
+  detect-libc@2.1.2: {}
 
   diff@8.0.4: {}
 
@@ -4810,6 +4940,10 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   encodeurl@2.0.0: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   enquirer@2.4.1:
     dependencies:
@@ -4982,6 +5116,8 @@ snapshots:
   eventsource@3.0.7:
     dependencies:
       eventsource-parser: 3.0.6
+
+  expand-template@2.0.3: {}
 
   expect-type@1.4.0: {}
 
@@ -5156,6 +5292,8 @@ snapshots:
 
   fresh@2.0.0: {}
 
+  fs-constants@1.0.0: {}
+
   fs-extra@7.0.1:
     dependencies:
       graceful-fs: 4.2.11
@@ -5213,6 +5351,8 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
     optional: true
+
+  github-from-package@0.0.0: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -5310,6 +5450,8 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  ieee754@1.2.1: {}
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -5322,6 +5464,8 @@ snapshots:
   imurmurhash@0.1.4: {}
 
   inherits@2.0.4: {}
+
+  ini@1.3.8: {}
 
   ip-address@10.2.0: {}
 
@@ -5412,6 +5556,11 @@ snapshots:
       jwa: 2.0.1
       safe-buffer: 5.2.1
 
+  keytar@7.9.0:
+    dependencies:
+      node-addon-api: 4.3.0
+      prebuild-install: 7.1.3
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -5475,6 +5624,8 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
+  mimic-response@3.1.0: {}
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.6
@@ -5487,7 +5638,11 @@ snapshots:
     dependencies:
       brace-expansion: 2.0.2
 
+  minimist@1.2.8: {}
+
   minipass@7.1.3: {}
+
+  mkdirp-classic@0.5.3: {}
 
   mlly@1.8.0:
     dependencies:
@@ -5510,9 +5665,17 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  napi-build-utils@2.0.0: {}
+
   natural-compare@1.4.0: {}
 
   negotiator@1.0.0: {}
+
+  node-abi@3.93.0:
+    dependencies:
+      semver: 7.7.4
+
+  node-addon-api@4.3.0: {}
 
   node-domexception@1.0.0: {}
 
@@ -5665,6 +5828,21 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.93.0
+      pump: 3.0.4
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.5
+      tunnel-agent: 0.6.0
+
   prelude-ls@1.2.1: {}
 
   prettier-linter-helpers@1.0.1:
@@ -5701,6 +5879,11 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
   punycode@2.3.1: {}
 
   qs@6.14.0:
@@ -5724,12 +5907,25 @@ snapshots:
       iconv-lite: 0.7.0
       unpipe: 1.0.0
 
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
+
   read-yaml-file@1.1.0:
     dependencies:
       graceful-fs: 4.2.11
       js-yaml: 3.14.2
       pify: 4.0.1
       strip-bom: 3.0.0
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
 
   readdirp@4.1.2: {}
 
@@ -5872,6 +6068,14 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+
   slash@3.0.0: {}
 
   source-map-js@1.2.1: {}
@@ -5910,6 +6114,10 @@ snapshots:
       get-east-asian-width: 1.6.0
       strip-ansi: 7.1.2
 
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -5919,6 +6127,8 @@ snapshots:
       ansi-regex: 6.2.2
 
   strip-bom@3.0.0: {}
+
+  strip-json-comments@2.0.1: {}
 
   strip-json-comments@3.1.1: {}
 
@@ -5941,6 +6151,21 @@ snapshots:
   synckit@0.11.13:
     dependencies:
       '@pkgr/core': 0.3.6
+
+  tar-fs@2.1.5:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   term-size@2.2.1: {}
 
@@ -6019,6 +6244,10 @@ snapshots:
       fsevents: 2.3.3
     optional: true
 
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -6067,6 +6296,8 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  util-deprecate@1.0.2: {}
 
   vary@1.1.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,9 @@ packages:
   - "packages/*"
 
 allowBuilds:
+  '@google/genai': set this to true or false
   esbuild: true
+  keytar: true
+  protobufjs: set this to true or false
 
 minimumReleaseAge: 10080


### PR DESCRIPTION
## Summary
- Adds a `CredentialStore` abstraction with keyring (via `keytar`) and JSON backends
- Auto-migrates existing `~/.config/context7/credentials.json` into the system keyring
- Supports `CTX7_CREDENTIAL_STORE=auto|json|keyring` for explicit backend selection
Fixes #2639
## Test plan
- [x] `pnpm --filter ctx7 lint:check && format:check && typecheck && test && build`
- [ ] `ctx7 login` on macOS — verify Keychain entry created, plaintext file removed
- [ ] `ctx7 logout` — verify Keychain entry cleared
- [ ] `CTX7_CREDENTIAL_STORE=json ctx7 login` — verify JSON fallback works