### PR TITLE
docs: add Autohand Code MCP setup

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -89,6 +89,25 @@ You can find your Smithery key in the [Smithery.ai webpage](https://smithery.ai/
 </details>
 
 <details>
+<summary><b>Install in Autohand Code</b></summary>
+
+Use the [Autohand Code CLI](https://github.com/autohandai/code-cli/) to add the local Context7 server:
+
+```sh
+autohand mcp add context7 npx -y @upstash/context7-mcp --api-key YOUR_API_KEY
+```
+
+Add `--scope project` before `context7` to save the server in the current project's `.autohand` configuration instead of your user configuration.
+
+For basic usage without an API key, you can connect to the remote server instead:
+
+```sh
+autohand mcp add --transport http context7 https://mcp.context7.com/mcp
+```
+
+</details>
+
+<details>
 <summary><b>Install in Cursor</b></summary>
 
 Go to: `Settings` -> `Cursor Settings` -> `MCP` -> `Add new global MCP server`

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -89,25 +89,6 @@ You can find your Smithery key in the [Smithery.ai webpage](https://smithery.ai/
 </details>
 
 <details>
-<summary><b>Install in Autohand Code</b></summary>
-
-Use the [Autohand Code CLI](https://github.com/autohandai/code-cli/) to add the local Context7 server:
-
-```sh
-autohand mcp add context7 npx -y @upstash/context7-mcp --api-key YOUR_API_KEY
-```
-
-Add `--scope project` before `context7` to save the server in the current project's `.autohand` configuration instead of your user configuration.
-
-For basic usage without an API key, you can connect to the remote server instead:
-
-```sh
-autohand mcp add --transport http context7 https://mcp.context7.com/mcp
-```
-
-</details>
-
-<details>
 <summary><b>Install in Cursor</b></summary>
 
 Go to: `Settings` -> `Cursor Settings` -> `MCP` -> `Add new global MCP server`
@@ -1382,6 +1363,25 @@ Once configured, Context7 tools will be available in your droid sessions. Type `
 Configure your coding agent (Codex, Claude Code, Cursor, etc.) to connect to Context7 MCP. Emdash does not modify your agent's config. See the respective MCP configuration sections above for your agent (e.g., OpenAI Codex, Claude Code, Cursor).
 
 See the [Emdash repository](https://github.com/generalaction/emdash) for more information.
+
+</details>
+
+<details>
+<summary><b>Install in Autohand Code</b></summary>
+
+Use the [Autohand Code CLI](https://github.com/autohandai/code-cli/) to add the local Context7 server:
+
+```sh
+autohand mcp add context7 npx -y @upstash/context7-mcp --api-key YOUR_API_KEY
+```
+
+Add `--scope project` before `context7` to save the server in the current project's `.autohand` configuration instead of your user configuration.
+
+For basic usage without an API key, you can connect to the remote server instead:
+
+```sh
+autohand mcp add --transport http context7 https://mcp.context7.com/mcp
+```
 
 </details>
 


### PR DESCRIPTION
## What changed

Added Autohand Code to the existing MCP client installation list with both local npm and remote HTTP setup commands.

## Why

Context7 already documents a broad set of MCP clients. These commands give Autohand Code users the same direct path without changing the server or its existing integrations.

## Validation

- Verified the commands against the current Autohand Code MCP CLI implementation
- Ran `git diff --check`
