### PR TITLE
docs(enterprise): GitOps multi-source manifest + Confluence URL/whole-space

### DIFF
--- a/docs/enterprise/gitops.mdx
+++ b/docs/enterprise/gitops.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "GitOps"
 description: "Manage the list of indexed repositories declaratively from a Git repo and reconcile your on-premise instance to match it"
 ---
 
-GitOps lets you keep the list of repositories Context7 indexes in a Git repository, instead of adding them one by one in the dashboard. Context7 reads a manifest file from that repo and reconciles its own state to match: it indexes anything new, re-indexes anything whose settings changed, and (optionally) removes anything you have deleted from the manifest.
+GitOps lets you keep the list of sources Context7 indexes in a Git repository, instead of adding them one by one in the dashboard. Alongside Git repositories, a source can be a Confluence space, a website, an llms.txt index, or an OpenAPI specification. Context7 reads a manifest file from that repo and reconciles its own state to match: it indexes anything new, re-indexes anything whose settings changed, and (optionally) removes anything you have deleted from the manifest.
 
 The point is to keep your configuration in code. After a disaster, or when standing up a second environment, you point a fresh instance at the manifest repository and the entire index rebuilds itself with no manual clicks.
 
@@ -24,10 +24,10 @@ If you set up the GitHub App **before** GitOps was available, it is not subscrib
 
 You commit a manifest file (by default `repos.yaml`) to a Git repository. Context7 clones that repository using the same Git credentials you already configured under **Settings → Integrations** (a GitHub App or a personal access token), reads the manifest, and compares it against the repositories it currently has indexed.
 
-For each repository in the manifest, Context7 decides what to do:
+For each source in the manifest, Context7 decides what to do:
 
 - **Add** it if it is in the manifest but not yet indexed.
-- **Re-index** it if its manifest entry changed, for example a different branch or new folder filters, or if its last indexing run did not finish.
+- **Re-index** it if its manifest entry changed, for example a different branch, new folder filters, or a changed page limit, or if its last indexing run did not finish.
 - **Leave it untouched** if it already matches. Running a sync with no changes is a safe no-op.
 
 When pruning is enabled, repositories that you remove from the manifest are also deleted from the instance. Pruning only ever removes repositories that GitOps itself added; repositories you add by hand in the dashboard are never touched.
@@ -38,33 +38,55 @@ GitOps is the source of truth only for the repositories listed in the manifest. 
 
 ## The manifest file
 
-The manifest is a YAML file with a list of repositories under `repos`. An optional `defaults` block applies to every entry unless an entry overrides it.
+The manifest is a YAML file with a list of sources under `repos`. An optional `defaults` block applies to every entry unless an entry overrides it.
+
+An entry's `type` selects which parser handles it. Omit `type` and the entry is treated as a Git repository, so manifests written before multi-source support keep working unchanged.
 
 ```yaml repos.yaml
 defaults:
   indexSourceCode: false
   branch: ""              # empty means the repository's default branch
 repos:
+  # Git repository (the default when type is omitted)
   - url: https://github.com/acme/payments
     branch: main
     folders: [docs]
     excludeFolders: [node_modules]
-  - url: https://github.com/acme/billing
-    indexSourceCode: true
+
+  # Confluence space (uses the connection from Settings → Integrations)
+  - url: https://acme.atlassian.net/wiki
+    type: confluence
+    spaceKey: TEAM
+
+  # llms.txt index
+  - url: https://docs.acme.com/llms.txt
+    type: llmstxt
+
+  # Website crawl
+  - url: https://docs.acme.com/
+    type: website
+    maxPages: 200
+
+  # OpenAPI specification
+  - url: https://petstore.swagger.io/v3/openapi.json
+    type: openapi
 ```
 
-Each entry accepts the same options as the **Add Repository** form in the dashboard:
+Every entry needs a `url` (or `repoUrl`). The remaining fields depend on `type`:
 
-| Field | Description |
-| ----- | ----------- |
-| `url` (or `repoUrl`) | The Git repository to index. Required. |
-| `branch` | Branch to index. Leave blank to use the repository's default branch. |
-| `folders` | Only index these folders. Omit to index the whole repository. |
-| `excludeFolders` | Folders to skip. |
-| `excludeFiles` | File patterns to skip, for example `["*.test.md"]`. |
-| `indexSourceCode` | Whether to also generate documentation from source code. Defaults to `false`. |
+| `type` | Fields |
+| ------ | ------ |
+| `git` (default) | `branch`, `folders`, `excludeFolders`, `excludeFiles`, `indexSourceCode` — the same options as the **Add Repository** form. |
+| `confluence` | `spaceKey` (required), `spaceId` (Cloud only, resolved automatically from the key when omitted), `spaceName`, `title`, `description`. The whole space is indexed. |
+| `website` | `maxPages`, `maxDepth`, `excludePatterns`, `title`, `description`. |
+| `llmstxt` | `maxPages`, `title`, `description`. The URL must point to an `llms.txt`, `llms-full.txt`, or `llms-small.txt` file. |
+| `openapi` | `title`, `description`. |
 
-If the manifest cannot be parsed, the whole sync is rejected and nothing changes, so a malformed file can never partially apply or wipe your index.
+<Note>
+Confluence entries reuse the site URL and API token you set under **Settings → Integrations → Confluence**, so no credentials go in the manifest. Website, llms.txt, and OpenAPI sources are fetched over public HTTP and need no credentials. Configure Confluence before adding Confluence entries, or the sync reports those entries as failed.
+</Note>
+
+The manifest is validated strictly: an unknown `type`, a field that does not belong to the entry's type (a common source of silent mistakes), or a missing required field rejects the **whole** sync. Nothing changes until the file parses cleanly, so a malformed manifest can never partially apply or wipe your index.
 
 ## Configuring in the dashboard
 

--- a/docs/enterprise/integrations/confluence.mdx
+++ b/docs/enterprise/integrations/confluence.mdx
@@ -55,7 +55,7 @@ Go to **Add** and choose **Confluence**.
   ![The Add Libraries source picker with a Confluence tile](/images/enterprise/integrations/confluence-source.png)
 </Frame>
 
-Pick a space, then choose which pages to index. The page tree mirrors the space hierarchy, so selecting a parent selects its children. Give the project a title and description if you want to override the auto-detected ones, then choose **Start Parsing**.
+Pick a space, then index the whole space or choose specific pages. Give the project a title and description if you want to override the auto-detected ones, then choose **Start Parsing**.
 
 <Frame>
   ![Selecting a Confluence space and pages, with the page tree and Start Parsing button](/images/enterprise/integrations/confluence-add.png)
@@ -63,10 +63,10 @@ Pick a space, then choose which pages to index. The page tree mirrors the space 
 
 <Steps>
   <Step title="Select a space">
-    Choose the space from the dropdown. Context7 lists every space the configured token can read.
+    Choose the space from the dropdown, or paste a space URL (for example `https://your-site.atlassian.net/wiki/spaces/TEAM`) into **Space URL** to select it directly — handy when the account can read many spaces.
   </Step>
-  <Step title="Choose pages">
-    Tick individual pages, or use **Select all** to index the whole space. Use the search box to filter a large space.
+  <Step title="Choose the scope">
+    Leave **Index the entire space** on to index everything, which is the fastest path and the right choice for large spaces. Turn it off to pick individual pages: the page tree mirrors the space hierarchy, so selecting a parent selects its children. Very large spaces load their pages in batches — use **Load more pages** to fetch the rest, and the search box to filter.
   </Step>
   <Step title="Start parsing">
     Context7 fetches the pages, converts them to Markdown (code blocks, tables, and callouts are preserved), and indexes them. The project appears under your libraries when it finishes.
@@ -74,8 +74,10 @@ Pick a space, then choose which pages to index. The page tree mirrors the space 
 </Steps>
 
 <Note>
-**Select all** indexes the whole space, so a later refresh also picks up pages added since. Selecting a specific subset pins the project to exactly those pages.
+Indexing the entire space means a later refresh also picks up pages added since. Selecting a specific subset pins the project to exactly those pages.
 </Note>
+
+You can also index Confluence spaces declaratively with [GitOps](/enterprise/gitops) — add a `type: confluence` entry with a `spaceKey` to your manifest, and it reuses this same connection.
 
 ## Refresh and delete
 


### PR DESCRIPTION
Documents the enterprise changes in upstash/context7parser#546.

- GitOps manifest: document the `type` field routing entries to Confluence, website, llms.txt, and OpenAPI parsers; bare entries stay git.
- Add the per-type field table plus the no-secrets and strict-validation notes.
- Confluence: document the space URL field, the "index entire space" scope toggle, and paginated page browsing.
- Cross-link declarative Confluence indexing from the Confluence integration page.