### PR TITLE
fix(sdk): return typed errors for malformed JSON responses

### DIFF
--- a/.changeset/success-json-guard.md
+++ b/.changeset/success-json-guard.md
@@ -1,0 +1,5 @@
+---
+"@upstash/context7-sdk": patch
+---
+
+Convert empty or malformed successful JSON responses into a typed `Context7Error` instead of exposing a native `SyntaxError`. Valid JSON responses and retry behavior are unchanged.

--- a/packages/sdk/src/http/index.test.ts
+++ b/packages/sdk/src/http/index.test.ts
@@ -78,4 +78,56 @@ describe("HttpClient error handling", () => {
     expect(error).toBeInstanceOf(Context7Error);
     expect(error.message).toBe("Service Unavailable");
   });
+
+  test("throws Context7Error (not SyntaxError) on empty application/json success body", async () => {
+    mockFetch(
+      new Response("", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    );
+
+    const error = await newClient()
+      .request({ path: ["search"] })
+      .catch((e) => e);
+
+    expect(error).toBeInstanceOf(Context7Error);
+    expect(error).not.toBeInstanceOf(SyntaxError);
+    expect(error.message).toBe("Failed to parse JSON response from Context7 API");
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  test("throws Context7Error (not SyntaxError) on malformed application/json success body", async () => {
+    mockFetch(
+      new Response("{ invalid json }", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    );
+
+    const error = await newClient()
+      .request({ path: ["search"] })
+      .catch((e) => e);
+
+    expect(error).toBeInstanceOf(Context7Error);
+    expect(error).not.toBeInstanceOf(SyntaxError);
+    expect(error.message).toBe("Failed to parse JSON response from Context7 API");
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns parsed result on valid application/json success body", async () => {
+    mockFetch(
+      new Response(JSON.stringify({ ok: true, items: [1, 2, 3] }), {
+        status: 200,
+        headers: { "content-type": "application/json; charset=utf-8" },
+      })
+    );
+
+    const response = await newClient().request<{ ok: boolean; items: number[] }>({
+      path: ["search"],
+    });
+
+    expect(response.result).toEqual({ ok: true, items: [1, 2, 3] });
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/sdk/src/http/index.ts
+++ b/packages/sdk/src/http/index.ts
@@ -179,7 +179,12 @@ export class HttpClient implements Requester {
     const contentType = res.headers.get("content-type");
 
     if (contentType?.includes("application/json")) {
-      const body = await res.json();
+      let body: unknown;
+      try {
+        body = await res.json();
+      } catch {
+        throw new Context7Error("Failed to parse JSON response from Context7 API");
+      }
       return { result: body as TResult };
     } else {
       const text = await res.text();


### PR DESCRIPTION
## Summary

- convert empty or malformed successful JSON responses into a typed `Context7Error`
- preserve valid JSON results and the existing network-retry boundary
- add focused regression coverage and a patch changeset for `@upstash/context7-sdk`

## Why

#2732 hardened the SDK's error-response path so response parsing could not leak a native `SyntaxError`. The successful `application/json` path still called `res.json()` without a guard, so an empty or malformed 200 response bypassed the SDK's typed error contract.

This keeps parsing after the fetch retry loop: malformed response bodies fail once and are not retried.

Follow-up to #2732 and #1964.

## Tests

- `vitest run src/http/index.test.ts` (7 tests)
- SDK typecheck
- SDK ESLint
- SDK build
- Prettier check
- `git diff --check`
