### PR TITLE
CTX7-1839: Surface the real error when a CLI OAuth request fails

### DIFF
--- a/.changeset/surface-cli-auth-errors.md
+++ b/.changeset/surface-cli-auth-errors.md
@@ -2,4 +2,4 @@
 "ctx7": patch
 ---
 
-Surface the underlying network error when `ctx7 login` cannot start device authorization. Connection failures now report the cause (TLS interception, DNS, firewall, timeout) with a hint, and non-JSON error responses report the HTTP status and body excerpt instead of a generic message.
+Surface the underlying network error when an OAuth request fails. Connection failures now report the cause (TLS interception, DNS, firewall, timeout) with a hint, and non-JSON error responses report the HTTP status and body excerpt instead of a generic message.

--- a/.changeset/surface-cli-auth-errors.md
+++ b/.changeset/surface-cli-auth-errors.md
@@ -1,0 +1,5 @@
+---
+"ctx7": patch
+---
+
+Surface the underlying network error when `ctx7 login` cannot start device authorization. Connection failures now report the cause (TLS interception, DNS, firewall, timeout) with a hint, and non-JSON error responses report the HTTP status and body excerpt instead of a generic message.

--- a/packages/cli/src/__tests__/auth-utils.test.ts
+++ b/packages/cli/src/__tests__/auth-utils.test.ts
@@ -354,11 +354,46 @@ describe("startDeviceAuthorization", () => {
       "fetch",
       vi.fn().mockResolvedValue({
         ok: false,
-        json: () =>
-          Promise.resolve({ error: "invalid_request", error_description: "bad client_id" }),
+        status: 400,
+        url: "https://t/api/oauth/device/code",
+        text: () =>
+          Promise.resolve(
+            JSON.stringify({ error: "invalid_request", error_description: "bad client_id" })
+          ),
       })
     );
     await expect(startDeviceAuthorization("https://t", "bogus")).rejects.toThrow("bad client_id");
+  });
+
+  // A proxy or firewall answers with HTML rather than an OAuth error object;
+  // the status and body must survive so the user can tell it was intercepted.
+  test("reports status and body excerpt when the response is not JSON", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        url: "https://t/api/oauth/device/code",
+        text: () => Promise.resolve("<html><body>Blocked by proxy</body></html>"),
+      })
+    );
+    await expect(startDeviceAuthorization("https://t", "c")).rejects.toThrow(
+      /HTTP 403.*Blocked by proxy/s
+    );
+  });
+
+  test("surfaces the underlying cause when the connection fails", async () => {
+    const failure = Object.assign(new TypeError("fetch failed"), {
+      cause: {
+        code: "UNABLE_TO_VERIFY_LEAF_SIGNATURE",
+        message: "unable to verify leaf signature",
+      },
+    });
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(failure));
+
+    await expect(startDeviceAuthorization("https://t", "c")).rejects.toThrow(
+      /UNABLE_TO_VERIFY_LEAF_SIGNATURE.*NODE_EXTRA_CA_CERTS/s
+    );
   });
 });
 

--- a/packages/cli/src/__tests__/auth-utils.test.ts
+++ b/packages/cli/src/__tests__/auth-utils.test.ts
@@ -299,8 +299,34 @@ describe("getValidAccessToken", () => {
       "fetch",
       vi.fn().mockResolvedValue({
         ok: false,
-        json: () => Promise.resolve({ error: "invalid_grant" }),
+        status: 400,
+        url: "https://test.context7.com/api/oauth/token",
+        text: () => Promise.resolve(JSON.stringify({ error: "invalid_grant" })),
       })
+    );
+
+    expect(await getValidAccessToken()).toBeNull();
+  });
+
+  // An expired refresh token is indistinguishable from being logged out, so the
+  // caller reports "not logged in" rather than surfacing a network error here.
+  test("returns null when the refresh connection fails", async () => {
+    const tokens: TokenData = {
+      access_token: "expired-tok",
+      token_type: "bearer",
+      expires_at: Date.now() - 1000,
+      refresh_token: "refresh-tok",
+    };
+
+    mfs.existsSync.mockReturnValue(true);
+    mfs.readFileSync.mockReturnValue(JSON.stringify(tokens));
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockRejectedValue(
+          Object.assign(new TypeError("fetch failed"), { cause: { code: "ENOTFOUND" } })
+        )
     );
 
     expect(await getValidAccessToken()).toBeNull();
@@ -447,7 +473,8 @@ describe("pollDeviceToken", () => {
     vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("ECONNREFUSED")));
     const result = await pollDeviceToken("https://t", "c", "dc");
     expect(result.status).toBe("transient");
-    expect(result.errorMessage).toBe("ECONNREFUSED");
+    // Polling keeps the described cause rather than the bare message.
+    expect(result.errorMessage).toContain("ECONNREFUSED");
   });
 
   test("throws on unknown 4xx error code", async () => {

--- a/packages/cli/src/__tests__/auth-utils.test.ts
+++ b/packages/cli/src/__tests__/auth-utils.test.ts
@@ -391,8 +391,6 @@ describe("startDeviceAuthorization", () => {
     await expect(startDeviceAuthorization("https://t", "bogus")).rejects.toThrow("bad client_id");
   });
 
-  // A proxy or firewall answers with HTML rather than an OAuth error object;
-  // the status and body must survive so the user can tell it was intercepted.
   test("reports status and body excerpt when the response is not JSON", async () => {
     vi.stubGlobal(
       "fetch",
@@ -473,7 +471,6 @@ describe("pollDeviceToken", () => {
     vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("ECONNREFUSED")));
     const result = await pollDeviceToken("https://t", "c", "dc");
     expect(result.status).toBe("transient");
-    // Polling keeps the described cause rather than the bare message.
     expect(result.errorMessage).toContain("ECONNREFUSED");
   });
 

--- a/packages/cli/src/utils/auth.ts
+++ b/packages/cli/src/utils/auth.ts
@@ -147,6 +147,71 @@ export interface DeviceAuthorizationResponse {
 
 const DEVICE_CODE_GRANT = "urn:ietf:params:oauth:grant-type:device_code";
 
+/**
+ * Builds an error message from a non-OK response. An OAuth server sends a JSON
+ * `error`/`error_description` (RFC 6749 §5.2), but an intercepting proxy sends
+ * HTML or nothing — so fall back to the status and a body excerpt rather than a
+ * generic message that hides whether the request even reached Context7.
+ */
+async function describeErrorResponse(response: Response, fallback: string): Promise<string> {
+  const body = await response.text().catch(() => "");
+
+  try {
+    const err = JSON.parse(body) as TokenErrorResponse;
+    const message = err.error_description || err.error;
+    if (message) return message;
+  } catch {
+    // Not JSON — an interceptor, not the OAuth server.
+  }
+
+  const excerpt = body.replace(/\s+/g, " ").trim().slice(0, 200);
+  const detail = `HTTP ${response.status} from ${response.url}`;
+  return excerpt ? `${fallback} (${detail}): ${excerpt}` : `${fallback} (${detail})`;
+}
+
+/**
+ * `fetch` rejects with a bare "fetch failed" and puts the real reason on
+ * `cause`, which reads as a Context7 outage when it is almost always local
+ * networking. Undici also ignores HTTPS_PROXY unless a dispatcher is set, so a
+ * machine whose npm works through a proxy can still fail here.
+ */
+function describeConnectionError(error: unknown, url: string): string {
+  const cause = (error as { cause?: { code?: string; message?: string } })?.cause;
+  const code = cause?.code;
+  const detail = cause?.message || (error instanceof Error ? error.message : String(error));
+
+  let hint: string;
+  switch (code) {
+    case "UNABLE_TO_VERIFY_LEAF_SIGNATURE":
+    case "SELF_SIGNED_CERT_IN_CHAIN":
+    case "DEPTH_ZERO_SELF_SIGNED_CERT":
+    case "CERT_HAS_EXPIRED":
+      hint =
+        "The TLS certificate could not be verified, which usually means a proxy is inspecting HTTPS traffic. Point NODE_EXTRA_CA_CERTS at your organization's root CA.";
+      break;
+    case "ENOTFOUND":
+    case "EAI_AGAIN":
+      hint = "DNS lookup failed. Check your network or VPN connection.";
+      break;
+    case "ECONNREFUSED":
+    case "ECONNRESET":
+    case "EHOSTUNREACH":
+    case "ENETUNREACH":
+      hint =
+        "The connection was refused or reset, which usually means a firewall or proxy is blocking it.";
+      break;
+    case "UND_ERR_CONNECT_TIMEOUT":
+    case "ETIMEDOUT":
+      hint = "The connection timed out. A proxy or firewall may be dropping the request.";
+      break;
+    default:
+      hint =
+        "If you are behind a corporate proxy, note that Node does not use HTTPS_PROXY automatically.";
+  }
+
+  return `Could not reach ${url}: ${detail}${code ? ` (${code})` : ""}\n${hint}`;
+}
+
 /** RFC 8628 §3.2 default poll interval when the server omits `interval`. */
 export const DEFAULT_DEVICE_POLL_INTERVAL_SECONDS = 5;
 
@@ -165,15 +230,20 @@ export async function startDeviceAuthorization(
     // ignore
   }
 
-  const response = await fetch(`${baseUrl}/api/oauth/device/code`, {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: params.toString(),
-  });
+  const url = `${baseUrl}/api/oauth/device/code`;
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: params.toString(),
+    });
+  } catch (error) {
+    throw new Error(describeConnectionError(error, url));
+  }
 
   if (!response.ok) {
-    const err = (await response.json().catch(() => ({}))) as TokenErrorResponse;
-    throw new Error(err.error_description || err.error || "Failed to start device authorization");
+    throw new Error(await describeErrorResponse(response, "Failed to start device authorization"));
   }
 
   return (await response.json()) as DeviceAuthorizationResponse;

--- a/packages/cli/src/utils/auth.ts
+++ b/packages/cli/src/utils/auth.ts
@@ -140,12 +140,6 @@ export interface DeviceAuthorizationResponse {
 
 const DEVICE_CODE_GRANT = "urn:ietf:params:oauth:grant-type:device_code";
 
-/**
- * Builds an error message from a non-OK response. An OAuth server sends a JSON
- * `error`/`error_description` (RFC 6749 §5.2), but an intercepting proxy sends
- * HTML or nothing — so fall back to the status and a body excerpt rather than a
- * generic message that hides whether the request even reached Context7.
- */
 async function describeErrorResponse(response: Response, fallback: string): Promise<string> {
   const body = await response.text().catch(() => "");
 
@@ -154,7 +148,7 @@ async function describeErrorResponse(response: Response, fallback: string): Prom
     const message = err.error_description || err.error;
     if (message) return message;
   } catch {
-    // Not JSON — an interceptor, not the OAuth server.
+    // An interceptor's HTML, not an OAuth error object.
   }
 
   const excerpt = body.replace(/\s+/g, " ").trim().slice(0, 200);
@@ -168,8 +162,6 @@ const DNS_HINT = "DNS lookup failed. Check your network or VPN connection.";
 const BLOCKED_HINT =
   "The connection was refused or reset, which usually means a firewall or proxy is blocking it.";
 const TIMEOUT_HINT = "The connection timed out. A proxy or firewall may be dropping the request.";
-// Undici ignores HTTPS_PROXY unless a dispatcher is set, so a machine whose npm
-// works through a proxy can still fail here with no recognizable code.
 const DEFAULT_HINT =
   "If you are behind a corporate proxy, note that Node does not use HTTPS_PROXY automatically.";
 
@@ -188,7 +180,6 @@ const CONNECTION_HINTS: Record<string, string> = {
   ETIMEDOUT: TIMEOUT_HINT,
 };
 
-/** `cause` is typed `unknown`, so narrow it rather than asserting its shape. */
 function getErrorCause(error: unknown): { code?: string; message?: string } {
   if (typeof error !== "object" || error === null || !("cause" in error)) return {};
   const cause = (error as { cause: unknown }).cause;
@@ -201,11 +192,6 @@ function getErrorCause(error: unknown): { code?: string; message?: string } {
   };
 }
 
-/**
- * `fetch` rejects with a bare "fetch failed" and puts the real reason on
- * `cause`, which reads as a Context7 outage when it is almost always local
- * networking.
- */
 function describeConnectionError(error: unknown, url: string): string {
   const { code, message } = getErrorCause(error);
   const detail = message || (error instanceof Error ? error.message : String(error));
@@ -214,11 +200,6 @@ function describeConnectionError(error: unknown, url: string): string {
   return `Could not reach ${url}: ${detail}${code ? ` (${code})` : ""}\n${hint}`;
 }
 
-/**
- * POSTs a form-encoded body to an OAuth endpoint. Rewrites a thrown `fetch`
- * into an error that names the actual cause; the response itself is returned
- * unexamined for callers that classify it (see `pollDeviceToken`).
- */
 async function postForm(url: string, params: URLSearchParams): Promise<Response> {
   try {
     return await fetch(url, {
@@ -231,10 +212,6 @@ async function postForm(url: string, params: URLSearchParams): Promise<Response>
   }
 }
 
-/**
- * POSTs to an OAuth endpoint and returns the parsed body, throwing a described
- * error for both connection failures and non-OK responses.
- */
 async function oauthRequest<T>(url: string, params: URLSearchParams, fallback: string): Promise<T> {
   const response = await postForm(url, params);
   if (!response.ok) {

--- a/packages/cli/src/utils/auth.ts
+++ b/packages/cli/src/utils/auth.ts
@@ -85,22 +85,15 @@ export function isTokenExpired(tokens: TokenData): boolean {
 }
 
 async function refreshAccessToken(refreshToken: string): Promise<TokenData> {
-  const response = await fetch(`${getBaseUrl()}/api/oauth/token`, {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
+  return oauthRequest<TokenData>(
+    `${getBaseUrl()}/api/oauth/token`,
+    new URLSearchParams({
       grant_type: "refresh_token",
       client_id: CLI_CLIENT_ID,
       refresh_token: refreshToken,
-    }).toString(),
-  });
-
-  if (!response.ok) {
-    const err = (await response.json().catch(() => ({}))) as TokenErrorResponse;
-    throw new Error(err.error_description || err.error || "Failed to refresh token");
-  }
-
-  return (await response.json()) as TokenData;
+    }),
+    "Failed to refresh token"
+  );
 }
 
 /**
@@ -169,47 +162,85 @@ async function describeErrorResponse(response: Response, fallback: string): Prom
   return excerpt ? `${fallback} (${detail}): ${excerpt}` : `${fallback} (${detail})`;
 }
 
+const TLS_HINT =
+  "The TLS certificate could not be verified, which usually means a proxy is inspecting HTTPS traffic. Point NODE_EXTRA_CA_CERTS at your organization's root CA.";
+const DNS_HINT = "DNS lookup failed. Check your network or VPN connection.";
+const BLOCKED_HINT =
+  "The connection was refused or reset, which usually means a firewall or proxy is blocking it.";
+const TIMEOUT_HINT = "The connection timed out. A proxy or firewall may be dropping the request.";
+// Undici ignores HTTPS_PROXY unless a dispatcher is set, so a machine whose npm
+// works through a proxy can still fail here with no recognizable code.
+const DEFAULT_HINT =
+  "If you are behind a corporate proxy, note that Node does not use HTTPS_PROXY automatically.";
+
+const CONNECTION_HINTS: Record<string, string> = {
+  UNABLE_TO_VERIFY_LEAF_SIGNATURE: TLS_HINT,
+  SELF_SIGNED_CERT_IN_CHAIN: TLS_HINT,
+  DEPTH_ZERO_SELF_SIGNED_CERT: TLS_HINT,
+  CERT_HAS_EXPIRED: TLS_HINT,
+  ENOTFOUND: DNS_HINT,
+  EAI_AGAIN: DNS_HINT,
+  ECONNREFUSED: BLOCKED_HINT,
+  ECONNRESET: BLOCKED_HINT,
+  EHOSTUNREACH: BLOCKED_HINT,
+  ENETUNREACH: BLOCKED_HINT,
+  UND_ERR_CONNECT_TIMEOUT: TIMEOUT_HINT,
+  ETIMEDOUT: TIMEOUT_HINT,
+};
+
+/** `cause` is typed `unknown`, so narrow it rather than asserting its shape. */
+function getErrorCause(error: unknown): { code?: string; message?: string } {
+  if (typeof error !== "object" || error === null || !("cause" in error)) return {};
+  const cause = (error as { cause: unknown }).cause;
+  if (typeof cause !== "object" || cause === null) return {};
+
+  const { code, message } = cause as { code?: unknown; message?: unknown };
+  return {
+    code: typeof code === "string" ? code : undefined,
+    message: typeof message === "string" ? message : undefined,
+  };
+}
+
 /**
  * `fetch` rejects with a bare "fetch failed" and puts the real reason on
  * `cause`, which reads as a Context7 outage when it is almost always local
- * networking. Undici also ignores HTTPS_PROXY unless a dispatcher is set, so a
- * machine whose npm works through a proxy can still fail here.
+ * networking.
  */
 function describeConnectionError(error: unknown, url: string): string {
-  const cause = (error as { cause?: { code?: string; message?: string } })?.cause;
-  const code = cause?.code;
-  const detail = cause?.message || (error instanceof Error ? error.message : String(error));
-
-  let hint: string;
-  switch (code) {
-    case "UNABLE_TO_VERIFY_LEAF_SIGNATURE":
-    case "SELF_SIGNED_CERT_IN_CHAIN":
-    case "DEPTH_ZERO_SELF_SIGNED_CERT":
-    case "CERT_HAS_EXPIRED":
-      hint =
-        "The TLS certificate could not be verified, which usually means a proxy is inspecting HTTPS traffic. Point NODE_EXTRA_CA_CERTS at your organization's root CA.";
-      break;
-    case "ENOTFOUND":
-    case "EAI_AGAIN":
-      hint = "DNS lookup failed. Check your network or VPN connection.";
-      break;
-    case "ECONNREFUSED":
-    case "ECONNRESET":
-    case "EHOSTUNREACH":
-    case "ENETUNREACH":
-      hint =
-        "The connection was refused or reset, which usually means a firewall or proxy is blocking it.";
-      break;
-    case "UND_ERR_CONNECT_TIMEOUT":
-    case "ETIMEDOUT":
-      hint = "The connection timed out. A proxy or firewall may be dropping the request.";
-      break;
-    default:
-      hint =
-        "If you are behind a corporate proxy, note that Node does not use HTTPS_PROXY automatically.";
-  }
+  const { code, message } = getErrorCause(error);
+  const detail = message || (error instanceof Error ? error.message : String(error));
+  const hint = (code && CONNECTION_HINTS[code]) || DEFAULT_HINT;
 
   return `Could not reach ${url}: ${detail}${code ? ` (${code})` : ""}\n${hint}`;
+}
+
+/**
+ * POSTs a form-encoded body to an OAuth endpoint. Rewrites a thrown `fetch`
+ * into an error that names the actual cause; the response itself is returned
+ * unexamined for callers that classify it (see `pollDeviceToken`).
+ */
+async function postForm(url: string, params: URLSearchParams): Promise<Response> {
+  try {
+    return await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: params.toString(),
+    });
+  } catch (error) {
+    throw new Error(describeConnectionError(error, url));
+  }
+}
+
+/**
+ * POSTs to an OAuth endpoint and returns the parsed body, throwing a described
+ * error for both connection failures and non-OK responses.
+ */
+async function oauthRequest<T>(url: string, params: URLSearchParams, fallback: string): Promise<T> {
+  const response = await postForm(url, params);
+  if (!response.ok) {
+    throw new Error(await describeErrorResponse(response, fallback));
+  }
+  return (await response.json()) as T;
 }
 
 /** RFC 8628 §3.2 default poll interval when the server omits `interval`. */
@@ -230,23 +261,11 @@ export async function startDeviceAuthorization(
     // ignore
   }
 
-  const url = `${baseUrl}/api/oauth/device/code`;
-  let response: Response;
-  try {
-    response = await fetch(url, {
-      method: "POST",
-      headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      body: params.toString(),
-    });
-  } catch (error) {
-    throw new Error(describeConnectionError(error, url));
-  }
-
-  if (!response.ok) {
-    throw new Error(await describeErrorResponse(response, "Failed to start device authorization"));
-  }
-
-  return (await response.json()) as DeviceAuthorizationResponse;
+  return oauthRequest<DeviceAuthorizationResponse>(
+    `${baseUrl}/api/oauth/device/code`,
+    params,
+    "Failed to start device authorization"
+  );
 }
 
 export interface PollDeviceTokenResult {
@@ -262,15 +281,14 @@ export async function pollDeviceToken(
 ): Promise<PollDeviceTokenResult> {
   let response: Response;
   try {
-    response = await fetch(`${baseUrl}/api/oauth/device/token`, {
-      method: "POST",
-      headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      body: new URLSearchParams({
+    response = await postForm(
+      `${baseUrl}/api/oauth/device/token`,
+      new URLSearchParams({
         grant_type: DEVICE_CODE_GRANT,
         device_code: deviceCode,
         client_id: clientId,
-      }).toString(),
-    });
+      })
+    );
   } catch (error) {
     // Network blip — keep polling.
     return {

--- a/packages/sdk/vitest.config.ts
+++ b/packages/sdk/vitest.config.ts
@@ -10,6 +10,8 @@ export default defineConfig({
     environment: "node",
     include: ["src/**/*.test.ts"],
     env: process.env,
+    // These tests call the live API, so the 5s default fails on latency alone.
+    testTimeout: 30_000,
   },
   resolve: {
     alias: {


### PR DESCRIPTION
Makes the CLI report why an OAuth request failed, instead of the generic "Failed to start device authorization" that hid every cause.

- Add `postForm`/`oauthRequest` so connection and error-response handling live in one place; `startDeviceAuthorization` and `refreshAccessToken` each collapse to a single call, and `pollDeviceToken` shares the request path.
- Report the cause of a thrown `fetch` (TLS interception, DNS, firewall, timeout) with an actionable hint; undici's bare "fetch failed" reads as a Context7 outage when it is almost always local networking.
- Report HTTP status and a body excerpt when an error response is not an OAuth error object, as when a proxy returns an HTML block page.
- Fix a refresh test that mocked only `json()`, so it passed via a swallowed `TypeError` rather than the path under test.
- Raise the SDK test timeout to 30s. Unrelated to the CLI change, but it was failing CI here: those tests call the live API and vitest's 5s default fails on latency alone.

Reported by a user on a proxied corporate network where `npm` reaches Artifactory but `ctx7 login` fails. This does not fix their connectivity — it makes the failure self-diagnosing rather than a dead end.

Note that `getValidAccessToken` still swallows refresh failures and returns `null`, since an expired refresh token is indistinguishable from being logged out; the improved message there is for future callers, not a user-visible change today.

## Test plan

Verified against the built binary, not just unit tests:

| Case | Output |
| --- | --- |
| Unresolvable host | `getaddrinfo ENOTFOUND ... (ENOTFOUND)` + DNS/VPN hint |
| Closed port | `connect ECONNREFUSED ... (ECONNREFUSED)` + firewall hint |
| HTML 403 from a local server | `HTTP 403 from ...: <html>...Blocked by corporate policy...` |
| TLS interception (injected cause) | `UNABLE_TO_VERIFY_LEAF_SIGNATURE` + `NODE_EXTRA_CA_CERTS` hint |
| Happy path against production | Real device code issued; flow unchanged |

CLI: 238 tests, typecheck, lint, build all pass. SDK: 27 tests pass (60s total runtime, well past the old 5s-per-test ceiling).