### PR TITLE
fix(cli): avoid shell for GitHub auth token

### DIFF
--- a/.changeset/avoid-shell-github-token.md
+++ b/.changeset/avoid-shell-github-token.md
@@ -2,4 +2,4 @@
 "ctx7": patch
 ---
 
-Invoke the GitHub CLI directly when reading its authentication token, avoiding an unnecessary shell process on Windows.
+Read the GitHub CLI auth token by invoking `gh` directly instead of through a shell. The shell wrapper (`cmd.exe /d /s /c` on Windows) caused endpoint protection tools such as Microsoft Defender for Endpoint to raise a "Suspicious Node.js process behavior" alert during `ctx7 setup`.

--- a/.changeset/avoid-shell-github-token.md
+++ b/.changeset/avoid-shell-github-token.md
@@ -1,0 +1,5 @@
+---
+"ctx7": patch
+---
+
+Invoke the GitHub CLI directly when reading its authentication token, avoiding an unnecessary shell process on Windows.

--- a/packages/cli/src/__tests__/github.test.ts
+++ b/packages/cli/src/__tests__/github.test.ts
@@ -7,7 +7,9 @@ vi.mock("node:child_process", () => ({ execFileSync }));
 import { listSkillsFromGitHub } from "../utils/github.js";
 
 beforeEach(() => {
-  vi.clearAllMocks();
+  // resetAllMocks, not clearAllMocks: the latter keeps implementations, so a
+  // mockImplementation set by one test would leak into the next.
+  vi.resetAllMocks();
   vi.stubEnv("GITHUB_TOKEN", undefined);
   vi.stubEnv("GH_TOKEN", undefined);
   vi.stubGlobal(
@@ -34,12 +36,14 @@ describe("GitHub authentication", () => {
   test("reads the GitHub CLI token without invoking a shell", async () => {
     execFileSync.mockReturnValue("cli-token\n");
 
-    await listSkillsFromGitHub("upstash/context7");
+    const result = await listSkillsFromGitHub("upstash/context7");
 
+    // No shell string and no `shell` option: the whole point of #2918.
     expect(execFileSync).toHaveBeenCalledWith("gh", ["auth", "token"], {
       encoding: "utf8",
       stdio: ["pipe", "pipe", "ignore"],
     });
+    expect(result).toEqual({ status: "ok", skills: [] });
     expect(vi.mocked(fetch).mock.calls[0][1]).toMatchObject({
       headers: expect.objectContaining({ Authorization: "token cli-token" }),
     });
@@ -48,21 +52,36 @@ describe("GitHub authentication", () => {
   test("prefers an environment token over invoking the GitHub CLI", async () => {
     vi.stubEnv("GITHUB_TOKEN", "env-token");
 
-    await listSkillsFromGitHub("upstash/context7");
+    const result = await listSkillsFromGitHub("upstash/context7");
 
     expect(execFileSync).not.toHaveBeenCalled();
+    expect(result).toEqual({ status: "ok", skills: [] });
     expect(vi.mocked(fetch).mock.calls[0][1]).toMatchObject({
       headers: expect.objectContaining({ Authorization: "token env-token" }),
     });
   });
 
+  test("falls back to GH_TOKEN when GITHUB_TOKEN is unset", async () => {
+    vi.stubEnv("GH_TOKEN", "gh-env-token");
+
+    const result = await listSkillsFromGitHub("upstash/context7");
+
+    expect(execFileSync).not.toHaveBeenCalled();
+    expect(result).toEqual({ status: "ok", skills: [] });
+    expect(vi.mocked(fetch).mock.calls[0][1]).toMatchObject({
+      headers: expect.objectContaining({ Authorization: "token gh-env-token" }),
+    });
+  });
+
   test("continues without authentication when the GitHub CLI is unavailable", async () => {
     execFileSync.mockImplementation(() => {
-      throw new Error("gh not found");
+      throw Object.assign(new Error("spawnSync gh ENOENT"), { code: "ENOENT" });
     });
 
-    await listSkillsFromGitHub("upstash/context7");
+    const result = await listSkillsFromGitHub("upstash/context7");
 
+    // A missing or unresolvable gh degrades to unauthenticated requests, it does not throw.
+    expect(result).toEqual({ status: "ok", skills: [] });
     const headers = vi.mocked(fetch).mock.calls[0][1]?.headers as Record<string, string>;
     expect(headers).not.toHaveProperty("Authorization");
   });

--- a/packages/cli/src/__tests__/github.test.ts
+++ b/packages/cli/src/__tests__/github.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const execFileSync = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", () => ({ execFileSync }));
+
+import { listSkillsFromGitHub } from "../utils/github.js";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubEnv("GITHUB_TOKEN", undefined);
+  vi.stubEnv("GH_TOKEN", undefined);
+  vi.stubGlobal(
+    "fetch",
+    vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ default_branch: "main" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ sha: "tree-sha", tree: [], truncated: false }),
+      })
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+describe("GitHub authentication", () => {
+  test("reads the GitHub CLI token without invoking a shell", async () => {
+    execFileSync.mockReturnValue("cli-token\n");
+
+    await listSkillsFromGitHub("upstash/context7");
+
+    expect(execFileSync).toHaveBeenCalledWith("gh", ["auth", "token"], {
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "ignore"],
+    });
+    expect(vi.mocked(fetch).mock.calls[0][1]).toMatchObject({
+      headers: expect.objectContaining({ Authorization: "token cli-token" }),
+    });
+  });
+
+  test("prefers an environment token over invoking the GitHub CLI", async () => {
+    vi.stubEnv("GITHUB_TOKEN", "env-token");
+
+    await listSkillsFromGitHub("upstash/context7");
+
+    expect(execFileSync).not.toHaveBeenCalled();
+    expect(vi.mocked(fetch).mock.calls[0][1]).toMatchObject({
+      headers: expect.objectContaining({ Authorization: "token env-token" }),
+    });
+  });
+
+  test("continues without authentication when the GitHub CLI is unavailable", async () => {
+    execFileSync.mockImplementation(() => {
+      throw new Error("gh not found");
+    });
+
+    await listSkillsFromGitHub("upstash/context7");
+
+    const headers = vi.mocked(fetch).mock.calls[0][1]?.headers as Record<string, string>;
+    expect(headers).not.toHaveProperty("Authorization");
+  });
+});

--- a/packages/cli/src/utils/github.ts
+++ b/packages/cli/src/utils/github.ts
@@ -1,4 +1,4 @@
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import type { SkillFile, Skill } from "../types.js";
 import { isSafeSkillName } from "./skill-name.js";
 
@@ -85,9 +85,10 @@ function getGitHubToken(): string | undefined {
   const envToken = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
   if (envToken) return envToken;
   try {
-    return execSync("gh auth token", { stdio: ["pipe", "pipe", "ignore"] })
-      .toString()
-      .trim();
+    return execFileSync("gh", ["auth", "token"], {
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "ignore"],
+    }).trim();
   } catch {
     return undefined;
   }

--- a/packages/cli/src/utils/github.ts
+++ b/packages/cli/src/utils/github.ts
@@ -85,6 +85,11 @@ function getGitHubToken(): string | undefined {
   const envToken = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
   if (envToken) return envToken;
   try {
+    // Deliberately shell-free: execSync would wrap this in `cmd.exe /d /s /c` on Windows,
+    // which EDR tooling reports as suspicious Node behavior (#2918). Do not add `shell`
+    // to make a .cmd/.bat `gh` shim resolve; that reintroduces the flagged process for
+    // everyone. Such shims are rare (mainstream Windows installs ship gh.exe) and only
+    // cost the fallback to unauthenticated requests.
     return execFileSync("gh", ["auth", "token"], {
       encoding: "utf8",
       stdio: ["pipe", "pipe", "ignore"],


### PR DESCRIPTION
## Summary

- invoke `gh auth token` directly instead of routing it through a shell
- preserve environment-token precedence and unauthenticated fallback behavior
- add regression coverage for direct invocation, environment tokens, and missing GitHub CLI behavior

## Testing

- `pnpm --filter ctx7 exec vitest run src/__tests__/github.test.ts`
- `pnpm --filter ctx7 test`
- `pnpm --filter ctx7 typecheck`
- `pnpm --filter ctx7 lint:check`

Closes #2918
