### PR TITLE
fix: extract x-context7-api-key header and tighten JWT detection

### DIFF
--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -372,6 +372,7 @@ async function main() {
       return (
         extractBearerToken(req.headers.authorization) ||
         extractHeaderValue(req.headers["context7-api-key"]) ||
+        extractHeaderValue(req.headers["x-context7-api-key"]) ||
         extractHeaderValue(req.headers["x-api-key"]) ||
         extractHeaderValue(req.headers["context7_api_key"]) ||
         extractHeaderValue(req.headers["x_api_key"])

--- a/packages/mcp/src/lib/jwt.ts
+++ b/packages/mcp/src/lib/jwt.ts
@@ -68,7 +68,8 @@ export interface JWTValidationResult {
 }
 
 export function isJWT(token: string): boolean {
-  return token.split(".").length === 3;
+  const parts = token.split(".");
+  return parts.length === 3 && parts.every((part) => part.length > 0);
 }
 
 export async function validateJWT(token: string): Promise<JWTValidationResult> {


### PR DESCRIPTION
## Summary

- **Add missing `x-context7-api-key` header extraction**: The CORS config already allows the `X-Context7-API-Key` header, but `extractApiKey` never checked for it. Added `x-context7-api-key` to the extraction chain so clients sending that header are properly authenticated.

- **Fix `isJWT` false positive for strings with two dots**: The previous check `token.split(".").length === 3` returned `true` for strings like `".."` or `"a..b"`. Now it also verifies that all three parts are non-empty, preventing false positives from malformed tokens.

## Test plan

- Verify that requests with `X-Context7-API-Key` header are correctly authenticated
- Verify that `isJWT("..")` and `isJWT("a..b")` return `false`
- Verify that `isJWT("header.payload.signature")` still returns `true`