### PR TITLE
feat: track auth sign-in nudge funnel

### DIFF
--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -1,4 +1,4 @@
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import pc from "picocolors";
 import ora from "ora";
 import { select } from "@inquirer/prompts";
@@ -53,6 +53,7 @@ interface SetupOptions {
   cli?: boolean;
   mcp?: boolean;
   stdio?: boolean;
+  from?: string;
 }
 
 function resolveTransport(options: SetupOptions): Transport {
@@ -94,6 +95,9 @@ export function registerSetupCommand(program: Command): void {
     .option("--api-key <key>", "Use API key authentication")
     .option("--oauth", "Use OAuth endpoint (IDE handles auth flow)")
     .option("--stdio", "Configure the MCP server as a local stdio process (default: HTTP)")
+    // Attribution source stamped into telemetry (e.g. the MCP sign-in nudge
+    // appends --from mcp-nudge). Hidden: not meant to be typed by hand.
+    .addOption(new Option("--from <source>").hideHelp())
     .action(async (options: SetupOptions) => {
       await setupCommand(options);
     });
@@ -440,7 +444,7 @@ async function setupMcp(agents: SetupAgent[], options: SetupOptions, scope: Scop
   }
   log.blank();
 
-  trackEvent("setup", { agents, scope, authMode: auth.mode });
+  trackEvent("setup", { agents, scope, authMode: auth.mode, from: options.from });
   trackEvent("install", { skills: ["/upstash/context7/context7-mcp"], ides: agents });
 }
 
@@ -526,7 +530,7 @@ async function setupCli(options: SetupOptions): Promise<void> {
   }
   log.blank();
 
-  trackEvent("setup", { mode: "cli" });
+  trackEvent("setup", { mode: "cli", from: options.from });
   trackEvent("install", { skills: ["/upstash/context7/find-docs"], ides: agents });
 }
 

--- a/packages/mcp/src/lib/auth/auth-prompt.ts
+++ b/packages/mcp/src/lib/auth/auth-prompt.ts
@@ -1,5 +1,26 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { ClientContext } from "../types.js";
+import { CONTEXT7_API_BASE_URL } from "../constants.js";
+
+type PromptOutcome = "shown" | "accepted" | "declined" | "dismissed";
+
+/**
+ * Fire-and-forget funnel telemetry: lets the backend measure how often the
+ * nudge actually renders ("shown") and what users pick, since the
+ * X-Context7-Auth-Prompt header alone can't distinguish rendered dialogs
+ * from silent no-ops. Mirrors the CLI's trackEvent, including its opt-out.
+ */
+function trackPromptOutcome(outcome: PromptOutcome, ctx: ClientContext): void {
+  if (process.env.CTX7_TELEMETRY_DISABLED) return;
+  fetch(`${CONTEXT7_API_BASE_URL}/v2/cli/events`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      event: "auth_prompt",
+      data: { outcome, ide: ctx.clientInfo?.ide, transport: ctx.transport },
+    }),
+  }).catch(() => {});
+}
 
 function clientFlagForCli(ide: string | undefined): string {
   if (!ide) return "";
@@ -18,6 +39,9 @@ function buildAuthCommand(
 ): string {
   const flag = clientFlagForCli(clientIde);
   const transportFlag = transport === "stdio" ? " --stdio" : "";
+  // TODO: append " --from mcp-nudge" for exact nudge→setup attribution once a
+  // ctx7 release with the --from flag has been published — emitting it earlier
+  // breaks users whose npx cache holds an older CLI (unknown-option error).
   return flag
     ? `npx ctx7 setup ${flag} --mcp${transportFlag} -y`
     : `npx ctx7 setup --mcp${transportFlag}`;
@@ -67,6 +91,7 @@ export function maybeElicitAuthSignIn(server: McpServer, ctx: ClientContext): vo
   if (ctx.apiKey || !ctx.shouldPrompt) return;
   if (!server.server.getClientCapabilities()?.elicitation) return;
 
+  trackPromptOutcome("shown", ctx);
   void server.server
     .elicitInput({
       message: buildElicitMessage(ctx.clientInfo?.ide, ctx.transport),
@@ -82,6 +107,15 @@ export function maybeElicitAuthSignIn(server: McpServer, ctx: ClientContext): vo
         },
         required: ["choice"],
       },
+    })
+    .then((result) => {
+      const outcome: PromptOutcome =
+        result.action === "accept"
+          ? result.content?.choice === CHOICE_STAY_ANON
+            ? "declined"
+            : "accepted"
+          : "dismissed";
+      trackPromptOutcome(outcome, ctx);
     })
     .catch(() => {
       // Client may not support elicitation despite the capability flag, or


### PR DESCRIPTION
## Summary

The MCP sign-in nudge (`maybeElicitAuthSignIn`) currently gives us no usage data: the backend knows it *asked* for a nudge (`X-Context7-Auth-Prompt` header), but not whether the dialog rendered, what the user picked, or whether they ran the setup command. This PR instruments the full funnel.

## Changes

**MCP server** — report nudge outcomes to the existing `/api/v2/cli/events` endpoint (same payload shape and `CTX7_TELEMETRY_DISABLED` opt-out as the CLI's `trackEvent`):
- `shown` — the dialog was actually sent to the client (distinguishes real renders from silent no-ops)
- `accepted` / `declined` / `dismissed` — the user's choice, which was previously discarded

**CLI** — hidden `--from <source>` flag on `ctx7 setup`, stamped into the `setup` telemetry event, so a setup run can be attributed to its source.

## The funnel

1. nudge triggered — backend header (already measurable)
2. nudge shown + choice — new MCP events
3. setup actually ran — `setup` event, attributable via `--from` once wired
4. signed in — `authMode` already in the setup event

## Deliberately not done yet

The nudge's suggested command does **not** include `--from mcp-nudge` yet — users with an older `ctx7` cached by npx would hit an unknown-option error. A TODO in `buildAuthCommand` marks flipping it on after a CLI release ships the flag. Until then, nudge→setup conversion can be approximated backend-side by correlating an `accepted` event with a `setup` event from the same IP within a few minutes.

## Verification

- `packages/mcp`: typecheck + 46/46 tests
- `packages/cli`: typecheck + 238/238 tests

https://claude.ai/code/session_01UdKfobSMnSFbdW6Lx78SSp