### PR TITLE
fix(cli): fall back to direct SKILL.md fetch when GitHub tree API is unreachable

### DIFF
--- a/.changeset/fix-codex-skill-install.md
+++ b/.changeset/fix-codex-skill-install.md
@@ -1,0 +1,5 @@
+---
+"ctx7": patch
+---
+
+Fix `ctx7 setup` skill install failing with "fetch failed" when the GitHub git tree API (`api.github.com`) is blocked or unreachable. Skill download now falls back to fetching the single `SKILL.md` directly from `raw.githubusercontent.com` — the URL the docs API already resolves — so setup succeeds in environments where only the docs/raw hosts are reachable.

--- a/packages/cli/src/__tests__/github.test.ts
+++ b/packages/cli/src/__tests__/github.test.ts
@@ -4,7 +4,14 @@ const execFileSync = vi.hoisted(() => vi.fn());
 
 vi.mock("node:child_process", () => ({ execFileSync }));
 
-import { listSkillsFromGitHub } from "../utils/github.js";
+import { downloadSkillFromGitHub, listSkillsFromGitHub } from "../utils/github.js";
+
+const SKILL = {
+  name: "context7-mcp",
+  description: "desc",
+  project: "/upstash/context7",
+  url: "https://raw.githubusercontent.com/upstash/context7/refs/heads/master/plugins/codex/context7/skills/context7-mcp/SKILL.md",
+};
 
 beforeEach(() => {
   // resetAllMocks, not clearAllMocks: the latter keeps implementations, so a
@@ -84,5 +91,76 @@ describe("GitHub authentication", () => {
     expect(result).toEqual({ status: "ok", skills: [] });
     const headers = vi.mocked(fetch).mock.calls[0][1]?.headers as Record<string, string>;
     expect(headers).not.toHaveProperty("Authorization");
+  });
+});
+
+describe("downloadSkillFromGitHub", () => {
+  test("downloads every file in the skill directory when the tree API works", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((url: string) => {
+        if (url.includes("api.github.com")) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                sha: "s",
+                truncated: false,
+                tree: [
+                  { type: "tree", path: "plugins/codex/context7/skills/context7-mcp" },
+                  {
+                    type: "blob",
+                    path: "plugins/codex/context7/skills/context7-mcp/SKILL.md",
+                  },
+                  {
+                    type: "blob",
+                    path: "plugins/codex/context7/skills/context7-mcp/references/guide.md",
+                  },
+                ],
+              }),
+          });
+        }
+        return Promise.resolve({ ok: true, text: () => Promise.resolve(`raw:${url}`) });
+      })
+    );
+
+    const result = await downloadSkillFromGitHub(SKILL);
+
+    expect(result.error).toBeUndefined();
+    expect(result.files.map((f) => f.path).sort()).toEqual(["SKILL.md", "references/guide.md"]);
+  });
+
+  test("falls back to the single SKILL.md when the tree API is unreachable (#2936)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((url: string) => {
+        if (url.includes("api.github.com")) {
+          return Promise.reject(new TypeError("fetch failed"));
+        }
+        return Promise.resolve({ ok: true, text: () => Promise.resolve("# Context7 skill") });
+      })
+    );
+
+    const result = await downloadSkillFromGitHub(SKILL);
+
+    expect(result.error).toBeUndefined();
+    expect(result.files).toEqual([{ path: "SKILL.md", content: "# Context7 skill" }]);
+  });
+
+  test("surfaces the tree error when both the tree API and the direct fetch fail", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((url: string) => {
+        if (url.includes("api.github.com")) {
+          return Promise.reject(new TypeError("fetch failed"));
+        }
+        return Promise.resolve({ ok: false, status: 404 });
+      })
+    );
+
+    const result = await downloadSkillFromGitHub(SKILL);
+
+    expect(result.files).toEqual([]);
+    expect(result.error).toBe("fetch failed");
   });
 });

--- a/packages/cli/src/utils/github.ts
+++ b/packages/cli/src/utils/github.ts
@@ -253,65 +253,102 @@ export async function getSkillFromGitHub(
   return { ...result, skill };
 }
 
+async function downloadSkillTree(
+  owner: string,
+  repo: string,
+  branch: string,
+  skillPath: string,
+  ghHeaders: Record<string, string>
+): Promise<{ files: SkillFile[]; error?: string }> {
+  const treeData = await fetchRepoTree(owner, repo, branch, ghHeaders);
+  if ("error" in treeData) {
+    const hint =
+      !ghHeaders["Authorization"] && /403|429|rate/.test(treeData.error)
+        ? " — run `gh auth login` or set the GITHUB_TOKEN env var to increase rate limits"
+        : "";
+    return { files: [], error: `GitHub API error: ${treeData.error}${hint}` };
+  }
+
+  const skillFiles = treeData.tree.filter(
+    (item) => item.type === "blob" && item.path.startsWith(skillPath + "/")
+  );
+
+  if (skillFiles.length === 0) {
+    return { files: [], error: `No files found in ${skillPath}` };
+  }
+
+  const files: SkillFile[] = [];
+  for (const item of skillFiles) {
+    const rawUrl = `${GITHUB_RAW}/${owner}/${repo}/${branch}/${item.path}`;
+    const fileResponse = await fetch(rawUrl, { headers: ghHeaders });
+
+    if (!fileResponse.ok) {
+      console.warn(`Failed to fetch ${item.path}: ${fileResponse.status}`);
+      continue;
+    }
+
+    const content = await fileResponse.text();
+    const relativePath = item.path.slice(skillPath.length + 1);
+
+    // Reject paths that attempt directory traversal
+    if (relativePath.includes("..")) {
+      console.warn(`Skipping file with unsafe path: ${item.path}`);
+      continue;
+    }
+
+    files.push({
+      path: relativePath,
+      content,
+    });
+  }
+
+  return { files };
+}
+
+async function downloadSingleSkillFile(
+  skillUrl: string,
+  ghHeaders: Record<string, string>
+): Promise<SkillFile[] | null> {
+  let fileName: string;
+  try {
+    const url = new URL(skillUrl);
+    const last = url.pathname.split("/").filter(Boolean).pop();
+    if (url.hostname !== "raw.githubusercontent.com" || !last || !last.includes(".")) {
+      return null;
+    }
+    fileName = last;
+  } catch {
+    return null;
+  }
+
+  const response = await fetch(skillUrl, { headers: ghHeaders });
+  if (!response.ok) return null;
+  const content = await response.text();
+  return [{ path: fileName, content }];
+}
+
 export async function downloadSkillFromGitHub(
   skill: Skill & { project: string }
 ): Promise<{ files: SkillFile[]; error?: string }> {
-  try {
-    const parsed = parseGitHubUrl(skill.url);
-
-    if (!parsed) {
-      return { files: [], error: `Invalid GitHub URL: ${skill.url}` };
-    }
-
-    const { owner, repo, branch, path: skillPath } = parsed;
-
-    const ghHeaders = getGitHubHeaders();
-
-    const treeData = await fetchRepoTree(owner, repo, branch, ghHeaders);
-    if ("error" in treeData) {
-      const hint =
-        !ghHeaders["Authorization"] && /403|429|rate/.test(treeData.error)
-          ? " — run `gh auth login` or set the GITHUB_TOKEN env var to increase rate limits"
-          : "";
-      return { files: [], error: `GitHub API error: ${treeData.error}${hint}` };
-    }
-
-    const skillFiles = treeData.tree.filter(
-      (item) => item.type === "blob" && item.path.startsWith(skillPath + "/")
-    );
-
-    if (skillFiles.length === 0) {
-      return { files: [], error: `No files found in ${skillPath}` };
-    }
-
-    const files: SkillFile[] = [];
-    for (const item of skillFiles) {
-      const rawUrl = `${GITHUB_RAW}/${owner}/${repo}/${branch}/${item.path}`;
-      const fileResponse = await fetch(rawUrl, { headers: ghHeaders });
-
-      if (!fileResponse.ok) {
-        console.warn(`Failed to fetch ${item.path}: ${fileResponse.status}`);
-        continue;
-      }
-
-      const content = await fileResponse.text();
-      const relativePath = item.path.slice(skillPath.length + 1);
-
-      // Reject paths that attempt directory traversal
-      if (relativePath.includes("..")) {
-        console.warn(`Skipping file with unsafe path: ${item.path}`);
-        continue;
-      }
-
-      files.push({
-        path: relativePath,
-        content,
-      });
-    }
-
-    return { files };
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    return { files: [], error: message };
+  const parsed = parseGitHubUrl(skill.url);
+  if (!parsed) {
+    return { files: [], error: `Invalid GitHub URL: ${skill.url}` };
   }
+
+  const { owner, repo, branch, path: skillPath } = parsed;
+  const ghHeaders = getGitHubHeaders();
+
+  let treeError: string | undefined;
+  try {
+    const result = await downloadSkillTree(owner, repo, branch, skillPath, ghHeaders);
+    if (result.files.length > 0) return { files: result.files };
+    treeError = result.error;
+  } catch (err) {
+    treeError = err instanceof Error ? err.message : String(err);
+  }
+
+  const single = await downloadSingleSkillFile(skill.url, ghHeaders).catch(() => null);
+  if (single) return { files: single };
+
+  return { files: [], error: treeError ?? `No files found in ${skillPath}` };
 }


### PR DESCRIPTION
Fixes the `ctx7 setup` "Skill failed / fetch failed" error (#2936) when the GitHub git tree API is blocked or unreachable.

- Skill download hits `api.github.com/.../git/trees` to enumerate a skill's files; when that host is unreachable (blocked/DNS/proxy) the fetch throws and the whole install fails — even though the docs host and `raw.githubusercontent.com` are reachable.
- Fall back to fetching the single `SKILL.md` directly from the raw URL the docs API already resolves, so single-file skills (e.g. `context7-mcp`, `find-docs`) install when only the raw host is reachable.
- The tree API stays the primary path, so multi-file skills still install completely when it works.
- Split `downloadSkillFromGitHub` into `downloadSkillTree` + `downloadSingleSkillFile` helpers.
- Add tests: tree-success (all files), tree-unreachable → direct fallback, and both-fail → surfaces the tree error.

Closes #2936