### PR TITLE
fix(mcp): bump undici to 7, require Node >=20.18.1

### DIFF
--- a/.changeset/fix-proxy-node26.md
+++ b/.changeset/fix-proxy-node26.md
@@ -1,0 +1,5 @@
+---
+"@upstash/context7-mcp": patch
+---
+
+Bump `undici` to 7 and require Node.js >= 20.18.1. On Node 26+ (internal undici 8) the bundled undici 6 `setGlobalDispatcher` wrote a global-dispatcher symbol the built-in `fetch` no longer reads, so `HTTPS_PROXY` and custom-CA settings were silently ignored and requests failed with `ENOTFOUND` behind CONNECT proxies. undici 7 writes both symbols, restoring proxy and CA support. Node 18 is no longer supported (EOL; undici 7 requires Node >= 20.18.1).

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -51,7 +51,7 @@ Check out our [project addition guide](https://context7.com/docs/adding-librarie
 
 ### Requirements
 
-- Node.js >= v18.0.0
+- Node.js >= v20.18.1
 - Cursor, Claude Code, VSCode, Devin Desktop or another MCP Client
 - Context7 API Key (Optional) for higher rate limits and private repositories (Get yours by creating an account at [context7.com/dashboard](https://context7.com/dashboard))
 
@@ -852,7 +852,7 @@ If you prefer to run the MCP server in a Docker container:
    <summary>Click to see Dockerfile content</summary>
 
    ```Dockerfile
-   FROM node:18-alpine
+   FROM node:20-alpine
 
    WORKDIR /app
 
@@ -1592,7 +1592,7 @@ Use the `--experimental-fetch` flag to bypass TLS-related problems:
 1. Try adding `@latest` to the package name
 2. Use `bunx` as an alternative to `npx`
 3. Consider using `deno` as another alternative
-4. Ensure you're using Node.js v18 or higher for native fetch support
+4. Ensure you're using Node.js v20 or higher for native fetch support
 
 </details>
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -51,12 +51,15 @@
     "commander": "^13.1.0",
     "express": "^5.1.0",
     "jose": "^6.2.3",
-    "undici": "^6.26.0",
+    "undici": "^7.0.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^25.0.3",
     "typescript": "^5.8.2",
     "vitest": "^4.1.9"
+  },
+  "engines": {
+    "node": ">=20.18.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,8 +128,8 @@ importers:
         specifier: ^6.2.3
         version: 6.2.3
       undici:
-        specifier: ^6.26.0
-        version: 6.26.0
+        specifier: ^7.0.0
+        version: 7.28.0
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -2961,9 +2961,9 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@6.26.0:
-    resolution: {integrity: sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==}
-    engines: {node: '>=18.17'}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+    engines: {node: '>=20.18.1'}
 
   undici@8.3.0:
     resolution: {integrity: sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==}
@@ -6056,7 +6056,7 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@6.26.0: {}
+  undici@7.28.0: {}
 
   undici@8.3.0: {}
 


### PR DESCRIPTION
Bumps the MCP server's `undici` to 7 so `HTTPS_PROXY` and `NODE_EXTRA_CA_CERTS` are honored on Node 26+.

- On Node 26+ (internal undici 8), `fetch` reads `Symbol.for('undici.globalDispatcher.2')`, which bundled undici 6 never wrote — so the ProxyAgent and custom-CA Agent in `api.ts` were silently ignored and requests failed with `ENOTFOUND` behind CONNECT proxies (#2935).
- undici 7 writes both the legacy and current dispatcher symbols, restoring proxy and CA support across Node 20–26.
- Requires Node >=20.18.1; drops Node 18 (EOL, and undici 7's floor). Adds `engines` and updates README Node references.
- Validated on the built dist through a resolver-less CONNECT proxy on Node 20/22/24/26; build, typecheck, lint, and 46 tests pass.

Fixes #2935