### PR TITLE
docs: add mcpindex screened badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![mcpindex](https://mcpindex.ai/api/v1/badge/io-github-upstash-context7)](https://mcpindex.ai/server/io-github-upstash-context7)
+
 ![Cover](https://github.com/upstash/context7/blob/master/public/cover.png?raw=true)
 
 [![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en/install-mcp?name=context7&config=eyJ1cmwiOiJodHRwczovL21jcC5jb250ZXh0Ny5jb20vbWNwIn0%3D)


### PR DESCRIPTION
Hey, Context7 is one of the MCP servers we see referenced constantly, so figured this was worth doing properly rather than assuming. mcpindex ran a semantic screen against your registered server and it came back clean (no injection/manipulation patterns found in the tool description); screened is advisory, not a security cert, just an honest description-level check. Added the badge to your README in case it's useful. No worries at all if you'd rather close this.