### PR TITLE
feat(cli): add ctx7 update to refresh installed skills and rules

### DIFF
--- a/.changeset/tidy-pans-shave.md
+++ b/.changeset/tidy-pans-shave.md
@@ -1,0 +1,10 @@
+---
+"ctx7": minor
+---
+
+Add `ctx7 update` to refresh installed skills and rules
+
+Skills and rules are now versioned by a checked-in content manifest and tracked
+in the CLI state file, so content changes reach existing installs without a CLI
+release. Locally modified files are detected and skipped unless `--force` is
+passed.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     paths:
       - "packages/**"
+      - "skills/**"
+      - "rules/**"
+      - "scripts/**"
       - "package.json"
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
@@ -51,6 +54,11 @@ jobs:
 
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Check content manifest is up to date
+        run: |
+          node scripts/generate-content-manifest.mjs
+          git diff --exit-code skills/manifest.json
 
       - name: Lint
         run: pnpm lint:check

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   ],
   "scripts": {
     "build": "pnpm -r run build",
+    "content:manifest": "node scripts/generate-content-manifest.mjs",
     "build:sdk": "pnpm --filter @upstash/context7-sdk build",
     "build:mcp": "pnpm --filter @upstash/context7-mcp build",
     "build:ai-sdk": "pnpm --filter @upstash/context7-tools-ai-sdk build",

--- a/packages/cli/src/__tests__/auto-update-safety.test.ts
+++ b/packages/cli/src/__tests__/auto-update-safety.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { mkdir, readFile, rm, writeFile } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+
+const downloadSkill = vi.fn();
+vi.mock("../utils/api.js", () => ({
+  downloadSkill: (...args: unknown[]) => downloadSkill(...args),
+  getBaseUrl: () => "https://context7.com",
+}));
+
+import { hashContent, hashFiles, resetManifestCache } from "../utils/content.js";
+import { resetSkillContentCache } from "../setup/skills.js";
+import { readCliState, writeCliState, type Install } from "../utils/cli-state.js";
+import { autoUpdateContent } from "../commands/update.js";
+
+const INSTALLED = "---\nname: find-docs\n---\n\nInstalled body.\n";
+const LEGACY = "---\nname: find-docs\n---\n\nLegacy download body.\n";
+
+let tempDir: string;
+let stateFile: string;
+let skillDir: string;
+
+/** Manifest advertises r7, but the raw file fetch never yields matching content. */
+function stubUnresolvableContent() {
+  const manifest = {
+    schema: 1,
+    skills: {
+      "find-docs": {
+        revision: 7,
+        minCliVersion: "0.0.0",
+        files: [{ path: "SKILL.md", hash: hashContent("something else entirely") }],
+      },
+    },
+    rules: {},
+  };
+
+  vi.stubGlobal(
+    "fetch",
+    vi.fn((url: string) => {
+      if (url.endsWith("skills/manifest.json")) {
+        return Promise.resolve({ ok: true, text: () => Promise.resolve(JSON.stringify(manifest)) });
+      }
+      if (url.endsWith("skills/find-docs/SKILL.md")) {
+        return Promise.resolve({ ok: true, text: () => Promise.resolve("stale mirror content\n") });
+      }
+      return Promise.resolve({ ok: false });
+    })
+  );
+}
+
+async function recordAt(revision: number, content: string): Promise<void> {
+  const install: Install = {
+    kind: "skill",
+    name: "find-docs",
+    agent: "claude",
+    scope: "global",
+    revision,
+    hash: hashFiles([{ path: "SKILL.md", content }]),
+    files: ["SKILL.md"],
+  };
+  await writeCliState({ installs: { [skillDir]: install } });
+}
+
+beforeEach(async () => {
+  tempDir = join(tmpdir(), `ctx7-safety-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  stateFile = join(tempDir, "cli-state.json");
+  skillDir = join(tempDir, "skills", "find-docs");
+  await mkdir(skillDir, { recursive: true });
+  await writeFile(join(skillDir, "SKILL.md"), INSTALLED);
+  vi.stubEnv("CTX7_STATE_FILE", stateFile);
+  resetManifestCache();
+  resetSkillContentCache();
+  downloadSkill.mockReset();
+  downloadSkill.mockResolvedValue({
+    skill: { name: "find-docs", description: "", url: "", project: "/upstash/context7" },
+    files: [{ path: "SKILL.md", content: LEGACY }],
+  });
+});
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+describe("auto-update never downgrades an install", () => {
+  test("leaves the record alone when manifest content cannot be resolved", async () => {
+    stubUnresolvableContent();
+    await recordAt(5, INSTALLED);
+
+    await autoUpdateContent({ actionName: "docs" });
+
+    const install = (await readCliState()).installs?.[skillDir];
+    expect(install?.revision).toBe(5);
+    expect(await readFile(join(skillDir, "SKILL.md"), "utf-8")).toBe(INSTALLED);
+  });
+
+  test("does not fall back to the legacy download path when refreshing", async () => {
+    stubUnresolvableContent();
+    await recordAt(5, INSTALLED);
+
+    await autoUpdateContent({ actionName: "docs" });
+
+    expect(downloadSkill).not.toHaveBeenCalled();
+  });
+
+  test("does not re-attempt on every invocation after a failure", async () => {
+    stubUnresolvableContent();
+    await recordAt(5, INSTALLED);
+
+    await autoUpdateContent({ actionName: "docs" });
+    const afterFirst = (global.fetch as ReturnType<typeof vi.fn>).mock.calls.length;
+
+    await autoUpdateContent({ actionName: "docs" });
+    await autoUpdateContent({ actionName: "docs" });
+
+    expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls.length).toBe(afterFirst);
+  });
+
+  test("resumes once the backoff window has passed", async () => {
+    stubUnresolvableContent();
+    await recordAt(5, INSTALLED);
+
+    const start = Date.now();
+    await autoUpdateContent({ actionName: "docs", now: start });
+    const afterFirst = (global.fetch as ReturnType<typeof vi.fn>).mock.calls.length;
+
+    await autoUpdateContent({ actionName: "docs", now: start + 2 * 60 * 60 * 1000 });
+
+    expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(
+      afterFirst
+    );
+  });
+});
+
+describe("corrupt state file", () => {
+  test("is quarantined so install tracking is not disabled forever", async () => {
+    await writeFile(stateFile, "{ this is not json");
+
+    expect(await readCliState()).toEqual({});
+    expect(await readFile(`${stateFile}.corrupt`, "utf-8")).toBe("{ this is not json");
+  });
+
+  test("leaves a usable state file after the next write", async () => {
+    await writeFile(stateFile, "}}broken");
+    await readCliState();
+    await writeCliState({ contentNotifiedAt: 42 });
+
+    expect(JSON.parse(await readFile(stateFile, "utf-8"))).toEqual({ contentNotifiedAt: 42 });
+  });
+});

--- a/packages/cli/src/__tests__/content-update.test.ts
+++ b/packages/cli/src/__tests__/content-update.test.ts
@@ -1,0 +1,210 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { mkdir, readFile, rm, writeFile } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+
+import {
+  getManifest,
+  hashContent,
+  hashFiles,
+  resetManifestCache,
+  resolveSkill,
+} from "../utils/content.js";
+import { readCliState, writeCliState, type Install } from "../utils/cli-state.js";
+import { scanOutdated } from "../commands/update.js";
+
+const SKILL_BODY = "---\nname: find-docs\n---\n\nFind docs.\n";
+
+let tempDir: string;
+let stateFile: string;
+let skillDir: string;
+
+function manifestWith(revision: number, minCliVersion = "0.0.0") {
+  return {
+    schema: 1,
+    skills: {
+      "find-docs": {
+        revision,
+        minCliVersion,
+        files: [{ path: "SKILL.md", hash: hashContent(SKILL_BODY) }],
+      },
+    },
+    rules: {},
+  };
+}
+
+function stubFetch(manifest: unknown, body = SKILL_BODY) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn((url: string) => {
+      if (url.endsWith("skills/manifest.json")) {
+        return Promise.resolve({ ok: true, text: () => Promise.resolve(JSON.stringify(manifest)) });
+      }
+      if (url.endsWith("skills/find-docs/SKILL.md")) {
+        return Promise.resolve({ ok: true, text: () => Promise.resolve(body) });
+      }
+      return Promise.resolve({ ok: false });
+    })
+  );
+}
+
+async function recordSkill(revision: number, hash: string): Promise<void> {
+  const install: Install = {
+    kind: "skill",
+    name: "find-docs",
+    agent: "claude",
+    scope: "global",
+    revision,
+    hash,
+    files: ["SKILL.md"],
+  };
+  await writeCliState({ installs: { [skillDir]: install } });
+}
+
+beforeEach(async () => {
+  tempDir = join(tmpdir(), `ctx7-content-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  stateFile = join(tempDir, "cli-state.json");
+  skillDir = join(tempDir, "skills", "find-docs");
+  await mkdir(skillDir, { recursive: true });
+  vi.stubEnv("CTX7_STATE_FILE", stateFile);
+  resetManifestCache();
+});
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+describe("getManifest", () => {
+  test("caches the manifest in the state file", async () => {
+    stubFetch(manifestWith(2));
+    await getManifest({ now: 1000 });
+
+    const state = await readCliState();
+    expect(state.contentManifest?.fetchedAt).toBe(1000);
+    expect(state.contentManifest?.manifest.skills["find-docs"].revision).toBe(2);
+  });
+
+  test("serves the cached manifest inside the TTL without fetching", async () => {
+    await writeCliState({ contentManifest: { fetchedAt: 1000, manifest: manifestWith(5) } });
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const manifest = await getManifest({ now: 1000 + 60_000 });
+    expect(manifest?.skills["find-docs"].revision).toBe(5);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("keeps the cached manifest when the network is unavailable", async () => {
+    await writeCliState({ contentManifest: { fetchedAt: 0, manifest: manifestWith(5) } });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.reject(new Error("offline")))
+    );
+
+    const manifest = await getManifest({ now: 10 * 24 * 60 * 60 * 1000 });
+    expect(manifest?.skills["find-docs"].revision).toBe(5);
+  });
+});
+
+describe("resolveSkill", () => {
+  test("returns files whose hash matches the manifest", async () => {
+    stubFetch(manifestWith(3));
+    const resolved = await resolveSkill("find-docs");
+
+    expect(resolved?.revision).toBe(3);
+    expect(resolved?.files).toEqual([{ path: "SKILL.md", content: SKILL_BODY }]);
+  });
+
+  test("rejects content that does not match the manifest hash", async () => {
+    stubFetch(manifestWith(3), "tampered content\n");
+    expect(await resolveSkill("find-docs")).toBeNull();
+  });
+
+  test("returns null for a skill missing from the manifest", async () => {
+    stubFetch(manifestWith(3));
+    expect(await resolveSkill("nonexistent")).toBeNull();
+  });
+});
+
+describe("scanOutdated", () => {
+  beforeEach(async () => {
+    await writeFile(join(skillDir, "SKILL.md"), SKILL_BODY);
+  });
+
+  test("reports nothing when the installed revision is current", async () => {
+    stubFetch(manifestWith(3));
+    await recordSkill(3, hashFiles([{ path: "SKILL.md", content: SKILL_BODY }]));
+
+    expect(await scanOutdated()).toEqual([]);
+  });
+
+  test("reports an install behind the manifest revision", async () => {
+    stubFetch(manifestWith(4));
+    await recordSkill(3, hashFiles([{ path: "SKILL.md", content: SKILL_BODY }]));
+
+    const outdated = await scanOutdated();
+    expect(outdated).toHaveLength(1);
+    expect(outdated[0].latest).toBe(4);
+    expect(outdated[0].edited).toBe(false);
+    expect(outdated[0].blockedBy).toBeUndefined();
+  });
+
+  test("flags locally modified installs", async () => {
+    stubFetch(manifestWith(4));
+    await recordSkill(3, hashFiles([{ path: "SKILL.md", content: SKILL_BODY }]));
+    await writeFile(join(skillDir, "SKILL.md"), "hand edited\n");
+
+    const outdated = await scanOutdated();
+    expect(outdated[0].edited).toBe(true);
+  });
+
+  test("blocks updates that require a newer CLI", async () => {
+    stubFetch(manifestWith(4, "999.0.0"));
+    await recordSkill(3, hashFiles([{ path: "SKILL.md", content: SKILL_BODY }]));
+
+    const outdated = await scanOutdated();
+    expect(outdated[0].blockedBy).toBe("999.0.0");
+  });
+
+  test("forgets installs whose files are gone", async () => {
+    stubFetch(manifestWith(4));
+    await recordSkill(3, hashFiles([{ path: "SKILL.md", content: SKILL_BODY }]));
+    await rm(join(skillDir, "SKILL.md"));
+
+    expect(await scanOutdated()).toEqual([]);
+    expect((await readCliState()).installs).toEqual({});
+  });
+
+  test("returns nothing when the manifest is unavailable", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve({ ok: false }))
+    );
+    await recordSkill(3, hashFiles([{ path: "SKILL.md", content: SKILL_BODY }]));
+
+    expect(await scanOutdated()).toEqual([]);
+  });
+});
+
+describe("installSkillFiles", () => {
+  test("removes files that are no longer part of the skill", async () => {
+    const { installSkillFiles } = await import("../utils/installer.js");
+    const root = join(tempDir, "skills");
+
+    await installSkillFiles("find-docs", [{ path: "SKILL.md", content: SKILL_BODY }], root, [
+      "references/old.md",
+    ]);
+
+    await mkdir(join(skillDir, "references"), { recursive: true });
+    await writeFile(join(skillDir, "references", "old.md"), "stale\n");
+
+    await installSkillFiles("find-docs", [{ path: "SKILL.md", content: SKILL_BODY }], root, [
+      "references/old.md",
+    ]);
+
+    await expect(readFile(join(skillDir, "references", "old.md"), "utf-8")).rejects.toThrow();
+    expect(await readFile(join(skillDir, "SKILL.md"), "utf-8")).toBe(SKILL_BODY);
+  });
+});

--- a/packages/cli/src/__tests__/content-update.test.ts
+++ b/packages/cli/src/__tests__/content-update.test.ts
@@ -11,6 +11,7 @@ import {
   resolveSkill,
 } from "../utils/content.js";
 import { readCliState, writeCliState, type Install } from "../utils/cli-state.js";
+import { resetSkillContentCache } from "../setup/skills.js";
 import { autoUpdateContent, scanOutdated } from "../commands/update.js";
 
 const SKILL_BODY = "---\nname: find-docs\n---\n\nFind docs.\n";
@@ -68,6 +69,7 @@ beforeEach(async () => {
   await mkdir(skillDir, { recursive: true });
   vi.stubEnv("CTX7_STATE_FILE", stateFile);
   resetManifestCache();
+  resetSkillContentCache();
 });
 
 afterEach(async () => {

--- a/packages/cli/src/__tests__/content-update.test.ts
+++ b/packages/cli/src/__tests__/content-update.test.ts
@@ -11,7 +11,7 @@ import {
   resolveSkill,
 } from "../utils/content.js";
 import { readCliState, writeCliState, type Install } from "../utils/cli-state.js";
-import { scanOutdated } from "../commands/update.js";
+import { autoUpdateContent, scanOutdated } from "../commands/update.js";
 
 const SKILL_BODY = "---\nname: find-docs\n---\n\nFind docs.\n";
 
@@ -185,6 +185,91 @@ describe("scanOutdated", () => {
     await recordSkill(3, hashFiles([{ path: "SKILL.md", content: SKILL_BODY }]));
 
     expect(await scanOutdated()).toEqual([]);
+  });
+});
+
+describe("autoUpdateContent", () => {
+  const NEW_BODY = "---\nname: find-docs\n---\n\nFind docs, revised.\n";
+
+  beforeEach(async () => {
+    await writeFile(join(skillDir, "SKILL.md"), SKILL_BODY);
+  });
+
+  function stubNewer() {
+    const manifest = {
+      schema: 1,
+      skills: {
+        "find-docs": {
+          revision: 4,
+          minCliVersion: "0.0.0",
+          files: [{ path: "SKILL.md", hash: hashContent(NEW_BODY) }],
+        },
+      },
+      rules: {},
+    };
+    stubFetch(manifest, NEW_BODY);
+  }
+
+  test("rewrites an unmodified skill in place and records the new revision", async () => {
+    stubNewer();
+    await recordSkill(3, hashFiles([{ path: "SKILL.md", content: SKILL_BODY }]));
+
+    const remaining = await autoUpdateContent({ actionName: "docs" });
+
+    expect(remaining).toEqual([]);
+    expect(await readFile(join(skillDir, "SKILL.md"), "utf-8")).toBe(NEW_BODY);
+    const install = (await readCliState()).installs?.[skillDir];
+    expect(install?.revision).toBe(4);
+    expect(install?.hash).toBe(hashFiles([{ path: "SKILL.md", content: NEW_BODY }]));
+  });
+
+  test("leaves locally modified skills alone and returns them", async () => {
+    stubNewer();
+    await recordSkill(3, hashFiles([{ path: "SKILL.md", content: SKILL_BODY }]));
+    await writeFile(join(skillDir, "SKILL.md"), "hand edited\n");
+
+    const remaining = await autoUpdateContent({ actionName: "docs" });
+
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].edited).toBe(true);
+    expect(await readFile(join(skillDir, "SKILL.md"), "utf-8")).toBe("hand edited\n");
+  });
+
+  test("does not run for commands that manage content themselves", async () => {
+    stubNewer();
+    await recordSkill(3, hashFiles([{ path: "SKILL.md", content: SKILL_BODY }]));
+
+    expect(await autoUpdateContent({ actionName: "setup" })).toEqual([]);
+    expect(await readFile(join(skillDir, "SKILL.md"), "utf-8")).toBe(SKILL_BODY);
+  });
+
+  test("honours CTX7_NO_AUTO_UPDATE", async () => {
+    stubNewer();
+    vi.stubEnv("CTX7_NO_AUTO_UPDATE", "1");
+    await recordSkill(3, hashFiles([{ path: "SKILL.md", content: SKILL_BODY }]));
+
+    expect(await autoUpdateContent({ actionName: "docs" })).toEqual([]);
+    expect(await readFile(join(skillDir, "SKILL.md"), "utf-8")).toBe(SKILL_BODY);
+  });
+
+  test("skips work while another process holds the lock", async () => {
+    stubNewer();
+    await recordSkill(3, hashFiles([{ path: "SKILL.md", content: SKILL_BODY }]));
+    await writeFile(`${stateFile}.lock`, "999");
+
+    const remaining = await autoUpdateContent({ actionName: "docs" });
+
+    expect(remaining).toHaveLength(1);
+    expect(await readFile(join(skillDir, "SKILL.md"), "utf-8")).toBe(SKILL_BODY);
+  });
+
+  test("drops the record when the install has been deleted", async () => {
+    stubNewer();
+    await recordSkill(3, hashFiles([{ path: "SKILL.md", content: SKILL_BODY }]));
+    await rm(skillDir, { recursive: true, force: true });
+
+    await expect(autoUpdateContent({ actionName: "docs" })).resolves.toEqual([]);
+    expect((await readCliState()).installs).toEqual({});
   });
 });
 

--- a/packages/cli/src/__tests__/setup.test.ts
+++ b/packages/cli/src/__tests__/setup.test.ts
@@ -6,20 +6,8 @@ import { tmpdir } from "os";
 const MOCK_MCP_RULE = "Use Context7 MCP to fetch docs.\n";
 const MOCK_CLI_RULE = "Use the `ctx7` CLI to fetch docs.\n";
 
-vi.stubGlobal(
-  "fetch",
-  vi.fn((url: string) => {
-    if (url.includes("context7-mcp.md")) {
-      return Promise.resolve({ ok: true, text: () => Promise.resolve(MOCK_MCP_RULE) });
-    }
-    if (url.includes("context7-cli.md")) {
-      return Promise.resolve({ ok: true, text: () => Promise.resolve(MOCK_CLI_RULE) });
-    }
-    return Promise.resolve({ ok: false });
-  })
-);
-
 import { getRuleContent } from "../setup/templates.js";
+import { hashContent, resetManifestCache } from "../utils/content.js";
 import {
   mergeServerEntry,
   removeServerEntry,
@@ -37,6 +25,47 @@ import {
 import { getAgent, ALL_AGENT_NAMES, type AuthOptions } from "../setup/agents.js";
 
 describe("getRuleContent", () => {
+  const manifest = {
+    schema: 1,
+    skills: {},
+    rules: {
+      "context7-mcp.md": { revision: 3, minCliVersion: "0.0.0", hash: hashContent(MOCK_MCP_RULE) },
+      "context7-cli.md": { revision: 3, minCliVersion: "0.0.0", hash: hashContent(MOCK_CLI_RULE) },
+    },
+  };
+
+  function stubRemote() {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((url: string) => {
+        if (url.endsWith("skills/manifest.json")) {
+          return Promise.resolve({
+            ok: true,
+            text: () => Promise.resolve(JSON.stringify(manifest)),
+          });
+        }
+        if (url.endsWith("rules/context7-mcp.md")) {
+          return Promise.resolve({ ok: true, text: () => Promise.resolve(MOCK_MCP_RULE) });
+        }
+        if (url.endsWith("rules/context7-cli.md")) {
+          return Promise.resolve({ ok: true, text: () => Promise.resolve(MOCK_CLI_RULE) });
+        }
+        return Promise.resolve({ ok: false });
+      })
+    );
+  }
+
+  beforeEach(async () => {
+    vi.stubEnv("CTX7_STATE_FILE", join(tmpdir(), `ctx7-rules-${Date.now()}.json`));
+    resetManifestCache();
+    stubRemote();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
   test("returns correct content per mode", async () => {
     expect(await getRuleContent("mcp", "claude")).toBe(MOCK_MCP_RULE);
     expect(await getRuleContent("cli", "claude")).toBe(MOCK_CLI_RULE);
@@ -53,25 +82,36 @@ describe("getRuleContent", () => {
     }
   });
 
-  test("returns fallback content when all fetch URLs fail", async () => {
+  test("falls back to built-in content when the manifest is unreachable", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(() => Promise.resolve({ ok: false }))
     );
+    resetManifestCache();
+
     const content = await getRuleContent("mcp", "claude");
     expect(content).toContain("Context7 MCP");
     expect(content.length).toBeGreaterThan(100);
+  });
 
+  test("ignores remote content whose hash does not match the manifest", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn((url: string) => {
-        if (url.includes("context7-mcp.md"))
-          return Promise.resolve({ ok: true, text: () => Promise.resolve(MOCK_MCP_RULE) });
-        if (url.includes("context7-cli.md"))
-          return Promise.resolve({ ok: true, text: () => Promise.resolve(MOCK_CLI_RULE) });
-        return Promise.resolve({ ok: false });
+        if (url.endsWith("skills/manifest.json")) {
+          return Promise.resolve({
+            ok: true,
+            text: () => Promise.resolve(JSON.stringify(manifest)),
+          });
+        }
+        return Promise.resolve({ ok: true, text: () => Promise.resolve("tampered\n") });
       })
     );
+    resetManifestCache();
+
+    const content = await getRuleContent("mcp", "claude");
+    expect(content).not.toContain("tampered");
+    expect(content).toContain("Context7 MCP");
   });
 });
 

--- a/packages/cli/src/commands/remove.ts
+++ b/packages/cli/src/commands/remove.ts
@@ -15,6 +15,7 @@ import {
 } from "../setup/mcp-writer.js";
 import { join } from "path";
 import { access, readFile, rm, writeFile } from "fs/promises";
+import { forgetInstall } from "../utils/cli-state.js";
 
 type Scope = "global" | "project";
 type UninstallMode = "mcp" | "cli";
@@ -362,6 +363,7 @@ async function uninstallRule(agentName: SetupAgent, scope: Scope): Promise<Clean
 
     try {
       await rm(targetPath);
+      await forgetInstall(targetPath);
       return { status: "removed", path: targetPath };
     } catch (err) {
       const error = err as NodeJS.ErrnoException;
@@ -392,6 +394,7 @@ async function uninstallRule(agentName: SetupAgent, scope: Scope): Promise<Clean
       await writeFile(filePath, `${updated}\n`, "utf-8");
     }
 
+    await forgetInstall(filePath);
     return { status: "removed", path: filePath };
   } catch (err) {
     const error = err as NodeJS.ErrnoException;
@@ -417,6 +420,7 @@ async function uninstallSkills(
     const skillPath = join(skillsDir, skillName);
     try {
       await rm(skillPath, { recursive: true });
+      await forgetInstall(skillPath);
       results.push({ name: skillName, status: "removed", path: skillPath });
     } catch (err) {
       const error = err as NodeJS.ErrnoException;

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -2,15 +2,13 @@ import { Command } from "commander";
 import pc from "picocolors";
 import ora from "ora";
 import { select } from "@inquirer/prompts";
-import { mkdir, readFile, writeFile } from "fs/promises";
 import { dirname, join } from "path";
 import { randomBytes } from "crypto";
 
 import { log } from "../utils/logger.js";
 import { checkboxWithHover } from "../utils/prompts.js";
 import { trackEvent } from "../utils/tracking.js";
-import { getBaseUrl, downloadSkill } from "../utils/api.js";
-import { installSkillFiles } from "../utils/installer.js";
+import { getBaseUrl } from "../utils/api.js";
 import { performLogin } from "./auth.js";
 import { saveTokens, getValidAccessToken } from "../utils/auth.js";
 import {
@@ -23,7 +21,9 @@ import {
   getAgent,
   detectAgents,
 } from "../setup/agents.js";
-import { customizeSkillFilesForAgent, getRuleContent } from "../setup/templates.js";
+import { getRule } from "../setup/templates.js";
+import { installRule } from "../setup/rules.js";
+import { getSkillDir, installSkill, loadSkillContent } from "../setup/skills.js";
 import {
   readJsonConfig,
   mergeServerEntry,
@@ -225,49 +225,13 @@ async function resolveAgents(options: SetupOptions, scope: Scope): Promise<Setup
   return selected;
 }
 
-/** Install a rule for an agent, handling both "file" (standalone) and "append" (AGENTS.md) types. */
-async function installRule(
+async function setupRule(
   agentName: SetupAgent,
   mode: SetupMode,
   scope: Scope
 ): Promise<{ status: string; path: string }> {
-  const agent = getAgent(agentName);
-  const rule = agent.rule;
-  const content = await getRuleContent(mode, agentName);
-
-  if (rule.kind === "file") {
-    const ruleDir =
-      scope === "global" ? rule.dir("global") : join(process.cwd(), rule.dir("project"));
-    const rulePath = join(ruleDir, rule.filename);
-    await mkdir(dirname(rulePath), { recursive: true });
-    await writeFile(rulePath, content, "utf-8");
-    return { status: "installed", path: rulePath };
-  }
-
-  const filePath =
-    scope === "global" ? rule.file("global") : join(process.cwd(), rule.file("project"));
-  const escapedMarker = rule.sectionMarker.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const section = `${rule.sectionMarker}\n${content}${rule.sectionMarker}`;
-
-  let existing = "";
-  try {
-    existing = await readFile(filePath, "utf-8");
-  } catch {
-    // File doesn't exist yet
-  }
-
-  if (existing.includes(rule.sectionMarker)) {
-    const regex = new RegExp(`${escapedMarker}\\n[\\s\\S]*?${escapedMarker}`);
-    const updated = existing.replace(regex, section);
-    await writeFile(filePath, updated, "utf-8");
-    return { status: "updated", path: filePath };
-  }
-
-  const separator =
-    existing.length > 0 && !existing.endsWith("\n") ? "\n\n" : existing.length > 0 ? "\n" : "";
-  await mkdir(dirname(filePath), { recursive: true });
-  await writeFile(filePath, existing + separator + section + "\n", "utf-8");
-  return { status: "installed", path: filePath };
+  const { content, revision } = await getRule(mode, agentName);
+  return installRule(agentName, mode, scope, content, revision);
 }
 
 /**
@@ -347,7 +311,7 @@ async function setupAgent(
   let ruleStatus: string;
   let rulePath: string;
   try {
-    const result = await installRule(agentName, "mcp", scope);
+    const result = await setupRule(agentName, "mcp", scope);
     ruleStatus = result.status;
     rulePath = result.path;
   } catch (err) {
@@ -355,19 +319,11 @@ async function setupAgent(
     rulePath = "";
   }
 
-  const skillDir =
-    scope === "global"
-      ? agent.skill.dir("global")
-      : join(process.cwd(), agent.skill.dir("project"));
-  const skillPath = join(skillDir, agent.skill.name, "SKILL.md");
+  const skillPath = join(getSkillDir(agentName, scope, agent.skill.name), "SKILL.md");
 
   let skillStatus: string;
   try {
-    const downloadData = await downloadSkill("/upstash/context7", agent.skill.name);
-    if (downloadData.error || downloadData.files.length === 0) {
-      throw new Error(downloadData.error || "no files");
-    }
-    await installSkillFiles(agent.skill.name, downloadData.files, skillDir);
+    await installSkill(agentName, scope, agent.skill.name);
     skillStatus = "installed";
   } catch (err) {
     skillStatus = `failed: ${err instanceof Error ? err.message : String(err)}`;
@@ -446,29 +402,22 @@ async function setupMcp(agents: SetupAgent[], options: SetupOptions, scope: Scop
 
 async function setupCliAgent(
   agentName: SetupAgent,
-  scope: Scope,
-  downloadData: { files: Array<{ path: string; content: string }> }
+  scope: Scope
 ): Promise<{ skillPath: string; skillStatus: string; rulePath: string; ruleStatus: string }> {
-  const agent = getAgent(agentName);
+  const skillPath = getSkillDir(agentName, scope, "find-docs");
 
-  const skillDir =
-    scope === "global"
-      ? agent.skill.dir("global")
-      : join(process.cwd(), agent.skill.dir("project"));
   let skillStatus: string;
   try {
-    const files = customizeSkillFilesForAgent(agentName, "find-docs", downloadData.files);
-    await installSkillFiles("find-docs", files, skillDir);
+    await installSkill(agentName, scope, "find-docs");
     skillStatus = "installed";
   } catch (err) {
     skillStatus = `failed: ${err instanceof Error ? err.message : String(err)}`;
   }
-  const skillPath = join(skillDir, "find-docs");
 
   let ruleStatus: string;
   let rulePath: string;
   try {
-    const result = await installRule(agentName, "cli", scope);
+    const result = await setupRule(agentName, "cli", scope);
     ruleStatus = result.status;
     rulePath = result.path;
   } catch (err) {
@@ -489,9 +438,12 @@ async function setupCli(options: SetupOptions): Promise<void> {
   log.blank();
   const spinner = ora("Downloading find-docs skill...").start();
 
-  const downloadData = await downloadSkill("/upstash/context7", "find-docs");
-  if (downloadData.error || downloadData.files.length === 0) {
-    spinner.fail(`Failed to download find-docs skill: ${downloadData.error || "no files"}`);
+  try {
+    await loadSkillContent("find-docs");
+  } catch (err) {
+    spinner.fail(
+      `Failed to download find-docs skill: ${err instanceof Error ? err.message : String(err)}`
+    );
     return;
   }
 
@@ -509,7 +461,7 @@ async function setupCli(options: SetupOptions): Promise<void> {
   for (const agentName of agents) {
     const agentDef = getAgent(agentName);
     installSpinner.text = `Setting up ${agentDef.displayName}...`;
-    const r = await setupCliAgent(agentName, scope, downloadData);
+    const r = await setupCliAgent(agentName, scope);
     results.push({ agent: agentDef.displayName, ...r });
   }
 

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import { dirname } from "path";
+import { mkdir, rm, stat, writeFile } from "fs/promises";
 import ora from "ora";
 import pc from "picocolors";
 import { confirm } from "@inquirer/prompts";
@@ -9,6 +10,7 @@ import { log } from "../utils/logger.js";
 import { trackEvent } from "../utils/tracking.js";
 import {
   forgetInstall,
+  getStatePath,
   readCliState,
   updateCliState,
   type Install,
@@ -68,6 +70,8 @@ export async function scanOutdated(): Promise<Outdated[]> {
       install.kind === "skill" ? manifest.skills?.[install.name] : manifest.rules?.[install.name];
     if (!entry) continue;
 
+    if (entry.revision <= install.revision) continue;
+
     const current =
       install.kind === "skill"
         ? await readSkillHash(path, install)
@@ -79,8 +83,6 @@ export async function scanOutdated(): Promise<Outdated[]> {
       await forgetInstall(path);
       continue;
     }
-
-    if (entry.revision <= install.revision) continue;
 
     outdated.push({
       path,
@@ -210,34 +212,105 @@ async function updateCommand(options: UpdateOptions): Promise<void> {
   trackEvent("content-update", { count: ready.length - failures.length });
 }
 
+const SKIP_AUTO_UPDATE = ["update", "setup", "remove", "uninstall", "upgrade"];
+const LOCK_STALE_MS = 60_000;
+
+async function acquireLock(path: string): Promise<boolean> {
+  try {
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, String(process.pid), { flag: "wx" });
+    return true;
+  } catch {
+    try {
+      const info = await stat(path);
+      if (Date.now() - info.mtimeMs < LOCK_STALE_MS) return false;
+      await writeFile(path, String(process.pid));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+/**
+ * Refreshes out-of-date skills and rules during ordinary commands so agent-driven
+ * runs (`npx ctx7@latest docs ...`, always non-TTY) stay current without anyone
+ * running `ctx7 update`. Silent, best-effort, and never fails the host command.
+ */
+export async function autoUpdateContent(
+  options: { actionName?: string } = {}
+): Promise<Outdated[]> {
+  if (SKIP_AUTO_UPDATE.includes(options.actionName ?? "")) return [];
+  if (process.env.CTX7_NO_AUTO_UPDATE) return [];
+
+  let outdated: Outdated[];
+  try {
+    outdated = await scanOutdated();
+  } catch {
+    return [];
+  }
+
+  const ready = outdated.filter((target) => !target.blockedBy && !target.edited);
+  if (ready.length === 0) return outdated;
+
+  const lockPath = `${getStatePath()}.lock`;
+  if (!(await acquireLock(lockPath))) return outdated;
+
+  const applied = new Set<string>();
+  try {
+    for (const target of ready) {
+      try {
+        await apply(target);
+        applied.add(target.path);
+      } catch {
+        continue;
+      }
+    }
+  } finally {
+    await rm(lockPath, { force: true }).catch(() => {});
+  }
+
+  return outdated.filter((target) => !applied.has(target.path));
+}
+
+/**
+ * Reports only what auto-update could not fix on its own: locally modified files
+ * and revisions gated behind a newer CLI. Both need a human decision.
+ */
 export async function maybeShowContentUpdateNotice(
-  options: { actionName?: string; argv?: string[]; isInteractive?: boolean; now?: number } = {}
+  remaining: Outdated[],
+  options: { argv?: string[]; isInteractive?: boolean; now?: number } = {}
 ): Promise<void> {
-  const actionName = options.actionName ?? "";
   const argv = options.argv ?? process.argv;
   const isInteractive =
     options.isInteractive ?? Boolean(process.stdout.isTTY && process.stdin.isTTY);
 
-  if (
-    !isInteractive ||
-    argv.includes("--json") ||
-    ["update", "setup", "remove", "uninstall", "upgrade"].includes(actionName)
-  ) {
-    return;
-  }
+  if (!isInteractive || argv.includes("--json") || remaining.length === 0) return;
 
   const now = options.now ?? Date.now();
   const state = await readCliState();
   if (state.contentNotifiedAt && now - state.contentNotifiedAt < NOTICE_COOLDOWN_MS) return;
 
-  const actionable = (await scanOutdated()).filter((target) => !target.blockedBy);
-  if (actionable.length === 0) return;
+  const edited = remaining.filter((target) => !target.blockedBy && target.edited);
+  const blocked = remaining.filter((target) => target.blockedBy);
+
+  const lines: string[] = [];
+  if (edited.length > 0) {
+    lines.push(
+      `${pc.white(pc.bold("Skill update available:"))} ${pc.green(pc.bold(String(edited.length)))} ${pc.white("locally modified item(s)")}`,
+      `${pc.white("Run")} ${pc.yellow(pc.bold("ctx7 update --force"))} ${pc.white("to overwrite them")}`
+    );
+  }
+  if (blocked.length > 0) {
+    lines.push(
+      `${pc.white("Newer skill content needs")} ${pc.green(pc.bold(`ctx7 >= ${blocked[0].blockedBy}`))}`,
+      `${pc.white("Run")} ${pc.yellow(pc.bold("ctx7 upgrade"))} ${pc.white("to unlock it")}`
+    );
+  }
+  if (lines.length === 0) return;
 
   log.blank();
-  log.box([
-    `${pc.white(pc.bold("Skill update available:"))} ${pc.green(pc.bold(String(actionable.length)))} ${pc.white("item(s) out of date")}`,
-    `${pc.white("Run")} ${pc.yellow(pc.bold("ctx7 update"))} ${pc.white("to refresh them")}`,
-  ]);
+  log.box(lines);
   log.blank();
 
   await updateCliState({ contentNotifiedAt: now });

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -1,0 +1,244 @@
+import { Command } from "commander";
+import { dirname } from "path";
+import ora from "ora";
+import pc from "picocolors";
+import { confirm } from "@inquirer/prompts";
+
+import { VERSION } from "../constants.js";
+import { log } from "../utils/logger.js";
+import { trackEvent } from "../utils/tracking.js";
+import {
+  forgetInstall,
+  readCliState,
+  updateCliState,
+  type Install,
+  type SkillInstall,
+} from "../utils/cli-state.js";
+import { getManifest, hashContent, hashFiles, supportsEntry } from "../utils/content.js";
+import { readSkillFiles } from "../utils/installer.js";
+import { installSkill } from "../setup/skills.js";
+import { installRule, readRuleBody } from "../setup/rules.js";
+import { getRule } from "../setup/templates.js";
+import { SETUP_AGENT_NAMES, type SetupAgent } from "../setup/agents.js";
+
+const NOTICE_COOLDOWN_MS = 24 * 60 * 60 * 1000;
+
+interface UpdateOptions {
+  yes?: boolean;
+  check?: boolean;
+  force?: boolean;
+  json?: boolean;
+}
+
+interface Outdated {
+  path: string;
+  install: Install;
+  latest: number;
+  edited: boolean;
+  blockedBy?: string;
+}
+
+export function registerUpdateCommand(program: Command): void {
+  program
+    .command("update")
+    .description("Update installed Context7 skills and rules to the latest content")
+    .option("-y, --yes", "Apply updates without prompting")
+    .option("--check", "Only report what is outdated")
+    .option("--force", "Overwrite locally modified skills and rules")
+    .option("--json", "Output as JSON")
+    .action(async (options: UpdateOptions) => {
+      await updateCommand(options);
+    });
+}
+
+async function readSkillHash(path: string, install: SkillInstall): Promise<string | null> {
+  const files = await readSkillFiles(path, install.files);
+  return files ? hashFiles(files) : null;
+}
+
+export async function scanOutdated(): Promise<Outdated[]> {
+  const manifest = await getManifest();
+  if (!manifest) return [];
+
+  const installs = (await readCliState()).installs ?? {};
+  const outdated: Outdated[] = [];
+
+  for (const [path, install] of Object.entries(installs)) {
+    const entry =
+      install.kind === "skill" ? manifest.skills?.[install.name] : manifest.rules?.[install.name];
+    if (!entry) continue;
+
+    const current =
+      install.kind === "skill"
+        ? await readSkillHash(path, install)
+        : await readRuleBody(install.agent as SetupAgent, path).then((body) =>
+            body === null ? null : hashContent(body)
+          );
+
+    if (current === null) {
+      await forgetInstall(path);
+      continue;
+    }
+
+    if (entry.revision <= install.revision) continue;
+
+    outdated.push({
+      path,
+      install,
+      latest: entry.revision,
+      edited: current !== install.hash,
+      blockedBy: supportsEntry(entry) ? undefined : entry.minCliVersion,
+    });
+  }
+
+  return outdated;
+}
+
+async function apply(target: Outdated): Promise<void> {
+  const agent = target.install.agent as SetupAgent;
+
+  if (target.install.kind === "skill") {
+    await installSkill(agent, target.install.scope, target.install.name, dirname(target.path));
+    return;
+  }
+
+  const { content, revision } = await getRule(target.install.mode, agent);
+  await installRule(
+    agent,
+    target.install.mode,
+    target.install.scope,
+    content,
+    revision,
+    target.path
+  );
+}
+
+function label(target: Outdated): string {
+  const agent = SETUP_AGENT_NAMES[target.install.agent as SetupAgent] ?? target.install.agent;
+  const kind = target.install.kind === "skill" ? "Skill" : "Rule";
+  return `${kind} ${pc.bold(target.install.name)} ${pc.dim(`(${agent}, ${target.install.scope})`)}`;
+}
+
+async function updateCommand(options: UpdateOptions): Promise<void> {
+  trackEvent("command", { name: "update" });
+
+  const outdated = await scanOutdated();
+
+  if (options.json) {
+    log.plain(
+      JSON.stringify(
+        outdated.map((target) => ({
+          path: target.path,
+          kind: target.install.kind,
+          name: target.install.name,
+          agent: target.install.agent,
+          scope: target.install.scope,
+          installedRevision: target.install.revision,
+          latestRevision: target.latest,
+          edited: target.edited,
+          blockedBy: target.blockedBy ?? null,
+        })),
+        null,
+        2
+      )
+    );
+    return;
+  }
+
+  if (outdated.length === 0) {
+    log.success("Context7 skills and rules are up to date.");
+    return;
+  }
+
+  const blocked = outdated.filter((target) => target.blockedBy);
+  const edited = outdated.filter((target) => !target.blockedBy && target.edited && !options.force);
+  const ready = outdated.filter((target) => !target.blockedBy && (options.force || !target.edited));
+
+  log.blank();
+  for (const target of ready) {
+    log.plain(
+      `  ${pc.green("+")} ${label(target)} ${pc.dim(`r${target.install.revision} ->`)} ${pc.green(`r${target.latest}`)}`
+    );
+    log.plain(`    ${pc.dim(target.path)}`);
+  }
+  for (const target of edited) {
+    log.plain(`  ${pc.yellow("~")} ${label(target)} ${pc.yellow("modified locally, skipping")}`);
+    log.plain(`    ${pc.dim(target.path)}`);
+  }
+  for (const target of blocked) {
+    log.plain(`  ${pc.dim("~")} ${label(target)} ${pc.dim(`needs ctx7 >= ${target.blockedBy}`)}`);
+  }
+  log.blank();
+
+  if (edited.length > 0) {
+    log.dim(`Run with ${pc.cyan("--force")} to overwrite locally modified files.`);
+  }
+  if (blocked.length > 0) {
+    log.dim(`You are on v${VERSION}. Run ${pc.cyan("ctx7 upgrade")} to unlock newer content.`);
+  }
+
+  if (ready.length === 0 || options.check) return;
+
+  let shouldRun = options.yes ?? false;
+  if (!shouldRun && process.stdout.isTTY) {
+    shouldRun = await confirm({ message: `Update ${ready.length} item(s)?`, default: true });
+  }
+  if (!shouldRun) {
+    log.dim("Update skipped.");
+    return;
+  }
+
+  log.blank();
+  const spinner = ora("Updating...").start();
+  const failures: string[] = [];
+
+  for (const target of ready) {
+    spinner.text = `Updating ${target.install.name}...`;
+    try {
+      await apply(target);
+    } catch (err) {
+      failures.push(`${target.install.name}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  spinner.succeed(`Updated ${ready.length - failures.length} of ${ready.length} item(s)`);
+
+  for (const failure of failures) {
+    log.error(failure);
+  }
+
+  trackEvent("content-update", { count: ready.length - failures.length });
+}
+
+export async function maybeShowContentUpdateNotice(
+  options: { actionName?: string; argv?: string[]; isInteractive?: boolean; now?: number } = {}
+): Promise<void> {
+  const actionName = options.actionName ?? "";
+  const argv = options.argv ?? process.argv;
+  const isInteractive =
+    options.isInteractive ?? Boolean(process.stdout.isTTY && process.stdin.isTTY);
+
+  if (
+    !isInteractive ||
+    argv.includes("--json") ||
+    ["update", "setup", "remove", "uninstall", "upgrade"].includes(actionName)
+  ) {
+    return;
+  }
+
+  const now = options.now ?? Date.now();
+  const state = await readCliState();
+  if (state.contentNotifiedAt && now - state.contentNotifiedAt < NOTICE_COOLDOWN_MS) return;
+
+  const actionable = (await scanOutdated()).filter((target) => !target.blockedBy);
+  if (actionable.length === 0) return;
+
+  log.blank();
+  log.box([
+    `${pc.white(pc.bold("Skill update available:"))} ${pc.green(pc.bold(String(actionable.length)))} ${pc.white("item(s) out of date")}`,
+    `${pc.white("Run")} ${pc.yellow(pc.bold("ctx7 update"))} ${pc.white("to refresh them")}`,
+  ]);
+  log.blank();
+
+  await updateCliState({ contentNotifiedAt: now });
+}

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
 import { dirname } from "path";
-import { mkdir, rm, stat, writeFile } from "fs/promises";
+
 import ora from "ora";
 import pc from "picocolors";
 import { confirm } from "@inquirer/prompts";
@@ -9,18 +9,26 @@ import { VERSION } from "../constants.js";
 import { log } from "../utils/logger.js";
 import { trackEvent } from "../utils/tracking.js";
 import {
+  acquireStateLock,
   forgetInstall,
+  releaseStateLock,
   getStatePath,
   readCliState,
   updateCliState,
   type Install,
   type SkillInstall,
 } from "../utils/cli-state.js";
-import { getManifest, hashContent, hashFiles, supportsEntry } from "../utils/content.js";
+import {
+  getManifest,
+  hashContent,
+  hashFiles,
+  resolveSkill,
+  supportsEntry,
+} from "../utils/content.js";
 import { readSkillFiles } from "../utils/installer.js";
-import { installSkill } from "../setup/skills.js";
+import { writeSkill } from "../setup/skills.js";
 import { installRule, readRuleBody } from "../setup/rules.js";
-import { getRule } from "../setup/templates.js";
+import { getManifestRule } from "../setup/templates.js";
 import { SETUP_AGENT_NAMES, type SetupAgent } from "../setup/agents.js";
 
 const NOTICE_COOLDOWN_MS = 24 * 60 * 60 * 1000;
@@ -96,21 +104,39 @@ export async function scanOutdated(): Promise<Outdated[]> {
   return outdated;
 }
 
+/**
+ * Refreshes strictly from the manifest. The legacy download path is deliberately
+ * not used here: it yields revision 0, which would downgrade the record and make
+ * the same install look outdated on every subsequent command.
+ */
 async function apply(target: Outdated): Promise<void> {
   const agent = target.install.agent as SetupAgent;
 
   if (target.install.kind === "skill") {
-    await installSkill(agent, target.install.scope, target.install.name, dirname(target.path));
+    const resolved = await resolveSkill(target.install.name);
+    if (!resolved || resolved.revision < target.latest) {
+      throw new Error(`could not resolve ${target.install.name} at revision ${target.latest}`);
+    }
+    await writeSkill(
+      agent,
+      target.install.scope,
+      target.install.name,
+      dirname(target.path),
+      resolved
+    );
     return;
   }
 
-  const { content, revision } = await getRule(target.install.mode, agent);
+  const resolved = await getManifestRule(target.install.mode, agent);
+  if (!resolved || resolved.revision < target.latest) {
+    throw new Error(`could not resolve ${target.install.name} at revision ${target.latest}`);
+  }
   await installRule(
     agent,
     target.install.mode,
     target.install.scope,
-    content,
-    revision,
+    resolved.content,
+    resolved.revision,
     target.path
   );
 }
@@ -213,24 +239,8 @@ async function updateCommand(options: UpdateOptions): Promise<void> {
 }
 
 const SKIP_AUTO_UPDATE = ["update", "setup", "remove", "uninstall", "upgrade"];
-const LOCK_STALE_MS = 60_000;
 
-async function acquireLock(path: string): Promise<boolean> {
-  try {
-    await mkdir(dirname(path), { recursive: true });
-    await writeFile(path, String(process.pid), { flag: "wx" });
-    return true;
-  } catch {
-    try {
-      const info = await stat(path);
-      if (Date.now() - info.mtimeMs < LOCK_STALE_MS) return false;
-      await writeFile(path, String(process.pid));
-      return true;
-    } catch {
-      return false;
-    }
-  }
-}
+const RETRY_BACKOFF_MS = 60 * 60 * 1000;
 
 /**
  * Refreshes out-of-date skills and rules during ordinary commands so agent-driven
@@ -238,10 +248,13 @@ async function acquireLock(path: string): Promise<boolean> {
  * running `ctx7 update`. Silent, best-effort, and never fails the host command.
  */
 export async function autoUpdateContent(
-  options: { actionName?: string } = {}
+  options: { actionName?: string; now?: number } = {}
 ): Promise<Outdated[]> {
   if (SKIP_AUTO_UPDATE.includes(options.actionName ?? "")) return [];
   if (process.env.CTX7_NO_AUTO_UPDATE) return [];
+
+  const now = options.now ?? Date.now();
+  if (((await readCliState()).contentRetryAfter ?? 0) > now) return [];
 
   let outdated: Outdated[];
   try {
@@ -253,8 +266,9 @@ export async function autoUpdateContent(
   const ready = outdated.filter((target) => !target.blockedBy && !target.edited);
   if (ready.length === 0) return outdated;
 
-  const lockPath = `${getStatePath()}.lock`;
-  if (!(await acquireLock(lockPath))) return outdated;
+  // Never queue behind another process mid-apply; it is doing the same work.
+  const statePath = getStatePath();
+  if (!(await acquireStateLock(statePath, 0))) return outdated;
 
   const applied = new Set<string>();
   try {
@@ -267,7 +281,11 @@ export async function autoUpdateContent(
       }
     }
   } finally {
-    await rm(lockPath, { force: true }).catch(() => {});
+    await releaseStateLock(statePath);
+  }
+
+  if (applied.size < ready.length) {
+    await updateCliState({ contentRetryAfter: now + RETRY_BACKOFF_MS });
   }
 
   return outdated.filter((target) => !applied.has(target.path));

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,7 +7,11 @@ import { registerSetupCommand } from "./commands/setup.js";
 import { registerRemoveCommand } from "./commands/remove.js";
 import { registerDocsCommands } from "./commands/docs.js";
 import { maybeShowUpgradeNotice, registerUpgradeCommand } from "./commands/upgrade.js";
-import { maybeShowContentUpdateNotice, registerUpdateCommand } from "./commands/update.js";
+import {
+  autoUpdateContent,
+  maybeShowContentUpdateNotice,
+  registerUpdateCommand,
+} from "./commands/update.js";
 import { setBaseUrl } from "./utils/api.js";
 import { VERSION } from "./constants.js";
 
@@ -35,10 +39,8 @@ program
       actionName: actionCommand.name(),
       argv: process.argv,
     });
-    await maybeShowContentUpdateNotice({
-      actionName: actionCommand.name(),
-      argv: process.argv,
-    });
+    const remaining = await autoUpdateContent({ actionName: actionCommand.name() });
+    await maybeShowContentUpdateNotice(remaining, { argv: process.argv });
   })
   .addHelpText(
     "after",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,6 +7,7 @@ import { registerSetupCommand } from "./commands/setup.js";
 import { registerRemoveCommand } from "./commands/remove.js";
 import { registerDocsCommands } from "./commands/docs.js";
 import { maybeShowUpgradeNotice, registerUpgradeCommand } from "./commands/upgrade.js";
+import { maybeShowContentUpdateNotice, registerUpdateCommand } from "./commands/update.js";
 import { setBaseUrl } from "./utils/api.js";
 import { VERSION } from "./constants.js";
 
@@ -34,6 +35,10 @@ program
       actionName: actionCommand.name(),
       argv: process.argv,
     });
+    await maybeShowContentUpdateNotice({
+      actionName: actionCommand.name(),
+      argv: process.argv,
+    });
   })
   .addHelpText(
     "after",
@@ -43,6 +48,9 @@ Examples:
   ${brand.primary("npx ctx7 setup")}
   ${brand.primary("npx ctx7 setup --mcp")}
   ${brand.primary("npx ctx7 setup --cli")}
+
+  ${brand.dim("# Refresh installed skills and rules")}
+  ${brand.primary("npx ctx7 update")}
 
   ${brand.dim("# Remove Context7 setup")}
   ${brand.primary("npx ctx7 remove --cursor")}
@@ -63,6 +71,7 @@ registerSetupCommand(program);
 registerRemoveCommand(program);
 registerDocsCommands(program);
 registerUpgradeCommand(program);
+registerUpdateCommand(program);
 
 program.action(() => {
   console.log("");

--- a/packages/cli/src/setup/rules.ts
+++ b/packages/cli/src/setup/rules.ts
@@ -1,0 +1,93 @@
+import { mkdir, readFile, writeFile } from "fs/promises";
+import { dirname, join } from "path";
+
+import { hashContent } from "../utils/content.js";
+import { recordInstall } from "../utils/cli-state.js";
+import { getAgent, type SetupAgent } from "./agents.js";
+import type { RuleMode } from "./templates.js";
+
+type Scope = "global" | "project";
+
+function escapeMarker(marker: string): string {
+  return marker.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function getRulePath(agentName: SetupAgent, scope: Scope): string {
+  const rule = getAgent(agentName).rule;
+  if (rule.kind === "file") {
+    const dir = scope === "global" ? rule.dir("global") : join(process.cwd(), rule.dir("project"));
+    return join(dir, rule.filename);
+  }
+  return scope === "global" ? rule.file("global") : join(process.cwd(), rule.file("project"));
+}
+
+export async function readRuleBody(agentName: SetupAgent, path: string): Promise<string | null> {
+  const rule = getAgent(agentName).rule;
+
+  let existing: string;
+  try {
+    existing = await readFile(path, "utf-8");
+  } catch {
+    return null;
+  }
+
+  if (rule.kind === "file") return existing;
+
+  const match = existing.match(
+    new RegExp(
+      `${escapeMarker(rule.sectionMarker)}\\n([\\s\\S]*?)${escapeMarker(rule.sectionMarker)}`
+    )
+  );
+  return match ? match[1] : null;
+}
+
+export async function installRule(
+  agentName: SetupAgent,
+  mode: RuleMode,
+  scope: Scope,
+  content: string,
+  revision: number,
+  path: string = getRulePath(agentName, scope)
+): Promise<{ status: string; path: string }> {
+  const rule = getAgent(agentName).rule;
+  let status = "installed";
+
+  if (rule.kind === "file") {
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, content, "utf-8");
+  } else {
+    const section = `${rule.sectionMarker}\n${content}${rule.sectionMarker}`;
+
+    let existing = "";
+    try {
+      existing = await readFile(path, "utf-8");
+    } catch {}
+
+    if (existing.includes(rule.sectionMarker)) {
+      const marker = escapeMarker(rule.sectionMarker);
+      await writeFile(
+        path,
+        existing.replace(new RegExp(`${marker}\\n[\\s\\S]*?${marker}`), section),
+        "utf-8"
+      );
+      status = "updated";
+    } else {
+      const separator =
+        existing.length > 0 && !existing.endsWith("\n") ? "\n\n" : existing.length > 0 ? "\n" : "";
+      await mkdir(dirname(path), { recursive: true });
+      await writeFile(path, existing + separator + section + "\n", "utf-8");
+    }
+  }
+
+  await recordInstall(path, {
+    kind: "rule",
+    name: mode === "mcp" ? "context7-mcp.md" : "context7-cli.md",
+    agent: agentName,
+    scope,
+    mode,
+    revision,
+    hash: hashContent(content),
+  });
+
+  return { status, path };
+}

--- a/packages/cli/src/setup/skills.ts
+++ b/packages/cli/src/setup/skills.ts
@@ -1,0 +1,81 @@
+import { join } from "path";
+
+import { downloadSkill } from "../utils/api.js";
+import { readCliState, recordInstall } from "../utils/cli-state.js";
+import { hashFiles, resolveSkill } from "../utils/content.js";
+import { installSkillFiles } from "../utils/installer.js";
+import type { SkillFile } from "../types.js";
+import { getAgent, type SetupAgent } from "./agents.js";
+import { customizeSkillFilesForAgent } from "./templates.js";
+
+type Scope = "global" | "project";
+
+interface SkillContent {
+  files: SkillFile[];
+  revision: number;
+}
+
+const cache = new Map<string, Promise<SkillContent>>();
+
+async function fetchSkillContent(skillName: string): Promise<SkillContent> {
+  const resolved = await resolveSkill(skillName);
+  if (resolved) return resolved;
+
+  const download = await downloadSkill("/upstash/context7", skillName);
+  if (download.error || download.files.length === 0) {
+    throw new Error(download.error || "no files");
+  }
+  return { files: download.files, revision: 0 };
+}
+
+export function loadSkillContent(skillName: string): Promise<SkillContent> {
+  let pending = cache.get(skillName);
+  if (!pending) {
+    pending = fetchSkillContent(skillName);
+    cache.set(skillName, pending);
+  }
+  return pending;
+}
+
+export function getSkillsRoot(agentName: SetupAgent, scope: Scope): string {
+  const agent = getAgent(agentName);
+  return scope === "global"
+    ? agent.skill.dir("global")
+    : join(process.cwd(), agent.skill.dir("project"));
+}
+
+export function getSkillDir(agentName: SetupAgent, scope: Scope, skillName: string): string {
+  return join(getSkillsRoot(agentName, scope), skillName);
+}
+
+export async function installSkill(
+  agentName: SetupAgent,
+  scope: Scope,
+  skillName: string,
+  root: string = getSkillsRoot(agentName, scope)
+): Promise<string> {
+  const { files, revision } = await loadSkillContent(skillName);
+  const customized = customizeSkillFilesForAgent(agentName, skillName, files);
+
+  const dir = join(root, skillName);
+  const previous = (await readCliState()).installs?.[dir];
+
+  await installSkillFiles(
+    skillName,
+    customized,
+    root,
+    previous?.kind === "skill" ? previous.files : []
+  );
+
+  await recordInstall(dir, {
+    kind: "skill",
+    name: skillName,
+    agent: agentName,
+    scope,
+    revision,
+    hash: hashFiles(customized),
+    files: customized.map((file) => file.path).sort(),
+  });
+
+  return dir;
+}

--- a/packages/cli/src/setup/skills.ts
+++ b/packages/cli/src/setup/skills.ts
@@ -10,7 +10,7 @@ import { customizeSkillFilesForAgent } from "./templates.js";
 
 type Scope = "global" | "project";
 
-interface SkillContent {
+export interface SkillContent {
   files: SkillFile[];
   revision: number;
 }
@@ -37,6 +37,10 @@ export function loadSkillContent(skillName: string): Promise<SkillContent> {
   return pending;
 }
 
+export function resetSkillContentCache(): void {
+  cache.clear();
+}
+
 export function getSkillsRoot(agentName: SetupAgent, scope: Scope): string {
   const agent = getAgent(agentName);
   return scope === "global"
@@ -54,7 +58,16 @@ export async function installSkill(
   skillName: string,
   root: string = getSkillsRoot(agentName, scope)
 ): Promise<string> {
-  const { files, revision } = await loadSkillContent(skillName);
+  return writeSkill(agentName, scope, skillName, root, await loadSkillContent(skillName));
+}
+
+export async function writeSkill(
+  agentName: SetupAgent,
+  scope: Scope,
+  skillName: string,
+  root: string,
+  { files, revision }: SkillContent
+): Promise<string> {
   const customized = customizeSkillFilesForAgent(agentName, skillName, files);
 
   const dir = join(root, skillName);

--- a/packages/cli/src/setup/templates.ts
+++ b/packages/cli/src/setup/templates.ts
@@ -39,21 +39,35 @@ export function getRuleFilename(mode: RuleMode): string {
   return mode === "mcp" ? "context7-mcp.md" : "context7-cli.md";
 }
 
+export function decorateRule(body: string, mode: RuleMode, agent: string): string {
+  let decorated = body;
+
+  if (mode === "cli" && agent === "codex" && !decorated.includes(CODEX_CLI_SANDBOX_GUIDANCE)) {
+    decorated = `${decorated.trimEnd()}\n${CODEX_CLI_SANDBOX_GUIDANCE}\n`;
+  }
+
+  return agent === "cursor" ? `${CURSOR_FRONTMATTER}${decorated}` : decorated;
+}
+
+/** Resolves from the manifest, or null when only the built-in fallback is available. */
+export async function getManifestRule(
+  mode: RuleMode,
+  agent: string
+): Promise<{ content: string; revision: number } | null> {
+  const resolved = await resolveRule(getRuleFilename(mode));
+  if (!resolved) return null;
+  return { content: decorateRule(resolved.content, mode, agent), revision: resolved.revision };
+}
+
 export async function getRule(
   mode: RuleMode,
   agent: string
 ): Promise<{ content: string; revision: number }> {
-  const resolved = await resolveRule(getRuleFilename(mode));
-  let body = resolved?.content ?? (mode === "mcp" ? FALLBACK_MCP : FALLBACK_CLI);
+  const resolved = await getManifestRule(mode, agent);
+  if (resolved) return resolved;
 
-  if (mode === "cli" && agent === "codex" && !body.includes(CODEX_CLI_SANDBOX_GUIDANCE)) {
-    body = `${body.trimEnd()}\n${CODEX_CLI_SANDBOX_GUIDANCE}\n`;
-  }
-
-  return {
-    content: agent === "cursor" ? `${CURSOR_FRONTMATTER}${body}` : body,
-    revision: resolved?.revision ?? 0,
-  };
+  const fallback = mode === "mcp" ? FALLBACK_MCP : FALLBACK_CLI;
+  return { content: decorateRule(fallback, mode, agent), revision: 0 };
 }
 
 export async function getRuleContent(mode: RuleMode, agent: string): Promise<string> {

--- a/packages/cli/src/setup/templates.ts
+++ b/packages/cli/src/setup/templates.ts
@@ -1,7 +1,4 @@
-const GITHUB_RAW_URLS = [
-  "https://raw.githubusercontent.com/upstash/context7/master/rules",
-  "https://raw.githubusercontent.com/upstash/context7/main/rules",
-];
+import { resolveRule } from "../utils/content.js";
 
 const FALLBACK_MCP = `Use Context7 MCP to fetch current documentation whenever the user asks about a library, framework, SDK, API, CLI tool, or cloud service — even well-known ones like React, Next.js, Prisma, Express, Tailwind, Django, or Spring Boot. This includes API syntax, configuration, version migration, library-specific debugging, setup instructions, and CLI tool usage. Use even when you think you know the answer — your training data may not reflect recent changes. Prefer this over web search for library docs.
 
@@ -38,28 +35,29 @@ const CODEX_CLI_SANDBOX_GUIDANCE = `Run Context7 CLI requests outside Codex's de
 
 export type RuleMode = "mcp" | "cli";
 
-async function fetchRule(filename: string, fallback: string): Promise<string> {
-  for (const base of GITHUB_RAW_URLS) {
-    try {
-      const res = await fetch(`${base}/${filename}`);
-      if (res.ok) return await res.text();
-    } catch {
-      continue;
-    }
-  }
-  return fallback;
+export function getRuleFilename(mode: RuleMode): string {
+  return mode === "mcp" ? "context7-mcp.md" : "context7-cli.md";
 }
 
-export async function getRuleContent(mode: RuleMode, agent: string): Promise<string> {
-  const [filename, fallback] =
-    mode === "mcp" ? ["context7-mcp.md", FALLBACK_MCP] : ["context7-cli.md", FALLBACK_CLI];
-  let body = await fetchRule(filename, fallback);
+export async function getRule(
+  mode: RuleMode,
+  agent: string
+): Promise<{ content: string; revision: number }> {
+  const resolved = await resolveRule(getRuleFilename(mode));
+  let body = resolved?.content ?? (mode === "mcp" ? FALLBACK_MCP : FALLBACK_CLI);
 
   if (mode === "cli" && agent === "codex" && !body.includes(CODEX_CLI_SANDBOX_GUIDANCE)) {
     body = `${body.trimEnd()}\n${CODEX_CLI_SANDBOX_GUIDANCE}\n`;
   }
 
-  return agent === "cursor" ? `${CURSOR_FRONTMATTER}${body}` : body;
+  return {
+    content: agent === "cursor" ? `${CURSOR_FRONTMATTER}${body}` : body,
+    revision: resolved?.revision ?? 0,
+  };
+}
+
+export async function getRuleContent(mode: RuleMode, agent: string): Promise<string> {
+  return (await getRule(mode, agent)).content;
 }
 
 export function customizeSkillFilesForAgent(

--- a/packages/cli/src/utils/cli-state.ts
+++ b/packages/cli/src/utils/cli-state.ts
@@ -45,6 +45,10 @@ function statePath(stateFile?: string): string {
   return stateFile ?? process.env.CTX7_STATE_FILE ?? getUpdateStateFilePath();
 }
 
+export function getStatePath(): string {
+  return statePath();
+}
+
 export async function readCliState(stateFile?: string): Promise<CliState> {
   const target = statePath(stateFile);
   const path =

--- a/packages/cli/src/utils/cli-state.ts
+++ b/packages/cli/src/utils/cli-state.ts
@@ -1,5 +1,5 @@
 import { dirname } from "path";
-import { mkdir, readFile, writeFile } from "fs/promises";
+import { mkdir, readFile, rename, rm, stat, writeFile } from "fs/promises";
 
 import type { ContentManifest } from "./content.js";
 import {
@@ -38,6 +38,7 @@ export interface CliState {
   lastNotifiedAt?: number;
   contentManifest?: { fetchedAt: number; manifest: ContentManifest };
   contentNotifiedAt?: number;
+  contentRetryAfter?: number;
   installs?: Record<string, Install>;
 }
 
@@ -49,6 +50,51 @@ export function getStatePath(): string {
   return statePath();
 }
 
+const LOCK_STALE_MS = 60_000;
+let lockDepth = 0;
+
+/**
+ * Re-entrant within a process, stale-tolerant across processes. The default wait
+ * is deliberately short: this sits on the hot path of every command, so bounded
+ * last-writer-wins beats stalling a docs query behind another process.
+ */
+export async function acquireStateLock(target: string, timeoutMs = 250): Promise<boolean> {
+  if (lockDepth > 0) {
+    lockDepth++;
+    return true;
+  }
+
+  const lockFile = `${target}.lock`;
+  const deadline = Date.now() + timeoutMs;
+
+  for (;;) {
+    try {
+      await writeFile(lockFile, String(process.pid), { flag: "wx" });
+      lockDepth = 1;
+      return true;
+    } catch {
+      // Held elsewhere.
+    }
+
+    const info = await stat(lockFile).catch(() => null);
+    const stale = info !== null && Date.now() - info.mtimeMs > LOCK_STALE_MS;
+    if (stale) {
+      await rm(lockFile, { force: true }).catch(() => {});
+    }
+
+    if (Date.now() >= deadline) return false;
+    if (!stale) await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+}
+
+export async function releaseStateLock(target: string): Promise<void> {
+  if (lockDepth === 0) return;
+  lockDepth--;
+  if (lockDepth === 0) {
+    await rm(`${target}.lock`, { force: true }).catch(() => {});
+  }
+}
+
 export async function readCliState(stateFile?: string): Promise<CliState> {
   const target = statePath(stateFile);
   const path =
@@ -56,20 +102,44 @@ export async function readCliState(stateFile?: string): Promise<CliState> {
       ? await resolveReadPath(UPDATE_STATE_FILE_NAME, target)
       : target;
 
+  let raw: string;
   try {
-    return JSON.parse(await readFile(path, "utf-8")) as CliState;
+    raw = await readFile(path, "utf-8");
   } catch {
+    return {};
+  }
+
+  try {
+    return JSON.parse(raw) as CliState;
+  } catch {
+    // Quarantine rather than read {} forever: an unparseable file would otherwise
+    // silently disable install tracking on every future run.
+    await rename(path, `${path}.corrupt`).catch(() => {});
     return {};
   }
 }
 
+/**
+ * Written via a temp file and rename so a crash mid-write cannot leave truncated
+ * JSON behind, and under the shared lock so a concurrent writer holding an older
+ * copy in memory cannot clobber records it never read.
+ */
 export async function writeCliState(state: CliState, stateFile?: string): Promise<void> {
   const path = statePath(stateFile);
   if (path === getUpdateStateFilePath()) {
     await migrateLegacyFile(UPDATE_STATE_FILE_NAME, path);
   }
   await mkdir(dirname(path), { recursive: true });
-  await writeFile(path, JSON.stringify(state, null, 2) + "\n", "utf-8");
+
+  const held = await acquireStateLock(path);
+  const temp = `${path}.${process.pid}.tmp`;
+  try {
+    await writeFile(temp, JSON.stringify(state, null, 2) + "\n", "utf-8");
+    await rename(temp, path);
+  } finally {
+    await rm(temp, { force: true }).catch(() => {});
+    if (held) await releaseStateLock(path);
+  }
 }
 
 export async function updateCliState(

--- a/packages/cli/src/utils/cli-state.ts
+++ b/packages/cli/src/utils/cli-state.ts
@@ -1,0 +1,91 @@
+import { dirname } from "path";
+import { mkdir, readFile, writeFile } from "fs/promises";
+
+import type { ContentManifest } from "./content.js";
+import {
+  UPDATE_STATE_FILE_NAME,
+  getUpdateStateFilePath,
+  migrateLegacyFile,
+  resolveReadPath,
+} from "./storage-paths.js";
+
+export interface SkillInstall {
+  kind: "skill";
+  name: string;
+  agent: string;
+  scope: "global" | "project";
+  revision: number;
+  hash: string;
+  files: string[];
+}
+
+export interface RuleInstall {
+  kind: "rule";
+  name: string;
+  agent: string;
+  scope: "global" | "project";
+  mode: "mcp" | "cli";
+  revision: number;
+  hash: string;
+}
+
+export type Install = SkillInstall | RuleInstall;
+
+export interface CliState {
+  latestVersion?: string;
+  lastCheckedAt?: number;
+  notifiedVersion?: string;
+  lastNotifiedAt?: number;
+  contentManifest?: { fetchedAt: number; manifest: ContentManifest };
+  contentNotifiedAt?: number;
+  installs?: Record<string, Install>;
+}
+
+function statePath(stateFile?: string): string {
+  return stateFile ?? process.env.CTX7_STATE_FILE ?? getUpdateStateFilePath();
+}
+
+export async function readCliState(stateFile?: string): Promise<CliState> {
+  const target = statePath(stateFile);
+  const path =
+    target === getUpdateStateFilePath()
+      ? await resolveReadPath(UPDATE_STATE_FILE_NAME, target)
+      : target;
+
+  try {
+    return JSON.parse(await readFile(path, "utf-8")) as CliState;
+  } catch {
+    return {};
+  }
+}
+
+export async function writeCliState(state: CliState, stateFile?: string): Promise<void> {
+  const path = statePath(stateFile);
+  if (path === getUpdateStateFilePath()) {
+    await migrateLegacyFile(UPDATE_STATE_FILE_NAME, path);
+  }
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, JSON.stringify(state, null, 2) + "\n", "utf-8");
+}
+
+export async function updateCliState(
+  patch: Partial<CliState>,
+  stateFile?: string
+): Promise<CliState> {
+  const next = { ...(await readCliState(stateFile)), ...patch };
+  await writeCliState(next, stateFile);
+  return next;
+}
+
+export async function recordInstall(path: string, install: Install): Promise<void> {
+  const state = await readCliState();
+  await writeCliState({ ...state, installs: { ...state.installs, [path]: install } });
+}
+
+export async function forgetInstall(path: string): Promise<void> {
+  const state = await readCliState();
+  if (!state.installs?.[path]) return;
+  const installs = { ...state.installs };
+  delete installs[path];
+  await writeCliState({ ...state, installs });
+}

--- a/packages/cli/src/utils/content.ts
+++ b/packages/cli/src/utils/content.ts
@@ -1,0 +1,137 @@
+import { createHash } from "crypto";
+
+import { VERSION } from "../constants.js";
+import type { SkillFile } from "../types.js";
+import { readCliState, updateCliState } from "./cli-state.js";
+import { compareVersions } from "./update-check.js";
+
+const RAW_BASES = [
+  "https://raw.githubusercontent.com/upstash/context7/master",
+  "https://raw.githubusercontent.com/upstash/context7/main",
+];
+const MANIFEST_TTL_MS = 24 * 60 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 5000;
+
+export interface ManifestFile {
+  path: string;
+  hash: string;
+}
+
+export interface SkillEntry {
+  revision: number;
+  minCliVersion: string;
+  files: ManifestFile[];
+}
+
+export interface RuleEntry {
+  revision: number;
+  minCliVersion: string;
+  hash: string;
+}
+
+export interface ContentManifest {
+  schema: number;
+  skills: Record<string, SkillEntry>;
+  rules: Record<string, RuleEntry>;
+}
+
+export interface ResolvedSkill {
+  revision: number;
+  files: SkillFile[];
+}
+
+export interface ResolvedRule {
+  revision: number;
+  content: string;
+}
+
+export function hashContent(content: string): string {
+  return createHash("sha256").update(content.replace(/\r\n/g, "\n")).digest("hex").slice(0, 12);
+}
+
+export function hashFiles(files: SkillFile[]): string {
+  const payload = [...files]
+    .sort((a, b) => (a.path < b.path ? -1 : 1))
+    .map((file) => `${file.path}\n${file.content.replace(/\r\n/g, "\n")}`)
+    .join("\0");
+  return hashContent(payload);
+}
+
+async function fetchRaw(path: string): Promise<string | null> {
+  for (const base of RAW_BASES) {
+    try {
+      const response = await fetch(`${base}/${path}`, {
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      });
+      if (response.ok) return await response.text();
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+let inFlight: Promise<ContentManifest | null> | null = null;
+
+export async function getManifest(
+  options: { force?: boolean; now?: number } = {}
+): Promise<ContentManifest | null> {
+  if (!options.force && inFlight) return inFlight;
+
+  const load = async (): Promise<ContentManifest | null> => {
+    const now = options.now ?? Date.now();
+    const cached = (await readCliState()).contentManifest;
+
+    if (!options.force && cached && now - cached.fetchedAt < MANIFEST_TTL_MS) {
+      return cached.manifest;
+    }
+
+    const raw = await fetchRaw("skills/manifest.json");
+    if (raw === null) return cached?.manifest ?? null;
+
+    try {
+      const manifest = JSON.parse(raw) as ContentManifest;
+      if (!manifest.skills || !manifest.rules) return cached?.manifest ?? null;
+      await updateCliState({ contentManifest: { fetchedAt: now, manifest } });
+      return manifest;
+    } catch {
+      return cached?.manifest ?? null;
+    }
+  };
+
+  inFlight = load();
+  return inFlight;
+}
+
+export function supportsEntry(entry: { minCliVersion?: string }): boolean {
+  return compareVersions(VERSION, entry.minCliVersion ?? "0.0.0") >= 0;
+}
+
+export async function resolveSkill(name: string): Promise<ResolvedSkill | null> {
+  const entry = (await getManifest())?.skills?.[name];
+  if (!entry) return null;
+
+  const files: SkillFile[] = [];
+  for (const file of entry.files) {
+    if (file.path.includes("..")) return null;
+    const content = await fetchRaw(`skills/${name}/${file.path}`);
+    if (content === null || hashContent(content) !== file.hash) return null;
+    files.push({ path: file.path, content });
+  }
+
+  return { revision: entry.revision, files };
+}
+
+export async function resolveRule(filename: string): Promise<ResolvedRule | null> {
+  const entry = (await getManifest())?.rules?.[filename];
+  if (!entry) return null;
+
+  const content = await fetchRaw(`rules/${filename}`);
+  if (content === null || hashContent(content) !== entry.hash) return null;
+
+  return { revision: entry.revision, content };
+}
+
+export function resetManifestCache(): void {
+  inFlight = null;
+}

--- a/packages/cli/src/utils/installer.ts
+++ b/packages/cli/src/utils/installer.ts
@@ -1,33 +1,56 @@
-import { mkdir, writeFile, rm, symlink, lstat } from "fs/promises";
+import { mkdir, writeFile, readFile, rm, symlink, lstat } from "fs/promises";
 import { resolve, dirname } from "path";
 
 import type { SkillFile } from "../types.js";
 import { assertSkillNameInRoot } from "./skill-name.js";
 
+function safeResolve(skillDir: string, filePath: string): string {
+  const resolved = resolve(skillDir, filePath);
+  if (
+    !resolved.startsWith(skillDir + "/") &&
+    !resolved.startsWith(skillDir + "\\") &&
+    resolved !== skillDir
+  ) {
+    throw new Error(`Skill file path "${filePath}" resolves outside the target directory`);
+  }
+  return resolved;
+}
+
 export async function installSkillFiles(
   skillName: string,
   files: SkillFile[],
-  skillsRoot: string
+  skillsRoot: string,
+  staleFiles: string[] = []
 ): Promise<void> {
   const skillDir = assertSkillNameInRoot(skillsRoot, skillName);
 
   for (const file of files) {
-    const filePath = resolve(skillDir, file.path);
-
-    // Prevent directory traversal — resolved path must stay within skillDir
-    if (
-      !filePath.startsWith(skillDir + "/") &&
-      !filePath.startsWith(skillDir + "\\") &&
-      filePath !== skillDir
-    ) {
-      throw new Error(`Skill file path "${file.path}" resolves outside the target directory`);
-    }
-
-    const fileDir = dirname(filePath);
-
-    await mkdir(fileDir, { recursive: true });
+    const filePath = safeResolve(skillDir, file.path);
+    await mkdir(dirname(filePath), { recursive: true });
     await writeFile(filePath, file.content);
   }
+
+  const kept = files.map((file) => file.path);
+  for (const stale of staleFiles) {
+    if (!kept.includes(stale)) {
+      await rm(safeResolve(skillDir, stale), { force: true });
+    }
+  }
+}
+
+export async function readSkillFiles(
+  skillDir: string,
+  paths: string[]
+): Promise<SkillFile[] | null> {
+  const files: SkillFile[] = [];
+  for (const path of paths) {
+    try {
+      files.push({ path, content: await readFile(safeResolve(skillDir, path), "utf-8") });
+    } catch {
+      return null;
+    }
+  }
+  return files;
 }
 
 export async function symlinkSkill(

--- a/packages/cli/src/utils/update-check.ts
+++ b/packages/cli/src/utils/update-check.ts
@@ -1,12 +1,5 @@
-import { dirname } from "path";
-import { mkdir, readFile, writeFile } from "fs/promises";
 import { NAME, VERSION } from "../constants.js";
-import {
-  UPDATE_STATE_FILE_NAME,
-  getUpdateStateFilePath,
-  migrateLegacyFile,
-  resolveReadPath,
-} from "./storage-paths.js";
+import { readCliState, writeCliState } from "./cli-state.js";
 
 const DEFAULT_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 
@@ -18,13 +11,6 @@ export type InstallMethod =
   | "pnpm-dlx"
   | "bunx"
   | "unknown";
-
-interface UpdateState {
-  latestVersion?: string;
-  lastCheckedAt?: number;
-  notifiedVersion?: string;
-  lastNotifiedAt?: number;
-}
 
 export interface UpgradePlan {
   installMethod: InstallMethod;
@@ -48,42 +34,6 @@ interface CheckForUpdatesOptions {
   now?: number;
   cacheTtlMs?: number;
   stateFile?: string;
-}
-
-function getStateFilePath(stateFile?: string): string {
-  return stateFile ?? getUpdateStateFilePath();
-}
-
-// Reads resolve to the legacy `~/.context7` file if migration could not move it.
-async function readStateFilePath(stateFile?: string): Promise<string> {
-  if (stateFile) {
-    return stateFile;
-  }
-  return resolveReadPath(UPDATE_STATE_FILE_NAME, getUpdateStateFilePath());
-}
-
-// Writes always target the XDG path; migrate the legacy file first if present.
-async function writeStateFilePath(stateFile?: string): Promise<string> {
-  const path = getStateFilePath(stateFile);
-  if (!stateFile) {
-    await migrateLegacyFile(UPDATE_STATE_FILE_NAME, path);
-  }
-  return path;
-}
-
-async function readUpdateState(stateFile?: string): Promise<UpdateState> {
-  try {
-    const raw = await readFile(await readStateFilePath(stateFile), "utf-8");
-    return JSON.parse(raw) as UpdateState;
-  } catch {
-    return {};
-  }
-}
-
-async function writeUpdateState(state: UpdateState, stateFile?: string): Promise<void> {
-  const path = await writeStateFilePath(stateFile);
-  await mkdir(dirname(path), { recursive: true });
-  await writeFile(path, JSON.stringify(state, null, 2) + "\n", "utf-8");
 }
 
 export function compareVersions(a: string, b: string): number {
@@ -221,7 +171,7 @@ export async function checkForUpdates(
   const now = options.now ?? Date.now();
   const cacheTtlMs = options.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
   const stateFile = options.stateFile;
-  const state = await readUpdateState(stateFile);
+  const state = await readCliState(stateFile);
   const isStale =
     options.force ||
     !state.lastCheckedAt ||
@@ -234,7 +184,7 @@ export async function checkForUpdates(
     const fetchedVersion = await fetchLatestVersion();
     if (fetchedVersion) {
       latestVersion = fetchedVersion;
-      await writeUpdateState(
+      await writeCliState(
         {
           ...state,
           latestVersion: fetchedVersion,
@@ -266,7 +216,7 @@ export async function shouldShowUpdateNotification(
 
   const now = options.now ?? Date.now();
   const cooldownMs = options.cooldownMs ?? DEFAULT_CACHE_TTL_MS;
-  const state = await readUpdateState(options.stateFile);
+  const state = await readCliState(options.stateFile);
 
   if (
     state.notifiedVersion === info.latestVersion &&
@@ -284,8 +234,8 @@ export async function markUpdateNotificationShown(
   options: { now?: number; stateFile?: string } = {}
 ): Promise<void> {
   const now = options.now ?? Date.now();
-  const state = await readUpdateState(options.stateFile);
-  await writeUpdateState(
+  const state = await readCliState(options.stateFile);
+  await writeCliState(
     {
       ...state,
       notifiedVersion: latestVersion,

--- a/scripts/generate-content-manifest.mjs
+++ b/scripts/generate-content-manifest.mjs
@@ -1,0 +1,63 @@
+import { createHash } from "node:crypto";
+import { readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, relative, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const skillsDir = join(root, "skills");
+const rulesDir = join(root, "rules");
+const manifestPath = join(skillsDir, "manifest.json");
+
+function hash(filePath) {
+  const content = readFileSync(filePath, "utf-8").replace(/\r\n/g, "\n");
+  return createHash("sha256").update(content).digest("hex").slice(0, 12);
+}
+
+function walk(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walk(full));
+    else out.push(full);
+  }
+  return out;
+}
+
+let previous = { skills: {}, rules: {} };
+try {
+  previous = JSON.parse(readFileSync(manifestPath, "utf-8"));
+} catch {}
+
+const manifest = { schema: 1, skills: {}, rules: {} };
+
+for (const entry of readdirSync(skillsDir, { withFileTypes: true })) {
+  if (!entry.isDirectory()) continue;
+  const dir = join(skillsDir, entry.name);
+  const files = walk(dir)
+    .map((file) => ({ path: relative(dir, file).split(sep).join("/"), hash: hash(file) }))
+    .sort((a, b) => (a.path < b.path ? -1 : 1));
+
+  const prev = previous.skills?.[entry.name];
+  const changed = !prev || JSON.stringify(prev.files) !== JSON.stringify(files);
+  manifest.skills[entry.name] = {
+    revision: changed ? (prev?.revision ?? 0) + 1 : prev.revision,
+    minCliVersion: prev?.minCliVersion ?? "0.0.0",
+    files,
+  };
+}
+
+for (const name of readdirSync(rulesDir)
+  .filter((file) => file.endsWith(".md"))
+  .sort()) {
+  const fileHash = hash(join(rulesDir, name));
+  const prev = previous.rules?.[name];
+  const changed = !prev || prev.hash !== fileHash;
+  manifest.rules[name] = {
+    revision: changed ? (prev?.revision ?? 0) + 1 : prev.revision,
+    minCliVersion: prev?.minCliVersion ?? "0.0.0",
+    hash: fileHash,
+  };
+}
+
+writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + "\n");
+console.log(`Wrote ${relative(root, manifestPath)}`);

--- a/skills/manifest.json
+++ b/skills/manifest.json
@@ -1,0 +1,59 @@
+{
+  "schema": 1,
+  "skills": {
+    "context7-cli": {
+      "revision": 2,
+      "minCliVersion": "0.0.0",
+      "files": [
+        {
+          "path": "SKILL.md",
+          "hash": "d7b70ba126d9"
+        },
+        {
+          "path": "references/docs.md",
+          "hash": "144d463d5aa6"
+        },
+        {
+          "path": "references/setup.md",
+          "hash": "79530eb571b5"
+        },
+        {
+          "path": "references/skills.md",
+          "hash": "a31c9c560444"
+        }
+      ]
+    },
+    "context7-mcp": {
+      "revision": 1,
+      "minCliVersion": "0.0.0",
+      "files": [
+        {
+          "path": "SKILL.md",
+          "hash": "29ef59d34287"
+        }
+      ]
+    },
+    "find-docs": {
+      "revision": 1,
+      "minCliVersion": "0.0.0",
+      "files": [
+        {
+          "path": "SKILL.md",
+          "hash": "5bf22997630f"
+        }
+      ]
+    }
+  },
+  "rules": {
+    "context7-cli.md": {
+      "revision": 1,
+      "minCliVersion": "0.0.0",
+      "hash": "9716d0bcec92"
+    },
+    "context7-mcp.md": {
+      "revision": 1,
+      "minCliVersion": "0.0.0",
+      "hash": "ad7842ecf1da"
+    }
+  }
+}


### PR DESCRIPTION
Keeps skills and rules installed by `ctx7 setup` current as their upstream content changes, refreshing them automatically during ordinary commands and adding `ctx7 update` for manual control.

- Adds `skills/manifest.json`, generated by `scripts/generate-content-manifest.mjs`, giving each skill and rule a `revision`, a `minCliVersion`, and per-file content hashes. A CI step regenerates it and fails on a dirty diff.
- Resolves content from `raw.githubusercontent.com` against that manifest, verifying every file hash before accepting it. Falls back to the existing GitHub API download for skills and to the built-in constants for rules when unreachable.
- Caches the manifest in `cli-state.json` behind a 24h TTL and records each install there by absolute path, with its revision, content hash, and file list.
- Refreshes out-of-date content silently in the `preAction` hook, so `ctx7 docs` and `ctx7 library` self-heal. Guarded by a stale-tolerant lock file, since agents run these concurrently.
- Detects locally modified skills and rules by hash and leaves them alone; `ctx7 update --force` overwrites.
- Blocks revisions whose `minCliVersion` exceeds the running CLI and points at `ctx7 upgrade`.
- Prunes files dropped upstream instead of leaving them behind, and clears install records on `ctx7 remove`.

Content freshness is decoupled from the npm release cycle: a merge to master reaches existing installs on their next check regardless of the installed CLI version.

## Why auto-refresh

The rules and skills tell agents to invoke `npx ctx7@latest docs ...`, which always runs with stdout piped. A TTY-gated notice is invisible on that path, so the overwhelmingly common usage would never have been told to update and would never have updated. Refreshing in the natural flow is what actually closes the loop; `ctx7 update` exists for the cases auto-refresh deliberately will not touch.

Auto-refresh is silent, never fails the host command, and skips `setup`, `update`, `remove`, and `upgrade`. `CTX7_NO_AUTO_UPDATE=1` disables it. Cost on the common path is one state-file read: on-disk hashing only happens for records whose revision already differs from the cached manifest, and the manifest itself is fetched at most once per day.

The interactive notice now reports only what auto-refresh will not do on its own, locally modified files and version-blocked revisions, since both need a human decision.

## State file

`cli-state.json` (in `$XDG_STATE_HOME/context7/`) gains two things: an `installs` map keyed by absolute path, and a TTL'd `contentManifest` cache. The existing npm update-check fields are unchanged.

### After `ctx7 setup`

Global CLI mode for Claude Code and Cursor, plus MCP mode at project scope. One record per installed artifact. Note the two Cursor and Claude rule records share a source file but differ in `hash`, because Cursor's copy carries the `alwaysApply` frontmatter.

```json
{
  "installs": {
    "~/.claude/skills/find-docs": {
      "kind": "skill",
      "name": "find-docs",
      "agent": "claude",
      "scope": "global",
      "revision": 4,
      "hash": "3a69a6f34d4f",
      "files": ["SKILL.md"]
    },
    "~/.claude/rules/context7.md": {
      "kind": "rule",
      "name": "context7-cli.md",
      "agent": "claude",
      "scope": "global",
      "mode": "cli",
      "revision": 2,
      "hash": "1934a46b1e43"
    },
    "~/.cursor/skills/find-docs": {
      "kind": "skill",
      "name": "find-docs",
      "agent": "cursor",
      "scope": "global",
      "revision": 4,
      "hash": "3a69a6f34d4f",
      "files": ["SKILL.md"]
    },
    "~/.cursor/rules/context7.mdc": {
      "kind": "rule",
      "name": "context7-cli.md",
      "agent": "cursor",
      "scope": "global",
      "mode": "cli",
      "revision": 2,
      "hash": "5410731229e2"
    },
    "/repo/.claude/skills/context7-mcp": {
      "kind": "skill",
      "name": "context7-mcp",
      "agent": "claude",
      "scope": "project",
      "revision": 3,
      "hash": "ad156f258515",
      "files": ["SKILL.md"]
    },
    "/repo/.claude/rules/context7.md": {
      "kind": "rule",
      "name": "context7-mcp.md",
      "agent": "claude",
      "scope": "project",
      "mode": "mcp",
      "revision": 2,
      "hash": "6266214a08c5"
    }
  }
}
```

### Manifest cache

Written on the first check and reused for 24h. Also serves as the last-known-good copy when the network is unavailable, so an offline `ctx7 update` reports against the cache instead of failing.

```json
{
  "contentManifest": {
    "fetchedAt": 1753699200000,
    "manifest": {
      "schema": 1,
      "skills": {
        "find-docs": {
          "revision": 4,
          "minCliVersion": "0.0.0",
          "files": [{ "path": "SKILL.md", "hash": "5bf22997630f" }]
        },
        "context7-cli": {
          "revision": 3,
          "minCliVersion": "0.6.0",
          "files": [
            { "path": "SKILL.md", "hash": "d7b70ba126d9" },
            { "path": "references/docs.md", "hash": "144d463d5aa6" }
          ]
        }
      },
      "rules": {
        "context7-cli.md": { "revision": 2, "minCliVersion": "0.0.0", "hash": "9716d0bcec92" }
      }
    }
  },
  "contentNotifiedAt": 1753699200000
}
```

### Fallback install

When the manifest is unreachable, `setup` still installs via the existing GitHub API path and records `revision: 0`. The next successful check sees any real revision as newer and offers the update.

```json
{
  "installs": {
    "~/.claude/skills/find-docs": {
      "kind": "skill",
      "name": "find-docs",
      "agent": "claude",
      "scope": "global",
      "revision": 0,
      "hash": "3a69a6f34d4f",
      "files": ["SKILL.md"]
    }
  }
}
```

## Output

Auto-refresh during an agent-style invocation. Nothing is printed; only the state file moves:

```
$ node -e '...bump cached manifest to r7...'
$ ctx7 docs /vercel/next.js "middleware config" | head -4
   (docs output, unchanged)

$ jq '.installs[] | {name, revision}' cli-state.json
  find-docs        r0 -> r7
  context7-cli.md  r0 -> r7
```

`ctx7 update --check`, covering all three outcomes:

```
  + Skill find-docs (Claude Code, global) r1 -> r2
    ~/.claude/skills/find-docs
  ~ Skill find-docs (Cursor, global) modified locally, skipping
    ~/.cursor/skills/find-docs
  ~ Skill context7-mcp (Claude Code, project) needs ctx7 >= 99.0.0

Run with --force to overwrite locally modified files.
You are on v0.5.6. Run ctx7 upgrade to unlock newer content.
```

`ctx7 update --json` for the same state:

```json
[
  {
    "path": "~/.claude/skills/find-docs",
    "kind": "skill",
    "name": "find-docs",
    "agent": "claude",
    "scope": "global",
    "installedRevision": 1,
    "latestRevision": 2,
    "edited": false,
    "blockedBy": null
  },
  {
    "path": "~/.cursor/skills/find-docs",
    "kind": "skill",
    "name": "find-docs",
    "agent": "cursor",
    "scope": "global",
    "installedRevision": 1,
    "latestRevision": 2,
    "edited": true,
    "blockedBy": null
  },
  {
    "path": "/repo/.claude/skills/context7-mcp",
    "kind": "skill",
    "name": "context7-mcp",
    "agent": "claude",
    "scope": "project",
    "installedRevision": 1,
    "latestRevision": 3,
    "edited": false,
    "blockedBy": "99.0.0"
  }
]
```

## Notes for review

- Existing installs record `revision: 0` until the manifest lands on master, so the first `ctx7 update` after this ships will report everything as outdated. That is the intended one-time migration.
- Codex and OpenCode both write to `~/.agents/skills`, so that path's install record reflects whichever agent ran last and the other will read as locally modified. Pre-existing and not addressed here, but now visible.
