### PR TITLE
test: verify MiniMax models through Context7Agent

### DIFF
--- a/packages/tools-ai-sdk/package.json
+++ b/packages/tools-ai-sdk/package.json
@@ -38,6 +38,7 @@
     "ai": "^6.0.5",
     "zod": "^4.4.3",
     "@ai-sdk/amazon-bedrock": "^4.0.9",
+    "@ai-sdk/openai": "^3.0.88",
     "@types/node": "^25.0.3",
     "dotenv": "^17.4.2",
     "tsup": "^8.5.1",

--- a/packages/tools-ai-sdk/src/minimax.test.ts
+++ b/packages/tools-ai-sdk/src/minimax.test.ts
@@ -1,0 +1,80 @@
+import { createOpenAI } from "@ai-sdk/openai";
+import { stepCountIs } from "ai";
+import { describe, expect, test } from "vitest";
+import { Context7Agent } from "./index";
+
+const minimaxEndpoints = [
+  {
+    region: "global_en",
+    baseURL: "https://api.minimax.io/v1",
+  },
+  {
+    region: "cn_zh",
+    baseURL: "https://api.minimaxi.com/v1",
+  },
+] as const;
+
+const minimaxModelIds = ["MiniMax-M3", "MiniMax-M2.7"] as const;
+
+describe("MiniMax OpenAI-compatible provider fixture", () => {
+  for (const endpoint of minimaxEndpoints) {
+    for (const modelId of minimaxModelIds) {
+      test(`${endpoint.region} ${modelId} runs through Context7Agent`, async () => {
+        const requests: Array<{
+          url: string;
+          body: Record<string, unknown>;
+        }> = [];
+
+        const fetchMock: typeof fetch = async (input, init) => {
+          const body = JSON.parse(init?.body as string) as Record<string, unknown>;
+          requests.push({ url: String(input), body });
+
+          return new Response(
+            JSON.stringify({
+              id: "fixture-response",
+              object: "chat.completion",
+              created: 0,
+              model: body.model,
+              choices: [
+                {
+                  index: 0,
+                  message: {
+                    role: "assistant",
+                    content: "fixture response",
+                  },
+                  finish_reason: "stop",
+                },
+              ],
+              usage: {
+                prompt_tokens: 1,
+                completion_tokens: 1,
+                total_tokens: 2,
+              },
+            }),
+            {
+              headers: { "content-type": "application/json" },
+            }
+          );
+        };
+
+        const provider = createOpenAI({
+          apiKey: "fixture-key",
+          baseURL: endpoint.baseURL,
+          fetch: fetchMock,
+        });
+        const agent = new Context7Agent({
+          model: provider.chat(modelId),
+          stopWhen: stepCountIs(1),
+        });
+
+        const result = await agent.generate({ prompt: "Reply with a short answer." });
+
+        expect(result.text).toBe("fixture response");
+        expect(requests).toHaveLength(1);
+        expect(requests[0]?.url).toBe(`${endpoint.baseURL}/chat/completions`);
+        expect(requests[0]?.body.model).toBe(modelId);
+        expect(requests[0]?.body.tools).toBeDefined();
+      });
+    }
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,6 +188,9 @@ importers:
       '@ai-sdk/amazon-bedrock':
         specifier: ^4.0.9
         version: 4.0.12(zod@4.4.3)
+      '@ai-sdk/openai':
+        specifier: ^3.0.88
+        version: 3.0.88(zod@4.4.3)
       '@types/node':
         specifier: ^25.0.3
         version: 25.0.3
@@ -233,11 +236,27 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/openai@3.0.88':
+    resolution: {integrity: sha512-6M4+bxK/UMijDYK2ia1hCKYma1iajFYxHDlhbinFUdhH2WbFsjoZRMpSjEMlTOBptqmh2J1JclKnprGulF8WwQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider-utils@4.0.4':
     resolution: {integrity: sha512-VxhX0B/dWGbpNHxrKCWUAJKXIXV015J4e7qYjdIU9lLWeptk0KMLGcqkB4wFxff5Njqur8dt8wRi1MN9lZtDqg==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@4.0.40':
+    resolution: {integrity: sha512-OL5IrpUm9Y8Dwy+w/vvFwPotS6m52O9W0op2oXgXdCROMJIBalBI0oro6OIBYkPxvm5Xg02GSkoQN25RlR0bnw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@3.0.14':
+    resolution: {integrity: sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==}
+    engines: {node: '>=18'}
 
   '@ai-sdk/provider@3.0.2':
     resolution: {integrity: sha512-HrEmNt/BH/hkQ7zpi2o6N3k1ZR1QTb7z85WYhYygiTxOQuaml4CMtHCWRbric5WPU+RNsYI7r1EpyVQMKO1pYw==}
@@ -1910,6 +1929,10 @@ packages:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
     engines: {node: '>=18.0.0'}
 
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
   eventsource@3.0.7:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
@@ -3165,12 +3188,29 @@ snapshots:
       '@vercel/oidc': 3.1.0
       zod: 4.4.3
 
+  '@ai-sdk/openai@3.0.88(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.14
+      '@ai-sdk/provider-utils': 4.0.40(zod@4.4.3)
+      zod: 4.4.3
+
   '@ai-sdk/provider-utils@4.0.4(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.2
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
       zod: 4.4.3
+
+  '@ai-sdk/provider-utils@4.0.40(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.14
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.1.0
+      zod: 4.4.3
+
+  '@ai-sdk/provider@3.0.14':
+    dependencies:
+      json-schema: 0.4.0
 
   '@ai-sdk/provider@3.0.2':
     dependencies:
@@ -4978,6 +5018,8 @@ snapshots:
   etag@1.8.1: {}
 
   eventsource-parser@3.0.6: {}
+
+  eventsource-parser@3.1.0: {}
 
   eventsource@3.0.7:
     dependencies:


### PR DESCRIPTION
Reason: Add a MiniMax OpenAI-compatible fixture that verifies both current models through Context7Agent at the configured regional endpoints.

- Add `@ai-sdk/openai` as a development dependency.
- Add a deterministic fixture test for `MiniMax-M3` and `MiniMax-M2.7` at the global and China endpoints.
- Verify that the Context7Agent path sends chat-completion requests with the selected model and Context7 tools.

Checks:
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm --filter @upstash/context7-tools-ai-sdk typecheck`
- `pnpm --filter @upstash/context7-tools-ai-sdk exec vitest run src/minimax.test.ts`
- `./node_modules/.bin/tsup` from `packages/tools-ai-sdk`
- ESLint and Prettier checks for the changed files
- Secret scan passed
- The full package suite was also run; its five network-backed cases require an unset cloud-region environment variable, while the remaining fifteen tests passed.
