### PR TITLE
fix(mcp): validate token audience and reject non-credential bearer strings

### DIFF
--- a/.changeset/mcp-oauth-audience.md
+++ b/.changeset/mcp-oauth-audience.md
@@ -1,0 +1,5 @@
+---
+"@upstash/context7-mcp": patch
+---
+
+Validate the audience on Clerk-issued JWTs and stop accepting arbitrary bearer strings on the OAuth-protected endpoint. The Clerk verification path checked only issuer and signature, so any JWT that instance signed for any purpose verified against this server; the MCP spec requires a resource server to accept only tokens issued for itself. Separately, `/mcp/oauth` returned 401 without a credential but let through any value that did not parse as a JWT, opening a session for a credential that could not be valid.

--- a/packages/mcp/src/__tests__/jwt.test.ts
+++ b/packages/mcp/src/__tests__/jwt.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { isApiKeyFormat, isJWT } from "../lib/jwt.js";
+
+describe("isJWT", () => {
+  it("accepts a three-segment token", () => {
+    expect(isJWT("aaa.bbb.ccc")).toBe(true);
+  });
+
+  it("rejects anything else", () => {
+    expect(isJWT("ctx7sk-1234")).toBe(false);
+    expect(isJWT("aaa.bbb")).toBe(false);
+    expect(isJWT("")).toBe(false);
+  });
+});
+
+describe("isApiKeyFormat", () => {
+  it("accepts member and enterprise key prefixes", () => {
+    expect(isApiKeyFormat("ctx7sk-7504e73e-dfcf-449f-b19f-f6f8285c4b3c")).toBe(true);
+    expect(isApiKeyFormat("ctx7op-abcdef_0123456789")).toBe(true);
+  });
+
+  // The endpoint that advertises authentication used to let any bearer string
+  // through and open a session; these are the strings that must not qualify.
+  it.each(["totally-not-a-real-token", "Bearer", "", "ctx7sk", "ctx7-1234", "sk-live-abc"])(
+    "rejects %s",
+    (token) => {
+      expect(isApiKeyFormat(token)).toBe(false);
+    }
+  );
+});

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -11,7 +11,7 @@ import {
   extractClientInfoFromUserAgent,
   envelopeClientInfo,
 } from "./lib/utils.js";
-import { isJWT, validateJWT } from "./lib/jwt.js";
+import { isApiKeyFormat, isJWT, validateJWT } from "./lib/jwt.js";
 import express from "express";
 import { Command } from "commander";
 import { AsyncLocalStorage } from "async_hooks";
@@ -427,6 +427,16 @@ async function main() {
                 id: null,
               });
             }
+          } else if (!isApiKeyFormat(apiKey)) {
+            // Anything that is neither a JWT nor an API key would previously
+            // fall through unchecked and open a session on the endpoint that
+            // advertises authentication. The key itself is still verified
+            // upstream; this only stops arbitrary strings getting that far.
+            return res.status(401).json({
+              jsonrpc: "2.0",
+              error: { code: -32001, message: "Invalid token. Please re-authenticate." },
+              id: null,
+            });
           }
         }
 

--- a/packages/mcp/src/lib/jwt.ts
+++ b/packages/mcp/src/lib/jwt.ts
@@ -71,6 +71,16 @@ export function isJWT(token: string): boolean {
   return token.split(".").length === 3;
 }
 
+/**
+ * Shape check only, deliberately permissive: it covers the `ctx7sk` member keys
+ * and the `ctx7op` enterprise keys without pinning either. The key is still
+ * verified upstream; this exists so a credential that cannot possibly be valid
+ * is rejected before it opens a session.
+ */
+export function isApiKeyFormat(token: string): boolean {
+  return /^ctx7[a-z]{2}[-_]/i.test(token);
+}
+
 export async function validateJWT(token: string): Promise<JWTValidationResult> {
   try {
     const decoded = jose.decodeJwt(token);
@@ -103,7 +113,14 @@ export async function validateJWT(token: string): Promise<JWTValidationResult> {
       return { valid: true };
     }
 
-    await jose.jwtVerify(token, clerkJwks, { issuer: CLERK_ISSUER });
+    // Audience matters as much as the signature here. Without it any JWT the
+    // Clerk instance signs for any purpose — a session token, a token minted for
+    // some other client — verifies against this server. The MCP spec requires a
+    // resource server to accept only tokens issued for itself.
+    await jose.jwtVerify(token, clerkJwks, {
+      issuer: CLERK_ISSUER,
+      audience: RESOURCE_URL,
+    });
     return { valid: true };
   } catch (error) {
     if (error instanceof jose.errors.JWTExpired) {

--- a/packages/mcp/test/credential-format.test.ts
+++ b/packages/mcp/test/credential-format.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { isApiKeyFormat, isJWT } from "../lib/jwt.js";
+import { isApiKeyFormat, isJWT } from "../src/lib/jwt.js";
 
 describe("isJWT", () => {
   it("accepts a three-segment token", () => {

--- a/packages/mcp/test/integration.test.ts
+++ b/packages/mcp/test/integration.test.ts
@@ -230,3 +230,77 @@ describe.each([
     expect(apiCall.headers["x-context7-client-version"]).toBe(expected.version);
   });
 });
+
+// End-to-end auth checks against the spawned HTTP server. /mcp/oauth is the
+// endpoint that advertises authentication; before the credential-format gate
+// any bearer string that did not parse as a JWT opened a session there.
+describe("http /mcp/oauth authentication", () => {
+  const INITIALIZE_BODY = JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {
+      protocolVersion: "2025-06-18",
+      capabilities: {},
+      clientInfo: { name: "auth-e2e", version: "1.0.0" },
+    },
+  });
+
+  function postOauth(authorization?: string) {
+    return fetch(`${httpUrl}/oauth`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+        ...(authorization ? { authorization } : {}),
+      },
+      body: INITIALIZE_BODY,
+    });
+  }
+
+  test("rejects a missing credential with 401", async () => {
+    const res = await postOauth();
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: { code: number } };
+    expect(body.error.code).toBe(-32001);
+  });
+
+  test("rejects an arbitrary bearer string with 401", async () => {
+    // This exact request used to open a session (confirmed HTTP 200 in
+    // production before the fix).
+    const res = await postOauth("Bearer totally-not-a-real-token");
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: { message: string } };
+    expect(body.error.message).toContain("Invalid token");
+  });
+
+  test("rejects a forged JWT with 401", async () => {
+    const header = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" })).toString("base64url");
+    const payload = Buffer.from(JSON.stringify({ iss: "https://evil.example" })).toString(
+      "base64url"
+    );
+    const res = await postOauth(`Bearer ${header}.${payload}.forged-signature`);
+    expect(res.status).toBe(401);
+  });
+
+  test("lets an API-key-shaped credential through to the session layer", async () => {
+    // The key itself is verified upstream on tool calls; the gate must only
+    // stop strings that cannot possibly be a credential.
+    const res = await postOauth("Bearer ctx7sk-7504e73e-dfcf-449f-b19f-f6f8285c4b3c");
+    expect(res.status).toBe(200);
+    await res.body?.cancel();
+  });
+
+  test("anonymous /mcp endpoint is unaffected by the gate", async () => {
+    const res = await fetch(httpUrl, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+      },
+      body: INITIALIZE_BODY,
+    });
+    expect(res.status).toBe(200);
+    await res.body?.cancel();
+  });
+});


### PR DESCRIPTION
Two resource-server fixes from an OAuth audit.

- The Clerk verification path passed only `issuer` to `jwtVerify`, so any JWT that instance signs for any purpose verified against this server. The EMA and Entra paths already check audience; this brings the Clerk path in line with them and with the MCP spec, which requires a resource server to accept only tokens issued for itself.
- `/mcp/oauth` returned 401 with no credential but accepted any value that did not parse as a JWT, so `Authorization: Bearer anything` opened a session on the endpoint that advertises authentication. Confirmed against production before the fix: that request returned HTTP 200 with a session id. The upstream still rejected the tool call, so this was never data access, but it let unauthenticated callers create session records. Credentials must now look like a JWT or an API key; the key itself is still verified upstream.

Impact on the audience fix is currently limited because Clerk OAuth access tokens are opaque (`oat_`) and never reach that branch, so only session JWTs did, and those already failed upstream. It is a latent audience-confusion bug rather than a live one, which is why it is a small change.

55 tests pass in the package, lint, format and typecheck clean across the monorepo.

Companion PR for the authorization server: upstash/context7app#837