### PR TITLE
fix: set isError on failed query-docs results

### DIFF
--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -303,6 +303,10 @@ Do not call this tool more than 3 times per question.`,
             text: response.data,
           },
         ],
+        // Flag failures at the protocol level. Without this an unset `isError`
+        // defaults to success, so a caller that branches on `isError` treats an
+        // error message (invalid ID, library not found) as documentation.
+        ...(response.isError ? { isError: true } : {}),
       };
     }
   );

--- a/packages/mcp/src/lib/api.ts
+++ b/packages/mcp/src/lib/api.ts
@@ -157,7 +157,7 @@ export async function fetchLibraryContext(
     if (!response.ok) {
       const errorMessage = await parseErrorResponse(response, context.apiKey);
       console.error(errorMessage);
-      return { data: errorMessage };
+      return { data: errorMessage, isError: true };
     }
 
     const text = await response.text();
@@ -170,6 +170,6 @@ export async function fetchLibraryContext(
   } catch (error) {
     const errorMessage = `Error fetching library context. Please try again later. ${error}`;
     console.error(errorMessage);
-    return { data: errorMessage };
+    return { data: errorMessage, isError: true };
   }
 }

--- a/packages/mcp/src/lib/types.ts
+++ b/packages/mcp/src/lib/types.ts
@@ -30,6 +30,12 @@ export type ContextRequest = {
 
 export type ContextResponse = {
   data: string;
+  /**
+   * True when `data` is an error message rather than documentation, so the
+   * caller can surface it as a tool error (`isError: true`) instead of letting
+   * it default to a successful result.
+   */
+  isError?: boolean;
 };
 
 export interface ClientContext {

--- a/packages/mcp/test/api.test.ts
+++ b/packages/mcp/test/api.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { fetchLibraryContext } from "../src/lib/api.js";
+
+// fetchLibraryContext calls global fetch; stub it per case.
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function stubFetch(response: Partial<Response> & { ok: boolean }) {
+  // fetchLibraryContext reads response.headers (auth-prompt signal), so every
+  // stub needs a real Headers object.
+  const full = { headers: new Headers(), ...response } as Response;
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => full)
+  );
+}
+
+describe("fetchLibraryContext", () => {
+  test("flags a non-ok API response as an error", async () => {
+    // A failed lookup (e.g. 404 for a nonexistent library) must be marked so
+    // the tool result can set isError:true instead of defaulting to success.
+    stubFetch({
+      ok: false,
+      status: 404,
+      json: async () => ({ message: "Library not found." }),
+    });
+
+    const result = await fetchLibraryContext({ query: "q", libraryId: "/no/such-lib" });
+    expect(result.isError).toBe(true);
+    expect(result.data).toBe("Library not found.");
+  });
+
+  test("flags a network failure as an error", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("network down");
+      })
+    );
+
+    const result = await fetchLibraryContext({ query: "q", libraryId: "/vercel/next.js" });
+    expect(result.isError).toBe(true);
+    expect(result.data).toContain("Error fetching library context");
+  });
+
+  test("does not flag a successful documentation response", async () => {
+    stubFetch({
+      ok: true,
+      status: 200,
+      text: async () => "# Some real documentation",
+    });
+
+    const result = await fetchLibraryContext({ query: "q", libraryId: "/vercel/next.js" });
+    expect(result.isError).toBeUndefined();
+    expect(result.data).toBe("# Some real documentation");
+  });
+});


### PR DESCRIPTION
## Problem

`query-docs` returns its result without setting `isError`, even when the call failed. Per the MCP schema an unset `isError` is *"assumed to be false (the call was successful)"*, so a client that branches on `isError` treats an error message as documentation.

Two paths reproduce it (both `@upstash/context7-mcp@3.2.5`, over stdio):

query-docs({ libraryId: "probe", query: "..." })
→ "Invalid library ID format: "probe". Expected format: /owner/repo ..."   (isError unset)

query-docs({ libraryId: "/nonexistent/does-not-exist-xyz", query: "..." })
→ "Library "/nonexistent/does-not-exist-xyz" not found. Please check the library ID ..."   (isError unset)

The second case matters most: the ID is well-formed, so this is not a "bad input" artifact — a genuine not-found response is reported as success. An agent that checks `isError` sees success and feeds "not found" back to the model as if it were docs.

The cause is in `fetchLibraryContext`: every failure path (`!response.ok`, and the `catch`) returns `{ data: errorMessage }` with no way for the caller to tell it apart from a real document, and the `query-docs` handler always builds a result without `isError`.

## Fix

- `ContextResponse` gains an optional `isError` flag.
- `fetchLibraryContext` sets `isError: true` on its failure returns (non-ok response, thrown fetch). The `data` text is unchanged.
- The `query-docs` handler forwards it: `...(response.isError ? { isError: true } : {})`.

The empty-body branch (`"Documentation not found or not finalized ..."`) is deliberately left as-is — it can be a legitimate not-yet-finalized state rather than a hard error.

The [spec](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#error-handling) classifies API failures and invalid input as *tool execution errors*, reported with `isError: true`, *"otherwise, the LLM would not be able to see that an error occurred and self-correct."*

## Verification

Added `packages/mcp/test/api.test.ts` covering all three paths (non-ok → flagged, thrown fetch → flagged, success → not flagged). Full `packages/mcp` suite passes (49
tests), lint and format clean.

Built the server and re-probed both cases end to end:

| | before | after |
|---|---|---|
| `query-docs` with a bad / nonexistent id | `isError` unset (reads as `resolve-library-id` has the same shape (returns its error text withoutup in a separate PR to keep this one focused.