### PR TITLE
Add hyperlink in Documentation for user creation of API key in browser

### DIFF
--- a/docs/howto/api-keys.mdx
+++ b/docs/howto/api-keys.mdx
@@ -13,7 +13,7 @@ API keys authenticate your requests to Context7's documentation services. Create
 
 <Steps>
   <Step title="Open the create dialog">
-    Click **Create API Key** in the API Keys card located
+    Click **Create API Key** in the API Keys card.
   </Step>
   <Step title="Name the key">
     Enter a name (optional but recommended). Descriptive names like "Cursor", "Claude", "VS Code", or "Devin Desktop" help you identify the key later.

--- a/docs/howto/api-keys.mdx
+++ b/docs/howto/api-keys.mdx
@@ -3,7 +3,7 @@ title: Manage API Keys
 description: Create and manage API keys for Context7 authentication
 ---
 
-API keys authenticate your requests to Context7's documentation services. Create your key [Here](https://context7.com/dashboard)
+API keys authenticate your requests to Context7's documentation services. You can create one in the [Context7 dashboard](https://context7.com/dashboard).
 
 ## Managing API Keys
 

--- a/docs/howto/api-keys.mdx
+++ b/docs/howto/api-keys.mdx
@@ -3,7 +3,7 @@ title: Manage API Keys
 description: Create and manage API keys for Context7 authentication
 ---
 
-API keys authenticate your requests to Context7's documentation services.
+API keys authenticate your requests to Context7's documentation services. Create your key [Here](https://context7.com/dashboard)
 
 ## Managing API Keys
 
@@ -13,7 +13,7 @@ API keys authenticate your requests to Context7's documentation services.
 
 <Steps>
   <Step title="Open the create dialog">
-    Click **Create API Key** in the API Keys card.
+    Click **Create API Key** in the API Keys card located
   </Step>
   <Step title="Name the key">
     Enter a name (optional but recommended). Descriptive names like "Cursor", "Claude", "VS Code", or "Devin Desktop" help you identify the key later.


### PR DESCRIPTION
added hyperlink to documentation for user generation of API key to link directly to the Dashboard page where the key creation exists at in broser.