### PR TITLE
docs: correct non-root image version floor to 1.3.2

### DIFF
--- a/docs/enterprise/deployment/docker.mdx
+++ b/docs/enterprise/deployment/docker.mdx
@@ -143,7 +143,7 @@ docker run -d --name context7 \
 
 Any UID works. Everything Context7 writes lives under `/data`, including source clones (`/data/repos`) and documentation-agent state (`/data/home`). The only other path it writes is `/tmp`.
 
-Skip the `chown` and the server exits at startup with the path it could not write. This requires image 1.4.0 or later. On Kubernetes, use `fsGroup` instead and the kubelet handles the ownership: see [Kubernetes](/enterprise/deployment/kubernetes#running-as-non-root).
+Skip the `chown` and the server exits at startup with the path it could not write. This requires image 1.3.2 or later. On Kubernetes, use `fsGroup` instead and the kubelet handles the ownership: see [Kubernetes](/enterprise/deployment/kubernetes#running-as-non-root).
 
 ## Scaling
 

--- a/docs/enterprise/deployment/kubernetes.mdx
+++ b/docs/enterprise/deployment/kubernetes.mdx
@@ -234,7 +234,7 @@ The container runs as root by default, so existing deployments are unaffected. S
 </Warning>
 
 <Note>
-  This requires image version 1.4.0 or later. Earlier images keep source clones on a root-owned layer inside the image, so a non-root UID starts normally but fails on the first parse.
+  This requires image version 1.3.2 or later. Earlier images keep source clones on a root-owned layer inside the image, so a non-root UID starts normally but fails on the first parse.
 </Note>
 
 If the volume is not writable by the UID you choose, the server exits at startup naming the offending paths rather than failing later:


### PR DESCRIPTION
The non-root support shipped in 1.3.2, not 1.4.0 as the pages state. Corrects both deployment guides.