### PR TITLE
Use the SDK default responseMode instead of forcing sse

### DIFF
--- a/.changeset/mcp-response-mode-auto.md
+++ b/.changeset/mcp-response-mode-auto.md
@@ -1,0 +1,7 @@
+---
+"@upstash/context7-mcp": patch
+---
+
+Stop forcing `responseMode: "sse"` on the HTTP handler and use the SDK default `"auto"` instead. Forcing `"sse"` put every response on an SSE stream, and those streams were not released: concurrent upstream streams went from ~10 before v4.0.0 to over 5000, exhausting the gateway connection pool and returning 503 `reset reason: overflow` on `mcp.context7.com`. Traffic and latency were unchanged over that period, so the growth was not load.
+
+With `"auto"` a request is answered with a single JSON body unless a handler emits a related message before its result, which upgrades that one exchange to SSE. No tool emits progress today, so modern-protocol responses are now plain JSON. The 2025-era legacy fallback is constructed without a `responseMode` and still streams over SSE, so it is unaffected.

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -365,14 +365,7 @@ async function main() {
     // no session store. The handler serves modern (2026-07-28) traffic natively
     // and 2025-era traffic through its stateless legacy fallback, which answers
     // GET/DELETE (session operations) with 405.
-    //
-    // responseMode "sse" keeps responses streaming: headers flush immediately
-    // after parsing the request rather than buffering until the tool returns.
-    // This is required for long-running tools because some MCP HTTP clients cap
-    // the underlying fetch at 60s waiting for headers, even though the per-tool
-    // timeout is much higher.
     const mcpHandler = createMcpHandler(() => createMcpServer(), {
-      responseMode: "sse",
       onerror: (error) => console.error("MCP handler error:", error),
     });
     // Without onerror, request-conversion / handler.fetch throws are answered


### PR DESCRIPTION
Fixes the stream leak behind today's `mcp.context7.com` outage (503 `reset reason: overflow`, response flag `UO`), which also broke customer OAuth logins and ChatGPT `query-docs` calls.

- Drop `responseMode: "sse"` from `createMcpHandler`, falling back to the SDK default `"auto"`

### Why

Forcing `"sse"` put **every** response on an SSE stream, and those streams were not released. Envoy metrics show the regression landing exactly with the v4.0.0 deploy:

| | before v4.0.0 | after |
|---|---|---|
| Concurrent upstream streams | **5-14** | 333 -> 5,477 |
| Request rate | ~834/s | ~800/s (unchanged) |
| Mean latency | ~13ms | ~10ms (unchanged) |

Traffic and latency are flat across the window, so this is not load. Little's Law puts healthy concurrency at 834 req/s x 13.4ms = **11 streams**, matching the ~10 observed before the deploy. The ReplicaSet timeline pins it: `mcp-7586c55cd5` (v4.0.0) created `2026-08-07T08:58:41Z`, and concurrency jumps in the very next sample and never recovers.

Connections climbed until they hit Envoy's 1024 default cap around 09:00 on 08/11, after which requests were rejected -- including `/ping`, which is why the healthcheck fired.

Per the SDK, `"auto"` answers with a single JSON body and upgrades to SSE only when a handler emits a related message before its result. Nothing here emits progress, so every response becomes JSON.

### Doesn't this break the header flush the old comment described?

No. The removed comment justified `"sse"` by saying some MCP HTTP clients cap the underlying fetch at 60s waiting for headers. Measured against production, that scenario does not occur:

| Slower than | Requests | Window |
|---|---|---|
| 10s | 202 | 62,713,594 |
| 30s | **0** | 62,713,594 |
| 60s | **0** | 62,713,594 |

Zero requests over 30s in 62.7M, on a clean pre-outage day (08/09-08/10). The `>60s` tail is 0.0000% on every day from 08/05 through 08/10 and appears only on 08/11, during the outage itself -- those are requests stalled in Envoy's pending queue, i.e. the symptom, not a pre-existing need. Mean latency is ~11ms every normal day versus 1917ms during the incident.

The tools are vector queries, not long-running work, so early header flush was protecting against something that never happens.

### Verified locally against a running server

- Modern (2026-07-28) requests now return `content-type: application/json` (previously `text/event-stream`)
- `tools/list`, `resolve-library-id`, `query-docs` all dispatch and reach the backend
- `/ping` healthy; typecheck, eslint, prettier clean

### Known limitation

The 2025-era legacy fallback is constructed as:

```js
createLegacyStatelessFallback(factory, reportError, options.keepAliveMs)
```

It never receives `responseMode`, so **legacy requests still stream over SSE**. Confirmed locally: a request without the `2026-07-28` `_meta` still returns `text/event-stream`. This change therefore only helps modern-protocol clients, and the share of prod traffic still on the 2025 protocol is unknown.

I was also unable to reproduce the leak locally (curl closes its own connections rather than pooling them like Envoy), so this is not proof the leak is gone -- only that the streaming path is removed for modern traffic.

### How to verify after deploy

Watch `sum(envoy_cluster_upstream_rq_active{envoy_cluster_name="httproute/default/mcp/rule/0"})`. Target is **~10-20**, the pre-08/07 baseline, not merely "stops growing". If it settles in the hundreds, the legacy path is carrying enough traffic to matter and needs a follow-up.

Gateway-side mitigation (raised connection cap, 1200s stream lifetime) shipped separately in upstash/context7parser#655 and stays in place as a backstop.