### PR TITLE
Bound Context7 API calls with an abort signal

### DIFF
--- a/.changeset/mcp-api-fetch-timeout.md
+++ b/.changeset/mcp-api-fetch-timeout.md
@@ -1,0 +1,5 @@
+---
+"@upstash/context7-mcp": patch
+---
+
+Add a 60s `AbortSignal.timeout()` to both Context7 API calls in `lib/api.ts`. Without a signal a stalled backend call rides undici's ~300s default before failing. 60s is generous: these are vector queries with p99.9 ~3.2s, and no request exceeded 30s across a full day of production traffic.

--- a/packages/mcp/src/lib/api.ts
+++ b/packages/mcp/src/lib/api.ts
@@ -6,6 +6,14 @@ import { readFileSync } from "fs";
 import tls from "tls";
 
 /**
+ * Ceiling on a single Context7 API call. Without a signal a stalled backend
+ * call rides undici's ~300s default before failing. 60s is generous for these
+ * vector queries: p99.9 is ~3.2s, and no request exceeded 30s across a full
+ * day of production traffic.
+ */
+const API_TIMEOUT_MS = 60_000;
+
+/**
  * Parses error response from the Context7 API
  * Extracts the server's error message, falling back to status-based messages if parsing fails
  * @param response The fetch Response object
@@ -119,7 +127,7 @@ export async function searchLibraries(
 
     const headers = generateHeaders(context);
 
-    const response = await fetch(url, { headers });
+    const response = await fetch(url, { headers, signal: AbortSignal.timeout(API_TIMEOUT_MS) });
     readPromptSignal(response, context);
     if (!response.ok) {
       const errorMessage = await parseErrorResponse(response, context.apiKey);
@@ -152,7 +160,7 @@ export async function fetchLibraryContext(
 
     const headers = generateHeaders(context);
 
-    const response = await fetch(url, { headers });
+    const response = await fetch(url, { headers, signal: AbortSignal.timeout(API_TIMEOUT_MS) });
     readPromptSignal(response, context);
     if (!response.ok) {
       const errorMessage = await parseErrorResponse(response, context.apiKey);


### PR DESCRIPTION
Bound both Context7 API calls with an explicit 60s `AbortSignal.timeout()`.

- Without a signal, a stalled backend call rides undici's ~300s implicit default before failing. Now it fails at 60s with a logged, proper JSON-RPC error result.
- 60s is generous: these are vector queries, p99.9 ~3.2s, zero requests over 30s in 62.7M/day.
- Pairs with #3019: with tool silence capped at 60s, legitimate SSE exchanges stay 5x clear of the gateway's 300s `streamIdleTimeout` while hung ones get reaped. Merge together.

Verified against a backend that accepts connections and never responds: before, `tools/call` stalled ~300s before erroring; after, it returns a JSON-RPC error result at 60s and logs it. Happy path unaffected; typecheck, eslint, prettier clean.

(Originally framed as the outage root cause — it is not; the leak mechanism and fix are in #3019. This PR makes backend stalls fast, visible, and deliberate instead of slow, silent, and implicit.)