### PR TITLE
Disable SSE keepalives so hung exchanges are reapable

### DIFF
--- a/.changeset/mcp-drop-self-cancellations.md
+++ b/.changeset/mcp-drop-self-cancellations.md
@@ -1,0 +1,5 @@
+---
+"@upstash/context7-mcp": patch
+---
+
+Disable SSE keepalive heartbeats on the HTTP handler (`keepAliveMs: 0`). Every tool is a millisecond vector query, so no legitimate exchange needs a heartbeat — but a hung exchange kept alive by heartbeats can never be reaped by a proxy's stream idle timeout. One such hang is deterministic: a 2025-era JSON-RPC batch carrying a request plus its own `notifications/cancelled` gets no response for the cancelled request (per spec), the SDK transport then never closes the stream, and heartbeats kept it alive until the gateway's 1200s hard cap — the dominant source of leaked upstream connections in the 2026-08-11 mcp.context7.com outage. With heartbeats off, silent hangs go idle and the proxy reaps them at its idle timeout.

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -365,7 +365,17 @@ async function main() {
     // no session store. The handler serves modern (2026-07-28) traffic natively
     // and 2025-era traffic through its stateless legacy fallback, which answers
     // GET/DELETE (session operations) with 405.
+    // keepAliveMs: 0 disables SSE keepalive heartbeats. Every tool here is a
+    // millisecond vector query (p100 ~28s), so no legitimate exchange needs a
+    // heartbeat to stay alive — but a hung exchange kept "alive" by heartbeats
+    // can never be reaped by the gateway's stream idle timeout. A batch
+    // carrying a request plus its own notifications/cancelled produces exactly
+    // that: per spec the cancelled request gets no response, the SDK transport
+    // then never closes the stream, and with heartbeats it survived until the
+    // gateway's 1200s hard cap (the 2026-08-11 outage). Silent hangs instead
+    // go idle and the gateway reaps them at streamIdleTimeout (300s).
     const mcpHandler = createMcpHandler(() => createMcpServer(), {
+      keepAliveMs: 0,
       onerror: (error) => console.error("MCP handler error:", error),
     });
     // Without onerror, request-conversion / handler.fetch throws are answered


### PR DESCRIPTION
Deterministic reproduction and a one-line fix for the stream leak behind the 2026-08-11 `mcp.context7.com` outage.

- `keepAliveMs: 0` on `createMcpHandler` — no SSE heartbeats

### The bug, reproduced

```
POST /mcp  [{"id":1,"method":"tools/call",...}, {"method":"notifications/cancelled","params":{"requestId":1}}]
-> 200, headers flushed, ": keepalive" every 15s, stream NEVER terminates
```

Both orderings hang. Per the spec a cancelled request receives **no response**, and the SDK protocol layer honors that — but the legacy stateless transport closes the POST's SSE stream only once **every request in it has been answered**. The accounting never completes. Nothing throws, nothing logs.

This matches the production fingerprint exactly: ~5,200 held streams vs ~12 predicted by Little's Law, sockets idle with empty tx/rx queues, and 100% of hangs ending via the gateway's 1200s hard cap (4.38/s reaps vs 4.36/s implied hang rate).

### Why the fix is heartbeats, not body filtering

The heartbeats are what made the hang unreapable: a hung exchange emitting `: keepalive` every 15s never looks idle, so the gateway's `streamIdleTimeout` (300s, deployed in upstash/context7parser#655) can never fire — only the 1200s hard cap ever reaped these.

No legitimate exchange here needs a heartbeat: every tool is a millisecond vector query (p50 ~3ms, p100 ~28s, **zero** requests over 30s in 62.7M/day). The only streams the heartbeats were keeping alive were dead ones. With them off, the whole class of silent hangs — not just the cancellation shape — goes idle and the existing gateway timeout reaps it within 5 minutes.

This is also exactly why v1 never blew up despite hanging on the identical batch (verified against a v3.2.4 build): v1 sent **no keepalives** on the hung stream, so proxy idle timeouts self-healed it. v2's heartbeats made hangs immortal; this restores the v1 dynamics deliberately.

### Validation

| Check | Result |
|---|---|
| Cancel-batch hang, 35s observation | **0 bytes emitted** (was: keepalive every 15s) |
| Gateway idle-reap of silent streams | proven on local Envoy Gateway v1.8.1: silent stream cut at the idle timeout; heartbeating stream never |
| `tools/call`, `[req,req]` batches, modern-era requests | unchanged |
| typecheck / eslint / prettier | clean |

### Expected effect after deploy

Steady-state leaked streams drop from ~5,200 (4.4/s x 1200s) to ~1,300 (4.4/s x 300s), each living <=5min, with headroom to tighten `streamIdleTimeout` further in the httproute we own. `sum(envoy_cluster_upstream_rq_active{envoy_cluster_name="httproute/default/mcp/rule/0"})` is the pass/fail metric.

### The real fix lives upstream

The SDK's stream-close accounting should treat cancelled requests as settled. Issue to be filed with the repro (related: modelcontextprotocol/typescript-sdk#2648, #2559). Until then this change makes the failure self-healing at the infrastructure layer instead of self-concealing.