### PR TITLE
feat(cli): add `context7` bin alias and `ctx7 add` library submit

### DIFF
--- a/.changeset/cli-context7-alias-and-add.md
+++ b/.changeset/cli-context7-alias-and-add.md
@@ -1,0 +1,5 @@
+---
+"ctx7": minor
+---
+
+Add a memorable `context7` binary alias alongside `ctx7`, and introduce `ctx7 add` to submit GitHub repositories for documentation indexing (stable `--json` output and script-friendly exit codes).

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Always use Context7 when I need library/API documentation, code generation, setu
 
 - `ctx7 library <name> <query>`: Searches the Context7 index by library name and returns matching libraries with their IDs.
 - `ctx7 docs <libraryId> <query>`: Retrieves documentation for a library using a Context7-compatible library ID (e.g., `/mongodb/docs`, `/vercel/next.js`).
+- `ctx7 add <repo>`: Submits a GitHub repository for documentation indexing (also available as `context7 add`). Requires login or `CONTEXT7_API_KEY`.
 
 ### MCP Tools
 

--- a/docs/clients/cli.mdx
+++ b/docs/clients/cli.mdx
@@ -3,12 +3,15 @@ title: CLI
 description: The ctx7 CLI — fetch library documentation and configure Context7 MCP from your terminal
 ---
 
-The `ctx7` CLI is the command-line interface for Context7. It does two things:
+The `ctx7` CLI is the command-line interface for Context7. It does three things:
 
 - **Fetch library documentation** — resolve any library by name and query its up-to-date docs directly in your terminal, without opening a browser
+- **Submit libraries for indexing** — add a missing GitHub repository so agents can close the loop when docs are not yet in Context7
 - **Configure your AI coding agent** — set up the Context7 MCP server (or a CLI-based `docs` skill) for Claude Code, Cursor, OpenCode, and more with a single command
 
 The CLI is useful both as a standalone tool (fetching docs while you code) and as a setup utility (wiring up Context7 for your AI coding agent).
+
+After a global install, both `ctx7` and `context7` resolve to the same entrypoint (the npm package name remains `ctx7` because `context7` is taken on npm by an unrelated package).
 
 ## Installation
 
@@ -20,18 +23,20 @@ Requires Node.js 18 or later.
 
     ```bash
     npx ctx7 --help
+    npx context7 --help
     npx ctx7 library react
     ```
 
   </Tab>
   <Tab title="Global install">
-    Install globally for faster access — no `npx` prefix needed on every command.
+    Install globally for faster access — no `npx` prefix needed on every command. Installs both the `ctx7` and `context7` commands.
 
     ```bash
     npm install -g ctx7
 
     # Verify installation
     ctx7 --version
+    context7 --version
     ```
 
   </Tab>
@@ -99,6 +104,52 @@ ctx7 docs /facebook/react "How to use hooks for state management" --json
 # Pipe to other tools — output is clean when not in a TTY (no spinners or colors)
 ctx7 docs /facebook/react "How to use hooks for state management" | head -50
 ctx7 docs /vercel/next.js "How to add middleware for route protection" | grep -A 10 "middleware"
+```
+
+---
+
+## Submit a Library
+
+When a library is missing from Context7, submit its public GitHub repository for indexing. This is the CLI façade over the [Add Library API](/api-reference/add-library/add-a-github-repository) — useful for agents that discover missing docs while browsing.
+
+### ctx7 add
+
+```bash
+# Accepts owner/repo, HTTPS, or SSH URLs
+ctx7 add vercel/next.js
+ctx7 add https://github.com/vercel/next.js
+ctx7 add git@github.com:vercel/next.js.git
+
+# Same command via the memorable alias
+context7 add vercel/next.js
+
+# Stable JSON for scripts and agents
+ctx7 add owner/repo --json
+
+# Private repositories (requires a plan that supports private libraries)
+ctx7 add owner/private-repo --private --git-token ghp_xxx
+ctx7 add owner/private-repo --private --generate-docs
+```
+
+Authentication is required: run `ctx7 login` first, or set `CONTEXT7_API_KEY`.
+
+| Exit code | Meaning                                              |
+| --------- | ---------------------------------------------------- |
+| **0**     | Submitted successfully                               |
+| **1**     | Validation error or other client/server failure      |
+| **2**     | Authentication required or invalid API key           |
+| **3**     | Duplicate repository (already indexed / in team)     |
+| **4**     | Rate limited                                         |
+
+JSON success shape:
+
+```json
+{
+  "libraryName": "/owner/repo",
+  "message": "Repository submitted successfully",
+  "docsRepoUrl": "https://github.com/owner/repo",
+  "status": 200
+}
 ```
 
 ---
@@ -221,6 +272,7 @@ export CONTEXT7_API_KEY=your_key
 | Feature                                                  | Required                                                                     |
 | -------------------------------------------------------- | ---------------------------------------------------------------------------- |
 | `ctx7 library` / `ctx7 docs`                             | No — login gives higher rate limits                                          |
+| `ctx7 add`                                               | Yes — `ctx7 login` or `CONTEXT7_API_KEY`                                     |
 | `ctx7 setup`                                             | Yes — unless `--api-key` is passed (`--oauth` also skips login for MCP mode) |
 
 ---

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -7,8 +7,10 @@ CLI for [Context7](https://context7.com) - query up-to-date library documentatio
 ```bash
 # Run directly with npx (no install needed)
 npx ctx7
+# Alias (same entrypoint):
+npx context7
 
-# Or install globally
+# Or install globally — installs both `ctx7` and `context7` commands
 npm install -g ctx7
 ```
 
@@ -37,6 +39,10 @@ ctx7 library nextjs "app router"
 # Get documentation
 ctx7 docs /facebook/react "useEffect cleanup"
 ctx7 docs /vercel/next.js "middleware"
+
+# Submit a GitHub repo for indexing (requires login or CONTEXT7_API_KEY)
+ctx7 add vercel/next.js
+context7 add https://github.com/vercel/next.js --json
 ```
 
 ## Usage
@@ -66,6 +72,24 @@ ctx7 docs /prisma/prisma "one-to-many relations"
 # Output as JSON
 ctx7 docs /facebook/react "hooks" --json
 ```
+
+### Submit a library
+
+Submit a public GitHub repository for documentation indexing. Requires authentication (`ctx7 login` or `CONTEXT7_API_KEY`).
+
+```bash
+ctx7 add vercel/next.js
+ctx7 add https://github.com/vercel/next.js
+ctx7 add git@github.com:vercel/next.js.git
+
+# Stable JSON for agents/scripts
+ctx7 add owner/repo --json
+
+# Private repo (requires token + plan that supports private libraries)
+ctx7 add owner/private-repo --private --git-token ghp_xxx
+```
+
+Exit codes: `0` success, `1` validation/other error, `2` auth required, `3` duplicate, `4` rate limited.
 
 ### Setup
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -4,7 +4,8 @@
   "description": "Context7 CLI - Fetch documentation context and configure Context7",
   "type": "module",
   "bin": {
-    "ctx7": "./dist/index.js"
+    "ctx7": "./dist/index.js",
+    "context7": "./dist/index.js"
   },
   "files": [
     "dist"

--- a/packages/cli/src/__tests__/add-command.test.ts
+++ b/packages/cli/src/__tests__/add-command.test.ts
@@ -1,0 +1,174 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import { Command } from "commander";
+
+const mockGetValidAccessToken = vi.fn();
+vi.mock("../utils/auth.js", () => ({
+  getValidAccessToken: (...args: unknown[]) => mockGetValidAccessToken(...args),
+}));
+
+const mockAddGitHubRepository = vi.fn();
+vi.mock("../utils/api.js", () => ({
+  addGitHubRepository: (...args: unknown[]) => mockAddGitHubRepository(...args),
+  getBaseUrl: () => "https://test.context7.com",
+}));
+
+vi.mock("../utils/tracking.js", () => ({ trackEvent: vi.fn() }));
+
+const mockSpinner = {
+  start: vi.fn().mockReturnThis(),
+  stop: vi.fn().mockReturnThis(),
+  succeed: vi.fn().mockReturnThis(),
+  fail: vi.fn().mockReturnThis(),
+  warn: vi.fn().mockReturnThis(),
+  text: "",
+};
+vi.mock("ora", () => ({ default: () => mockSpinner }));
+
+import {
+  registerAddCommand,
+  normalizeGitHubRepoUrl,
+  exitCodeForAddFailure,
+} from "../commands/add.js";
+
+const TOKEN = "test-token";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetValidAccessToken.mockResolvedValue(TOKEN);
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  process.exitCode = undefined;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  process.exitCode = undefined;
+});
+
+async function run(...args: string[]): Promise<void> {
+  const program = new Command();
+  program.exitOverride();
+  registerAddCommand(program);
+  await program.parseAsync(["node", "test", ...args]);
+}
+
+describe("normalizeGitHubRepoUrl", () => {
+  test.each([
+    ["vercel/next.js", "https://github.com/vercel/next.js"],
+    ["https://github.com/vercel/next.js", "https://github.com/vercel/next.js"],
+    ["https://github.com/vercel/next.js.git", "https://github.com/vercel/next.js"],
+    ["http://github.com/vercel/next.js", "https://github.com/vercel/next.js"],
+    ["git@github.com:vercel/next.js.git", "https://github.com/vercel/next.js"],
+    ["github.com/vercel/next.js", "https://github.com/vercel/next.js"],
+    ["https://github.com/vercel/next.js/tree/canary", "https://github.com/vercel/next.js"],
+  ])("%s → %s", (input, expected) => {
+    expect(normalizeGitHubRepoUrl(input)).toBe(expected);
+  });
+
+  test.each(["", "not-a-repo", "https://gitlab.com/a/b", "https://github.com/only-owner"])(
+    "rejects %s",
+    (input) => {
+      expect(normalizeGitHubRepoUrl(input)).toBeNull();
+    }
+  );
+});
+
+describe("exitCodeForAddFailure", () => {
+  test("maps auth, duplicate, and rate-limit statuses", () => {
+    expect(exitCodeForAddFailure(401, "invalid_api_key")).toBe(2);
+    expect(exitCodeForAddFailure(409, "duplicate_repo")).toBe(3);
+    expect(exitCodeForAddFailure(429, "rate_limit_exceeded")).toBe(4);
+    expect(exitCodeForAddFailure(500, "internal_error")).toBe(1);
+  });
+});
+
+describe("ctx7 add", () => {
+  test("submits a normalized repo URL with a refreshed token", async () => {
+    mockAddGitHubRepository.mockResolvedValue({
+      ok: true,
+      status: 200,
+      libraryName: "/vercel/next.js",
+      message: "Repository submitted successfully",
+    });
+
+    await run("add", "vercel/next.js");
+
+    expect(mockGetValidAccessToken).toHaveBeenCalled();
+    expect(mockAddGitHubRepository).toHaveBeenCalledWith(
+      { docsRepoUrl: "https://github.com/vercel/next.js" },
+      TOKEN
+    );
+    expect(process.exitCode).toBe(0);
+  });
+
+  test("emits stable JSON on success", async () => {
+    mockAddGitHubRepository.mockResolvedValue({
+      ok: true,
+      status: 200,
+      libraryName: "/vercel/next.js",
+      message: "Repository submitted successfully",
+    });
+
+    await run("add", "https://github.com/vercel/next.js", "--json");
+
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining('"libraryName": "/vercel/next.js"')
+    );
+    expect(process.exitCode).toBe(0);
+  });
+
+  test("rejects invalid repo input without calling the API", async () => {
+    await run("add", "not-valid");
+
+    expect(mockAddGitHubRepository).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
+  test("maps duplicate_repo to exit code 3", async () => {
+    mockAddGitHubRepository.mockResolvedValue({
+      ok: false,
+      status: 409,
+      error: "duplicate_repo",
+      message: "This private repository is already in your team",
+    });
+
+    await run("add", "owner/repo", "--json");
+
+    expect(process.exitCode).toBe(3);
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('"error": "duplicate_repo"'));
+  });
+
+  test("maps unauthorized to exit code 2", async () => {
+    mockGetValidAccessToken.mockResolvedValue(undefined);
+    mockAddGitHubRepository.mockResolvedValue({
+      ok: false,
+      status: 401,
+      error: "unauthorized",
+      message: "Authentication required.",
+    });
+
+    await run("add", "owner/repo");
+
+    expect(process.exitCode).toBe(2);
+  });
+
+  test("forwards private/git-token flags", async () => {
+    mockAddGitHubRepository.mockResolvedValue({
+      ok: true,
+      status: 200,
+      libraryName: "/owner/private-repo",
+      message: "ok",
+    });
+
+    await run("add", "owner/private-repo", "--private", "--git-token", "ghp_test");
+
+    expect(mockAddGitHubRepository).toHaveBeenCalledWith(
+      {
+        docsRepoUrl: "https://github.com/owner/private-repo",
+        private: true,
+        gitToken: "ghp_test",
+      },
+      TOKEN
+    );
+  });
+});

--- a/packages/cli/src/__tests__/command-auth-wiring.test.ts
+++ b/packages/cli/src/__tests__/command-auth-wiring.test.ts
@@ -13,10 +13,12 @@ vi.mock("../utils/auth.js", () => ({
 const mockResolveLibrary = vi.fn();
 const mockGetLibraryContext = vi.fn();
 const mockSuggestSkills = vi.fn();
+const mockAddGitHubRepository = vi.fn();
 vi.mock("../utils/api.js", () => ({
   resolveLibrary: (...args: unknown[]) => mockResolveLibrary(...args),
   getLibraryContext: (...args: unknown[]) => mockGetLibraryContext(...args),
   suggestSkills: (...args: unknown[]) => mockSuggestSkills(...args),
+  addGitHubRepository: (...args: unknown[]) => mockAddGitHubRepository(...args),
   getBaseUrl: () => "https://test.context7.com",
   listProjectSkills: vi.fn(),
   searchSkills: vi.fn(),
@@ -46,6 +48,7 @@ vi.mock("ora", () => ({ default: () => mockSpinner }));
 
 import { registerDocsCommands } from "../commands/docs.js";
 import { registerSkillCommands } from "../commands/skill.js";
+import { registerAddCommand } from "../commands/add.js";
 
 const REFRESHED = "refreshed-token";
 
@@ -100,6 +103,23 @@ describe("commands pass a refreshed token to the API", () => {
 
     expect(mockGetValidAccessToken).toHaveBeenCalled();
     expect(mockSuggestSkills).toHaveBeenCalledWith(["react"], REFRESHED);
+  });
+
+  test("ctx7 add", async () => {
+    mockAddGitHubRepository.mockResolvedValue({
+      ok: true,
+      status: 200,
+      libraryName: "/a/b",
+      message: "ok",
+    });
+
+    await run(registerAddCommand, "add", "a/b");
+
+    expect(mockGetValidAccessToken).toHaveBeenCalled();
+    expect(mockAddGitHubRepository).toHaveBeenCalledWith(
+      { docsRepoUrl: "https://github.com/a/b" },
+      REFRESHED
+    );
   });
 });
 

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -1,0 +1,225 @@
+import { Command } from "commander";
+import pc from "picocolors";
+import ora from "ora";
+
+import { addGitHubRepository } from "../utils/api.js";
+import { getValidAccessToken } from "../utils/auth.js";
+import { log } from "../utils/logger.js";
+import { trackEvent } from "../utils/tracking.js";
+import type { AddLibraryRequest } from "../types.js";
+
+const isTTY = process.stdout.isTTY;
+
+/**
+ * Normalize common GitHub repo inputs into a canonical HTTPS URL.
+ * Accepts:
+ *   - https://github.com/owner/repo(.git)
+ *   - http://github.com/owner/repo
+ *   - git@github.com:owner/repo(.git)
+ *   - owner/repo
+ *   - github.com/owner/repo
+ */
+export function normalizeGitHubRepoUrl(input: string): string | null {
+  const raw = input.trim();
+  if (!raw) return null;
+
+  // git@github.com:owner/repo(.git)
+  const sshMatch = raw.match(/^git@github\.com:([^/]+)\/([^/]+?)(?:\.git)?$/i);
+  if (sshMatch) {
+    return `https://github.com/${sshMatch[1]}/${sshMatch[2]}`;
+  }
+
+  // owner/repo (no protocol/host)
+  const shortMatch = raw.match(/^([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+?)(?:\.git)?$/);
+  if (shortMatch && !raw.includes("://") && !raw.includes("github.com")) {
+    return `https://github.com/${shortMatch[1]}/${shortMatch[2]}`;
+  }
+
+  // http(s)://github.com/... or github.com/...
+  let urlText = raw;
+  if (/^github\.com\//i.test(urlText)) {
+    urlText = `https://${urlText}`;
+  }
+
+  try {
+    const url = new URL(urlText);
+    if (!/^github\.com$/i.test(url.hostname)) {
+      return null;
+    }
+    const parts = url.pathname.split("/").filter(Boolean);
+    if (parts.length < 2) {
+      return null;
+    }
+    const owner = parts[0];
+    const repo = parts[1].replace(/\.git$/i, "");
+    if (!owner || !repo) {
+      return null;
+    }
+    return `https://github.com/${owner}/${repo}`;
+  } catch {
+    return null;
+  }
+}
+
+export interface AddCommandOptions {
+  json?: boolean;
+  private?: boolean;
+  gitToken?: string;
+  skipVersionFiltering?: boolean;
+  generateDocs?: boolean;
+}
+
+/**
+ * Exit codes for scripting:
+ *   0 — submitted successfully
+ *   1 — validation / client / unexpected error
+ *   2 — authentication required or invalid
+ *   3 — duplicate repository (already indexed / already in team)
+ *   4 — rate limited
+ */
+export function exitCodeForAddFailure(status: number, error: string): number {
+  if (status === 401 || error === "unauthorized" || error === "invalid_api_key") {
+    return 2;
+  }
+  if (status === 409 || error === "duplicate_repo") {
+    return 3;
+  }
+  if (status === 429 || error === "rate_limit_exceeded") {
+    return 4;
+  }
+  return 1;
+}
+
+async function addCommand(repoInput: string, options: AddCommandOptions): Promise<void> {
+  trackEvent("command", { name: "add" });
+
+  const docsRepoUrl = normalizeGitHubRepoUrl(repoInput);
+  if (!docsRepoUrl) {
+    const message =
+      `Invalid GitHub repository: "${repoInput}". ` +
+      `Expected https://github.com/owner/repo, git@github.com:owner/repo.git, or owner/repo.`;
+    if (options.json) {
+      console.log(JSON.stringify({ error: "validation_error", message, status: 400 }, null, 2));
+    } else {
+      log.error(message);
+      log.info(`Examples: ${pc.cyan("ctx7 add vercel/next.js")}`);
+      log.info(`          ${pc.cyan("ctx7 add https://github.com/vercel/next.js")}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  const accessToken = await getValidAccessToken();
+  const request: AddLibraryRequest = { docsRepoUrl };
+  if (options.private) request.private = true;
+  if (options.gitToken) request.gitToken = options.gitToken;
+  if (options.skipVersionFiltering) request.skipVersionFiltering = true;
+  if (options.generateDocs) request.generateDocs = true;
+
+  const spinner = isTTY && !options.json ? ora(`Submitting ${docsRepoUrl}...`).start() : null;
+
+  let result;
+  try {
+    result = await addGitHubRepository(request, accessToken);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    spinner?.fail(`Error: ${message}`);
+    if (options.json) {
+      console.log(JSON.stringify({ error: "request_failed", message, status: 0 }, null, 2));
+    } else if (!spinner) {
+      log.error(message);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  if (result.ok) {
+    spinner?.succeed(result.message);
+    if (options.json) {
+      console.log(
+        JSON.stringify(
+          {
+            libraryName: result.libraryName,
+            message: result.message,
+            docsRepoUrl,
+            status: result.status,
+          },
+          null,
+          2
+        )
+      );
+    } else {
+      if (!spinner) log.success(result.message);
+      if (result.libraryName) {
+        log.info(`Library ID: ${pc.cyan(result.libraryName)}`);
+        log.info(`View: ${pc.cyan(`https://context7.com${result.libraryName}`)}`);
+      }
+      log.dim("Indexing can take a few minutes. Refresh later from the dashboard if needed.");
+    }
+    process.exitCode = 0;
+    return;
+  }
+
+  const exitCode = exitCodeForAddFailure(result.status, result.error);
+  spinner?.fail(result.message);
+
+  if (options.json) {
+    console.log(
+      JSON.stringify(
+        {
+          error: result.error,
+          message: result.message,
+          status: result.status,
+          docsRepoUrl,
+        },
+        null,
+        2
+      )
+    );
+  } else if (!spinner) {
+    log.error(result.message);
+  }
+
+  if (!options.json) {
+    if (exitCode === 2) {
+      log.info(`Run ${pc.cyan("ctx7 login")} or set ${pc.cyan("CONTEXT7_API_KEY")}`);
+    } else if (exitCode === 3) {
+      log.info("This repository is already registered with Context7.");
+    } else if (exitCode === 4) {
+      log.info("Rate limit exceeded — try again later.");
+    }
+  }
+
+  process.exitCode = exitCode;
+}
+
+export function registerAddCommand(program: Command): void {
+  program
+    .command("add")
+    .argument("<repo>", "GitHub repository URL or owner/repo")
+    .option("--json", "Output as JSON (stable fields for scripts/agents)")
+    .option("--private", "Mark the repository as private")
+    .option("--git-token <token>", "GitHub personal access token for private repos")
+    .option("--skip-version-filtering", "Skip filtering version-specific documentation pages")
+    .option("--generate-docs", "Generate docs from source (private repos)")
+    .description("Submit a GitHub repository to Context7 for documentation indexing")
+    .addHelpText(
+      "after",
+      `
+Exit codes:
+  0  submitted successfully
+  1  validation or other client/server error
+  2  authentication required or invalid API key
+  3  duplicate repository
+  4  rate limited
+
+Examples:
+  $ ctx7 add vercel/next.js
+  $ ctx7 add https://github.com/vercel/next.js --json
+  $ context7 add owner/repo --private --git-token ghp_xxx
+`
+    )
+    .action(async (repo: string, options: AddCommandOptions) => {
+      await addCommand(repo, options);
+    });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,6 +6,7 @@ import { registerAuthCommands, setAuthBaseUrl } from "./commands/auth.js";
 import { registerSetupCommand } from "./commands/setup.js";
 import { registerRemoveCommand } from "./commands/remove.js";
 import { registerDocsCommands } from "./commands/docs.js";
+import { registerAddCommand } from "./commands/add.js";
 import { maybeShowUpgradeNotice, registerUpgradeCommand } from "./commands/upgrade.js";
 import { setBaseUrl } from "./utils/api.js";
 import { VERSION } from "./constants.js";
@@ -17,9 +18,12 @@ const brand = {
 
 const program = new Command();
 
+// Both `ctx7` and `context7` resolve to this entrypoint (see package.json bin).
 program
   .name("ctx7")
-  .description("Context7 CLI - Fetch documentation context and configure Context7")
+  .description(
+    "Context7 CLI - Fetch documentation context, submit libraries, and configure Context7"
+  )
   .version(VERSION, "-v, --version")
   .option("--base-url <url>")
   .hook("preAction", (thisCommand) => {
@@ -53,6 +57,10 @@ Examples:
   ${brand.dim("# Query library documentation")}
   ${brand.primary('npx ctx7 library react "how to use hooks"')}
   ${brand.primary('npx ctx7 docs /facebook/react "useEffect examples"')}
+
+  ${brand.dim("# Submit a library for indexing (requires login or CONTEXT7_API_KEY)")}
+  ${brand.primary("npx ctx7 add vercel/next.js")}
+  ${brand.primary("npx context7 add https://github.com/vercel/next.js --json")}
 `
   );
 
@@ -62,6 +70,7 @@ registerAuthCommands(program);
 registerSetupCommand(program);
 registerRemoveCommand(program);
 registerDocsCommands(program);
+registerAddCommand(program);
 registerUpgradeCommand(program);
 
 program.action(() => {
@@ -74,9 +83,12 @@ program.action(() => {
   console.log("  Quick start:");
   console.log(`    ${brand.primary("npx ctx7 setup")}`);
   console.log(`    ${brand.primary('npx ctx7 docs /facebook/react "useEffect examples"')}`);
+  console.log(`    ${brand.primary("npx ctx7 add owner/repo")}`);
   console.log("");
 
-  console.log(`  Run ${brand.primary("npx ctx7 --help")} for all commands and options`);
+  console.log(
+    `  Run ${brand.primary("npx ctx7 --help")} (or ${brand.primary("npx context7 --help")}) for all commands and options`
+  );
   console.log("");
 });
 

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -250,3 +250,27 @@ export interface ContextResponse {
   message?: string;
   redirectUrl?: string;
 }
+
+// Add library types
+export interface AddLibraryRequest {
+  docsRepoUrl: string;
+  gitToken?: string;
+  private?: boolean;
+  skipVersionFiltering?: boolean;
+  generateDocs?: boolean;
+}
+
+export interface AddLibrarySuccess {
+  libraryName: string;
+  message: string;
+}
+
+export interface AddLibraryError {
+  error: string;
+  message: string;
+  status: number;
+}
+
+export type AddLibraryResult =
+  | ({ ok: true; status: number } & AddLibrarySuccess)
+  | ({ ok: false } & AddLibraryError);

--- a/packages/cli/src/utils/api.ts
+++ b/packages/cli/src/utils/api.ts
@@ -10,6 +10,8 @@ import type {
   GenerateStreamEvent,
   SkillQuotaResponse,
   ContextResponse,
+  AddLibraryRequest,
+  AddLibraryResult,
 } from "../types.js";
 import { downloadSkillFromGitHub, getSkillFromGitHub } from "./github.js";
 import { VERSION } from "../constants.js";
@@ -358,4 +360,56 @@ export async function getLibraryContext(
   }
 
   return (await response.json()) as ContextResponse;
+}
+
+/**
+ * Submit a public (or private) GitHub repository for documentation indexing.
+ * Requires an API key or login session (`Authorization: Bearer …`).
+ */
+export async function addGitHubRepository(
+  request: AddLibraryRequest,
+  accessToken?: string
+): Promise<AddLibraryResult> {
+  const headers: Record<string, string> = {
+    ...getAuthHeaders(accessToken),
+    "Content-Type": "application/json",
+  };
+
+  if (!headers["Authorization"]) {
+    return {
+      ok: false,
+      status: 401,
+      error: "unauthorized",
+      message:
+        "Authentication required. Run `ctx7 login` or set CONTEXT7_API_KEY before adding a library.",
+    };
+  }
+
+  const response = await fetch(`${baseUrl}/api/v2/add/repo/github`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(request),
+  });
+
+  const body = (await response.json().catch(() => ({}))) as {
+    libraryName?: string;
+    message?: string;
+    error?: string;
+  };
+
+  if (response.ok) {
+    return {
+      ok: true,
+      status: response.status,
+      libraryName: body.libraryName || "",
+      message: body.message || "Repository submitted successfully",
+    };
+  }
+
+  return {
+    ok: false,
+    status: response.status,
+    error: body.error || `http_${response.status}`,
+    message: body.message || `HTTP error ${response.status}`,
+  };
 }

--- a/skills/context7-cli/SKILL.md
+++ b/skills/context7-cli/SKILL.md
@@ -31,6 +31,8 @@ npx ctx7@latest <command>
 # Documentation
 ctx7 library <name> <query>           # Step 1: resolve library ID
 ctx7 docs <libraryId> <query>         # Step 2: fetch docs
+ctx7 add <repo>                       # Submit a GitHub repo for indexing (requires auth)
+context7 add <repo> --json            # Same entrypoint; memorable alias + JSON for agents
 
 # Skills
 ctx7 skills install /owner/repo       # Install from a repo (interactive)
@@ -56,7 +58,7 @@ ctx7 logout              # Clear stored tokens
 ctx7 whoami              # Show current login status (name + email)
 ```
 
-Most commands work without login. Exceptions: `skills generate` always requires it; `ctx7 setup` requires it unless `--api-key` or `--oauth` is passed. Login also unlocks higher rate limits on docs commands.
+Most commands work without login. Exceptions: `skills generate` and `ctx7 add` always require it; `ctx7 setup` requires it unless `--api-key` or `--oauth` is passed. Login also unlocks higher rate limits on docs commands.
 
 Set an API key via environment variable to skip interactive login entirely:
 


### PR DESCRIPTION
## Summary

Addresses parts of #2949 that are fixable in-repo without release infrastructure:

1. **Memorable CLI alias** — `npm install -g ctx7` now installs both `ctx7` and `context7` (same entrypoint). Package name stays `ctx7` because `context7` is taken on npm by an unrelated package.
2. **Agent-friendly library submit** — new `ctx7 add <repo>` wraps `POST /api/v2/add/repo/github` so coding agents can submit missing libraries without dropping to raw REST or the web UI.

Winget packaging (item 1 in the issue) is intentionally left for follow-up — it needs published Windows release artifacts / WinGet Releaser setup.

## Changes

### CLI
- `packages/cli/package.json`: `bin.context7` → same `./dist/index.js` as `ctx7`
- `ctx7 add <repo>` with URL normalization for:
  - `owner/repo`
  - `https://github.com/owner/repo(.git)`
  - `git@github.com:owner/repo(.git)`
  - `github.com/owner/repo`
- Options: `--json`, `--private`, `--git-token`, `--skip-version-filtering`, `--generate-docs`
- Auth via existing `CONTEXT7_API_KEY` / `ctx7 login` session
- Script-friendly exit codes:
  | Code | Meaning |
  | --- | --- |
  | 0 | success |
  | 1 | validation / other error |
  | 2 | auth required or invalid |
  | 3 | duplicate (`409` / `duplicate_repo`) |
  | 4 | rate limited |

### Docs
- `docs/clients/cli.mdx` — new “Submit a Library” section + auth table row
- Root `README.md`, `packages/cli/README.md`, `skills/context7-cli/SKILL.md`

### Tests
- 18 unit tests for URL normalization, exit codes, JSON shape, flag forwarding, and auth wiring
- Extended `command-auth-wiring` so `add` always goes through `getValidAccessToken()`

## Test plan

- [x] `pnpm --filter ctx7 exec vitest run src/__tests__/add-command.test.ts src/__tests__/command-auth-wiring.test.ts` (24 passed)
- [x] `pnpm --filter ctx7 exec tsc --noEmit`
- [ ] Manual: `npx . add owner/repo --json` with a real `CONTEXT7_API_KEY`
- [ ] Manual: confirm global install exposes both `ctx7` and `context7` after publish

## Note on open issues

Most current open issues on this repo are platform/admin work (library refresh, verification, catalog metadata) rather than in-repo code fixes. This PR targets the main code-actionable request (#2949 items 2–3).
