### PR TITLE
Add Docs7 deployments to ctx7

### DIFF
--- a/.changeset/calm-badgers-deploy.md
+++ b/.changeset/calm-badgers-deploy.md
@@ -1,0 +1,5 @@
+---
+"ctx7": minor
+---
+
+Add `ctx7 deploy` with automatic Docs7 site creation, local linking, previews, and production deployments.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -130,6 +130,22 @@ ctx7 whoami
 ctx7 logout
 ```
 
+### Deploy documentation
+
+Deploy local documentation files. The first deployment creates a Docs7 site
+and links it to the current directory.
+
+```bash
+ctx7 login
+ctx7 deploy .
+ctx7 deploy . --prod
+```
+
+The default deployment updates the stable CLI preview. `--prod` updates the
+production site. Use `ctx7 link . --site <site-id>` only when you want to link
+the directory to another site. CI can use `CONTEXT7_API_KEY` instead of
+interactive login.
+
 ## Supported Clients
 
 The CLI automatically detects which AI coding assistants you have installed and configures Context7 for them:

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,11 +29,13 @@
     "figlet": "^1.9.4",
     "open": "^10.1.0",
     "ora": "^9.4.0",
-    "picocolors": "^1.1.1"
+    "picocolors": "^1.1.1",
+    "tar-stream": "3.2.0"
   },
   "devDependencies": {
     "@types/figlet": "^1.7.0",
     "@types/node": "^22.19.1",
+    "@types/tar-stream": "3.1.4",
     "@typescript-eslint/eslint-plugin": "^8.28.0",
     "@typescript-eslint/parser": "^8.28.0",
     "eslint": "^9.34.0",

--- a/packages/cli/src/__tests__/deploy-command.test.ts
+++ b/packages/cli/src/__tests__/deploy-command.test.ts
@@ -1,0 +1,173 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { Command } from "commander";
+import { registerDeployCommands } from "../commands/deploy.js";
+import { setBaseUrl } from "../utils/api.js";
+
+const DEPLOYMENT_ID = "22222222-2222-4222-8222-222222222222";
+
+async function requestJson(request: http.IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return JSON.parse(Buffer.concat(chunks).toString("utf8")) as unknown;
+}
+
+afterEach(() => {
+  delete process.env.CONTEXT7_API_KEY;
+  setBaseUrl("https://context7.com");
+  vi.restoreAllMocks();
+});
+
+describe("deploy command", () => {
+  test("uses the existing API key, creates its own site, deploys, and prints the URL", async () => {
+    const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "ctx7-deploy-test-"));
+    fs.writeFileSync(
+      path.join(projectDir, "docs.json"),
+      JSON.stringify({ name: "CLI Docs", navigation: { pages: ["index"] } })
+    );
+    fs.writeFileSync(path.join(projectDir, "index.mdx"), "---\ntitle: Home\n---\n\nHello.");
+    execFileSync("git", ["-C", projectDir, "init"]);
+    execFileSync("git", [
+      "-C",
+      projectDir,
+      "remote",
+      "add",
+      "origin",
+      "git@github.com:acme/docs.git",
+    ]);
+
+    let uploaded = Buffer.alloc(0);
+    let siteId: string | null = null;
+    const server = http.createServer(async (request, response) => {
+      if (request.method === "POST" && request.url === "/api/v2/cli/events") {
+        response.statusCode = 204;
+        response.end();
+        return;
+      }
+      if (request.method === "GET" && request.url === "/api/v2/docs/sites") {
+        expect(request.headers.authorization).toBe("Bearer test-key");
+        response.setHeader("Content-Type", "application/json");
+        response.end(
+          JSON.stringify({
+            data: [
+              {
+                id: "11111111-1111-4111-8111-111111111111",
+                name: "Existing Git site",
+                repoUrl: "https://github.com/acme/docs",
+              },
+            ],
+          })
+        );
+        return;
+      }
+      if (request.method === "POST" && request.url === "/api/v2/docs/sites") {
+        const body = await requestJson(request);
+        if (typeof body !== "object" || body === null || !("id" in body)) {
+          throw new Error("Site creation did not include an ID");
+        }
+        siteId = typeof body.id === "string" ? body.id : null;
+        expect(siteId).toMatch(/^[0-9a-f-]{36}$/);
+        expect(body).toMatchObject({ name: "CLI Docs" });
+        response.statusCode = 201;
+        response.setHeader("Content-Type", "application/json");
+        response.end(JSON.stringify({ data: { id: siteId, name: "CLI Docs", repoUrl: null } }));
+        return;
+      }
+      if (
+        request.method === "POST" &&
+        siteId !== null &&
+        request.url === `/api/v2/docs/sites/${siteId}/deployments`
+      ) {
+        response.setHeader("Content-Type", "application/json");
+        response.end(
+          JSON.stringify({
+            deployment: {
+              id: DEPLOYMENT_ID,
+              state: "queued",
+              url: "https://preview.example.docs7.io",
+              failureMessage: null,
+            },
+            sourceUploadToken: "upload-token",
+          })
+        );
+        return;
+      }
+      if (
+        request.method === "POST" &&
+        siteId !== null &&
+        request.url === `/api/v2/docs/sites/${siteId}/deployments/${DEPLOYMENT_ID}/source`
+      ) {
+        expect(request.headers.authorization).toBe("Bearer upload-token");
+        const chunks: Buffer[] = [];
+        for await (const chunk of request)
+          chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+        uploaded = Buffer.concat(chunks);
+        response.statusCode = 202;
+        response.end();
+        return;
+      }
+      if (
+        request.method === "GET" &&
+        siteId !== null &&
+        request.url === `/api/v2/docs/sites/${siteId}/deployments/${DEPLOYMENT_ID}`
+      ) {
+        response.setHeader("Content-Type", "application/json");
+        response.end(
+          JSON.stringify({
+            data: {
+              id: DEPLOYMENT_ID,
+              state: "ready",
+              url: "https://preview.example.docs7.io",
+              failureMessage: null,
+            },
+          })
+        );
+        return;
+      }
+      response.statusCode = 404;
+      response.end();
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const addressValue = server.address();
+    if (!addressValue || typeof addressValue === "string")
+      throw new Error("The test server did not start");
+    const address = addressValue;
+
+    try {
+      setBaseUrl(`http://127.0.0.1:${address.port}`);
+      process.env.CONTEXT7_API_KEY = "test-key";
+      const stdout: string[] = [];
+      vi.spyOn(console, "log").mockImplementation((...values: unknown[]) =>
+        stdout.push(values.join(" "))
+      );
+      vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+      const program = new Command();
+      program.exitOverride();
+      registerDeployCommands(program);
+      await program.parseAsync(["node", "ctx7", "deploy", projectDir]);
+
+      expect(stdout.at(-1)).toBe("https://preview.example.docs7.io");
+      expect(uploaded[0]).toBe(0x1f);
+      expect(uploaded[1]).toBe(0x8b);
+      expect(siteId).not.toBeNull();
+      expect(
+        JSON.parse(fs.readFileSync(path.join(projectDir, ".docs7/project.json"), "utf8"))
+      ).toEqual({
+        siteId,
+      });
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      fs.rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -1,0 +1,214 @@
+import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { Command } from "commander";
+import {
+  createDocsDeployment,
+  createDocsSite,
+  getDocsDeployment,
+  listDocsSites,
+  uploadDocsSource,
+  type DocsSite,
+} from "../docs/hosting-api.js";
+import { loadDocsProjectLink, saveDocsProjectLink } from "../docs/project-link.js";
+import { createSourceArchive } from "../docs/source-archive.js";
+import { getValidAccessToken } from "../utils/auth.js";
+import { trackEvent } from "../utils/tracking.js";
+
+function progress(message: string): void {
+  process.stderr.write(`${message}\n`);
+}
+
+async function accessToken(): Promise<string> {
+  const environmentToken = process.env.CONTEXT7_API_KEY?.trim();
+  const token = environmentToken || (await getValidAccessToken());
+  if (!token) throw new Error("You are not signed in. Run `ctx7 login`, then try again.");
+  return token;
+}
+
+function gitRemote(directory: string): Promise<string | null> {
+  return new Promise((resolve) => {
+    execFile("git", ["-C", directory, "remote", "get-url", "origin"], (error, stdout) => {
+      resolve(error ? null : stdout.trim() || null);
+    });
+  });
+}
+
+function normalizedRepository(value: string): string {
+  const scp = /^git@github\.com:([^/]+\/[^/]+?)(?:\.git)?$/.exec(value);
+  const repository =
+    scp?.[1] ?? value.replace(/^https?:\/\/github\.com\//, "").replace(/\.git$/, "");
+  return repository.toLowerCase();
+}
+
+function sitesMessage(sites: ReadonlyArray<DocsSite>): string {
+  return sites.map((site) => `  ${site.id}  ${site.name}`).join("\n");
+}
+
+async function selectSite(
+  projectDir: string,
+  token: string,
+  explicitSiteId?: string
+): Promise<DocsSite> {
+  const sites = await listDocsSites(token);
+  if (sites.length === 0) {
+    throw new Error("No Docs7 sites found. Run `ctx7 deploy .` to create and deploy one.");
+  }
+  const linked = explicitSiteId ? null : await loadDocsProjectLink(projectDir);
+  const siteId = explicitSiteId ?? linked?.siteId;
+  let site = siteId ? sites.find((candidate) => candidate.id === siteId) : undefined;
+  if (!site && siteId)
+    throw new Error(`The linked Docs7 site ${siteId} is not available to this teamspace.`);
+  if (!site) {
+    const remote = await gitRemote(projectDir);
+    if (remote) {
+      const normalizedRemote = normalizedRepository(remote);
+      const matches = sites.filter(
+        (candidate) =>
+          candidate.repoUrl !== null && normalizedRepository(candidate.repoUrl) === normalizedRemote
+      );
+      if (matches.length === 1) site = matches[0];
+    }
+  }
+  if (!site)
+    throw new Error(`Choose a site with --site <id>. Available sites:\n${sitesMessage(sites)}`);
+  await saveDocsProjectLink(projectDir, { siteId: site.id });
+  return site;
+}
+
+async function projectName(projectDir: string): Promise<string> {
+  for (const fileName of ["docs.json", "mint.json"]) {
+    try {
+      const value: unknown = JSON.parse(await fs.readFile(path.join(projectDir, fileName), "utf8"));
+      if (typeof value === "object" && value !== null && "name" in value) {
+        const name = value.name;
+        if (typeof name === "string" && name.trim()) return name.trim().slice(0, 100);
+      }
+    } catch (error) {
+      if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error;
+    }
+  }
+  return path.basename(projectDir).slice(0, 100) || "Documentation";
+}
+
+async function siteForDeploy(
+  projectDir: string,
+  token: string,
+  explicitSiteId?: string
+): Promise<DocsSite> {
+  const sites = await listDocsSites(token);
+  const linked = await loadDocsProjectLink(projectDir);
+  const requestedSiteId = explicitSiteId ?? linked?.siteId;
+  if (requestedSiteId) {
+    const existing = sites.find((site) => site.id === requestedSiteId);
+    if (existing) {
+      await saveDocsProjectLink(projectDir, { siteId: existing.id });
+      return existing;
+    }
+    if (explicitSiteId) {
+      throw new Error(`Docs7 site ${explicitSiteId} is not available to this teamspace.`);
+    }
+  }
+
+  const siteId = randomUUID();
+  await saveDocsProjectLink(projectDir, { siteId });
+  return await createDocsSite(token, { id: siteId, name: await projectName(projectDir) });
+}
+
+function wait(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function linkCommand(directory: string, siteId?: string): Promise<void> {
+  trackEvent("command", { name: "link" });
+  const projectDir = path.resolve(directory);
+  try {
+    const site = await selectSite(projectDir, await accessToken(), siteId);
+    console.log(`Linked ${projectDir} to ${site.name} (${site.id})`);
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}
+
+async function deployCommand(
+  directory: string,
+  options: { readonly prod?: boolean; readonly site?: string }
+): Promise<void> {
+  trackEvent("command", { name: "deploy" });
+  const projectDir = path.resolve(directory);
+  let temporaryDirectory: string | null = null;
+  try {
+    const hasConfig = await Promise.all([
+      fs.access(path.join(projectDir, "docs.json")).then(
+        () => true,
+        () => false
+      ),
+      fs.access(path.join(projectDir, "mint.json")).then(
+        () => true,
+        () => false
+      ),
+    ]);
+    if (!hasConfig.some(Boolean)) {
+      throw new Error("The documentation directory does not contain docs.json or mint.json.");
+    }
+    const token = await accessToken();
+    const site = await siteForDeploy(projectDir, token, options.site);
+    progress(`Deploying ${site.name}`);
+
+    temporaryDirectory = await fs.mkdtemp(path.join(os.tmpdir(), "ctx7-deploy-"));
+    const archivePath = path.join(temporaryDirectory, "source.tar.gz");
+    progress("Preparing documentation source");
+    await createSourceArchive(projectDir, archivePath);
+
+    const target = options.prod ? "production" : "preview";
+    const upload = await createDocsDeployment(token, site.id, target);
+    progress(`Uploading ${target} deployment`);
+    await uploadDocsSource(upload.sourceUploadToken, site.id, upload.deployment.id, archivePath);
+
+    const deadline = Date.now() + 15 * 60_000;
+    let currentDeployment = upload.deployment;
+    while (currentDeployment.state === "queued" || currentDeployment.state === "running") {
+      if (Date.now() >= deadline)
+        throw new Error(`Deployment ${currentDeployment.id} did not finish before the timeout.`);
+      await wait(1_000);
+      currentDeployment = await getDocsDeployment(token, site.id, currentDeployment.id);
+    }
+    if (currentDeployment.state === "failed")
+      throw new Error(currentDeployment.failureMessage ?? "The deployment failed.");
+    console.log(currentDeployment.url);
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  } finally {
+    if (temporaryDirectory) {
+      await fs.rm(temporaryDirectory, { recursive: true, force: true }).catch(() => undefined);
+    }
+  }
+}
+
+/** Register Docs7 project linking and deployment commands. */
+export function registerDeployCommands(program: Command): void {
+  program
+    .command("link")
+    .description("Link a local documentation directory to an existing Docs7 site")
+    .argument("[dir]", "Documentation directory", ".")
+    .option("--site <id>", "Hosted Docs7 site ID")
+    .action(async (directory: string, options: { readonly site?: string }) => {
+      await linkCommand(directory, options.site);
+    });
+
+  program
+    .command("deploy")
+    .description("Deploy local documentation files to Docs7")
+    .argument("[dir]", "Documentation directory", ".")
+    .option("--prod", "Deploy to production instead of the CLI preview")
+    .option("--site <id>", "Hosted Docs7 site ID and save the link")
+    .action(
+      async (directory: string, options: { readonly prod?: boolean; readonly site?: string }) => {
+        await deployCommand(directory, options);
+      }
+    );
+}

--- a/packages/cli/src/docs/hosting-api.ts
+++ b/packages/cli/src/docs/hosting-api.ts
@@ -1,0 +1,162 @@
+import fs from "node:fs/promises";
+import { getBaseUrl } from "../utils/api.js";
+
+/** One hosted Docs7 site visible to the authenticated teamspace. */
+export type DocsSite = {
+  readonly id: string;
+  readonly name: string;
+  readonly repoUrl: string | null;
+};
+
+/** Current state of one Docs7 CLI deployment. */
+export type DocsDeployment = {
+  readonly id: string;
+  readonly state: "queued" | "running" | "ready" | "failed";
+  readonly url: string;
+  readonly failureMessage: string | null;
+};
+
+/** Deployment plus its short-lived source upload credential. */
+export type DocsDeploymentUpload = {
+  readonly deployment: DocsDeployment;
+  readonly sourceUploadToken: string;
+};
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null;
+}
+
+function requiredString(value: Readonly<Record<string, unknown>>, name: string): string | null {
+  const field = value[name];
+  return typeof field === "string" && field !== "" ? field : null;
+}
+
+function parseDeployment(value: unknown): DocsDeployment | null {
+  if (!isRecord(value)) return null;
+  const id = requiredString(value, "id");
+  const state = requiredString(value, "state");
+  const url = requiredString(value, "url");
+  const failureMessage = value.failureMessage;
+  if (!id || !url || (failureMessage !== null && typeof failureMessage !== "string")) return null;
+  if (state !== "queued" && state !== "running" && state !== "ready" && state !== "failed")
+    return null;
+  return { id, state, url, failureMessage };
+}
+
+async function responseError(response: Response): Promise<Error> {
+  const value: unknown = await response.json().catch(() => null);
+  const message =
+    isRecord(value) && typeof value.message === "string"
+      ? value.message
+      : `Docs7 returned HTTP ${response.status}`;
+  return new Error(message);
+}
+
+function authorization(accessToken: string): Headers {
+  return new Headers({ Authorization: `Bearer ${accessToken}` });
+}
+
+/** List Docs7 sites in the authenticated teamspace. */
+export async function listDocsSites(accessToken: string): Promise<ReadonlyArray<DocsSite>> {
+  const response = await fetch(`${getBaseUrl()}/api/v2/docs/sites`, {
+    headers: authorization(accessToken),
+  });
+  if (!response.ok) throw await responseError(response);
+  const value: unknown = await response.json();
+  if (!isRecord(value) || !Array.isArray(value.data))
+    throw new Error("Docs7 returned an invalid site list");
+  return value.data.map((item: unknown) => {
+    if (!isRecord(item)) throw new Error("Docs7 returned an invalid site");
+    const id = requiredString(item, "id");
+    const name = requiredString(item, "name");
+    const repoUrl = item.repoUrl;
+    if (!id || !name || (repoUrl !== null && typeof repoUrl !== "string")) {
+      throw new Error("Docs7 returned an invalid site");
+    }
+    return { id, name, repoUrl };
+  });
+}
+
+/** Create a CLI-owned Docs7 site with a caller-generated stable ID. */
+export async function createDocsSite(
+  accessToken: string,
+  input: { readonly id: string; readonly name: string }
+): Promise<DocsSite> {
+  const headers = authorization(accessToken);
+  headers.set("Content-Type", "application/json");
+  const response = await fetch(`${getBaseUrl()}/api/v2/docs/sites`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(input),
+  });
+  if (!response.ok) throw await responseError(response);
+  const value: unknown = await response.json();
+  if (!isRecord(value) || !isRecord(value.data)) {
+    throw new Error("Docs7 returned an invalid site");
+  }
+  const id = requiredString(value.data, "id");
+  const name = requiredString(value.data, "name");
+  if (!id || !name || value.data.repoUrl !== null) {
+    throw new Error("Docs7 returned an invalid site");
+  }
+  return { id, name, repoUrl: null };
+}
+
+/** Create one Docs7 deployment and obtain its source upload instructions. */
+export async function createDocsDeployment(
+  accessToken: string,
+  siteId: string,
+  target: "preview" | "production"
+): Promise<DocsDeploymentUpload> {
+  const headers = authorization(accessToken);
+  headers.set("Content-Type", "application/json");
+  const response = await fetch(
+    `${getBaseUrl()}/api/v2/docs/sites/${encodeURIComponent(siteId)}/deployments`,
+    {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ target }),
+    }
+  );
+  if (!response.ok) throw await responseError(response);
+  const value: unknown = await response.json();
+  if (!isRecord(value)) throw new Error("Docs7 returned an invalid deployment");
+  const deployment = parseDeployment(value.deployment);
+  const sourceUploadToken = requiredString(value, "sourceUploadToken");
+  if (!deployment || !sourceUploadToken) throw new Error("Docs7 returned an invalid deployment");
+  return { deployment, sourceUploadToken };
+}
+
+/** Upload one local documentation source archive through the Context7 API. */
+export async function uploadDocsSource(
+  sourceUploadToken: string,
+  siteId: string,
+  deploymentId: string,
+  archivePath: string
+): Promise<void> {
+  const headers = authorization(sourceUploadToken);
+  headers.set("Content-Type", "application/gzip");
+  const response = await fetch(
+    `${getBaseUrl()}/api/v2/docs/sites/${encodeURIComponent(siteId)}/deployments/${encodeURIComponent(deploymentId)}/source`,
+    { method: "POST", headers, body: await fs.readFile(archivePath) }
+  );
+  if (!response.ok) throw await responseError(response);
+}
+
+/** Read the current state of one Docs7 deployment. */
+export async function getDocsDeployment(
+  accessToken: string,
+  siteId: string,
+  deploymentId: string
+): Promise<DocsDeployment> {
+  const response = await fetch(
+    `${getBaseUrl()}/api/v2/docs/sites/${encodeURIComponent(siteId)}/deployments/${encodeURIComponent(deploymentId)}`,
+    { headers: authorization(accessToken) }
+  );
+  if (!response.ok) throw await responseError(response);
+  const value: unknown = await response.json();
+  if (!isRecord(value)) throw new Error("Docs7 returned an invalid deployment");
+  const deployment = parseDeployment(value.data);
+  if (!deployment) throw new Error("Docs7 returned an invalid deployment");
+  return deployment;
+}

--- a/packages/cli/src/docs/project-link.ts
+++ b/packages/cli/src/docs/project-link.ts
@@ -1,0 +1,46 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const PROJECT_DIRECTORY = ".docs7";
+const PROJECT_FILE = "project.json";
+
+/** Local link between one documentation directory and one hosted Docs7 site. */
+export type DocsProjectLink = { readonly siteId: string };
+
+function projectFile(projectDir: string): string {
+  return path.join(projectDir, PROJECT_DIRECTORY, PROJECT_FILE);
+}
+
+/** Read the local Docs7 project link, or null when the directory is not linked. */
+export async function loadDocsProjectLink(projectDir: string): Promise<DocsProjectLink | null> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(projectFile(projectDir), "utf8");
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return null;
+    throw error;
+  }
+  const value: unknown = JSON.parse(raw);
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !("siteId" in value) ||
+    typeof value.siteId !== "string" ||
+    value.siteId === ""
+  ) {
+    throw new Error(".docs7/project.json does not contain a valid siteId");
+  }
+  return { siteId: value.siteId };
+}
+
+/** Save the local link to one hosted Docs7 site. */
+export async function saveDocsProjectLink(
+  projectDir: string,
+  link: DocsProjectLink
+): Promise<void> {
+  const directory = path.join(projectDir, PROJECT_DIRECTORY);
+  await fs.mkdir(directory, { recursive: true, mode: 0o700 });
+  await fs.writeFile(projectFile(projectDir), `${JSON.stringify(link, null, 2)}\n`, {
+    mode: 0o600,
+  });
+}

--- a/packages/cli/src/docs/source-archive.ts
+++ b/packages/cli/src/docs/source-archive.ts
@@ -1,0 +1,73 @@
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import path from "node:path";
+import { pipeline } from "node:stream/promises";
+import { createGzip } from "node:zlib";
+import tar from "tar-stream";
+
+const SKIPPED_ENTRIES = new Set([".docs7", ".git", "node_modules"]);
+
+type SourceFile = { readonly absolutePath: string; readonly name: string };
+
+async function sourceFiles(rootDir: string): Promise<ReadonlyArray<SourceFile>> {
+  const files: SourceFile[] = [];
+  const visit = async (directory: string): Promise<void> => {
+    const entries = await fsp.readdir(directory, { withFileTypes: true });
+    entries.sort((left, right) => left.name.localeCompare(right.name));
+    for (const entry of entries) {
+      if (
+        SKIPPED_ENTRIES.has(entry.name) ||
+        (entry.name.startsWith(".") && entry.name !== ".mintignore")
+      ) {
+        continue;
+      }
+      const absolutePath = path.join(directory, entry.name);
+      if (entry.isSymbolicLink())
+        throw new Error("The documentation source contains a symbolic link");
+      if (entry.isDirectory()) {
+        await visit(absolutePath);
+        continue;
+      }
+      if (!entry.isFile())
+        throw new Error("The documentation source contains an unsupported file type");
+      files.push({
+        absolutePath,
+        name: path.relative(rootDir, absolutePath).split(path.sep).join("/"),
+      });
+    }
+  };
+  await visit(rootDir);
+  return files;
+}
+
+/** Create a gzip-compressed archive of one local documentation source directory. */
+export async function createSourceArchive(sourceDir: string, archivePath: string): Promise<void> {
+  const files = await sourceFiles(sourceDir);
+  const pack = tar.pack();
+  const output = pipeline(
+    pack,
+    createGzip({ level: 6 }),
+    fs.createWriteStream(archivePath, { flags: "wx", mode: 0o600 })
+  );
+  try {
+    for (const file of files) {
+      const stat = await fsp.stat(file.absolutePath);
+      await pipeline(
+        fs.createReadStream(file.absolutePath),
+        pack.entry({
+          name: file.name,
+          type: "file",
+          size: stat.size,
+          mode: stat.mode & 0o777,
+          mtime: stat.mtime,
+        })
+      );
+    }
+    pack.finalize();
+    await output;
+  } catch (error) {
+    pack.destroy(error instanceof Error ? error : undefined);
+    await output.catch(() => undefined);
+    throw error;
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,6 +6,7 @@ import { registerAuthCommands, setAuthBaseUrl } from "./commands/auth.js";
 import { registerSetupCommand } from "./commands/setup.js";
 import { registerRemoveCommand } from "./commands/remove.js";
 import { registerDocsCommands } from "./commands/docs.js";
+import { registerDeployCommands } from "./commands/deploy.js";
 import { maybeShowUpgradeNotice, registerUpgradeCommand } from "./commands/upgrade.js";
 import { setBaseUrl } from "./utils/api.js";
 import { VERSION } from "./constants.js";
@@ -53,6 +54,10 @@ Examples:
   ${brand.dim("# Query library documentation")}
   ${brand.primary('npx ctx7 library react "how to use hooks"')}
   ${brand.primary('npx ctx7 docs /facebook/react "useEffect examples"')}
+
+  ${brand.dim("# Deploy a local Docs7 site")}
+  ${brand.primary("npx ctx7 deploy .")}
+  ${brand.primary("npx ctx7 deploy . --prod")}
 `
   );
 
@@ -62,6 +67,7 @@ registerAuthCommands(program);
 registerSetupCommand(program);
 registerRemoveCommand(program);
 registerDocsCommands(program);
+registerDeployCommands(program);
 registerUpgradeCommand(program);
 
 program.action(() => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
+      tar-stream:
+        specifier: 3.2.0
+        version: 3.2.0
     devDependencies:
       '@types/figlet':
         specifier: ^1.7.0
@@ -79,6 +82,9 @@ importers:
       '@types/node':
         specifier: ^22.19.1
         version: 22.19.7
+      '@types/tar-stream':
+        specifier: 3.1.4
+        version: 3.1.4
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.28.0
         version: 8.47.0(@typescript-eslint/parser@8.47.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
@@ -1374,6 +1380,9 @@ packages:
   '@types/serve-static@1.15.10':
     resolution: {integrity: sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==}
 
+  '@types/tar-stream@3.1.4':
+    resolution: {integrity: sha512-921gW0+g29mCJX0fRvqeHzBlE/XclDaAG0Ousy1LCghsOhvaKacDeRGEVzQP9IPfKn8Vysy7FEXAIxycpc/CMg==}
+
   '@typescript-eslint/eslint-plugin@8.47.0':
     resolution: {integrity: sha512-fe0rz9WJQ5t2iaLfdbDc9T80GJy0AeO453q8C3YCilnGozvOyCG5t+EZtg7j7D88+c3FipfP/x+wzGnh1xp8ZA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1552,12 +1561,57 @@ packages:
   aws4fetch@1.0.20:
     resolution: {integrity: sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g==}
 
+  b4a@1.8.1:
+    resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
+
+  bare-events@2.9.1:
+    resolution: {integrity: sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+
+  bare-fs@4.8.0:
+    resolution: {integrity: sha512-fM+MhCvdQhZ7NV6S95a07gPSqjIYKn6mFaXfx266wN3ajZGl/+1AzH+ubkXQ0fFZvOe2nk9VHkzdYkQE5zMV3Q==}
+    engines: {bare: '>=1.28.0'}
+    peerDependencies:
+      bare-buffer: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+
+  bare-path@3.1.1:
+    resolution: {integrity: sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==}
+
+  bare-stream@2.13.3:
+    resolution: {integrity: sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==}
+    peerDependencies:
+      bare-abort-controller: '*'
+      bare-buffer: '*'
+      bare-events: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+      bare-buffer:
+        optional: true
+      bare-events:
+        optional: true
+
+  bare-url@2.5.2:
+    resolution: {integrity: sha512-L13PCJzKG8RGvx8V1/DdMi12ERhC3tprr7/8a94BxpmnRsFqxh5XZNdhtMxu5HPkRshYOOWRGY8lDP7ZhpG9Cg==}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -1912,6 +1966,9 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
   eventsource-parser@3.0.6:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
     engines: {node: '>=18.0.0'}
@@ -1949,6 +2006,9 @@ packages:
 
   fast-diff@1.3.0:
     resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
+
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -2797,6 +2857,9 @@ packages:
     resolution: {integrity: sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==}
     engines: {node: '>=18'}
 
+  streamx@2.28.0:
+    resolution: {integrity: sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==}
+
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -2841,9 +2904,18 @@ packages:
     resolution: {integrity: sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
+  tar-stream@3.2.0:
+    resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
+
+  teex@1.0.1:
+    resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
+
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
+
+  text-decoder@1.2.7:
+    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
@@ -4396,6 +4468,10 @@ snapshots:
       '@types/node': 25.9.1
       '@types/send': 0.17.6
 
+  '@types/tar-stream@3.1.4':
+    dependencies:
+      '@types/node': 25.9.1
+
   '@typescript-eslint/eslint-plugin@8.47.0(@typescript-eslint/parser@8.47.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -4621,9 +4697,40 @@ snapshots:
 
   aws4fetch@1.0.20: {}
 
+  b4a@1.8.1: {}
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
+
+  bare-events@2.9.1: {}
+
+  bare-fs@4.8.0:
+    dependencies:
+      bare-events: 2.9.1
+      bare-path: 3.1.1
+      bare-stream: 2.13.3(bare-events@2.9.1)
+      bare-url: 2.5.2
+      fast-fifo: 1.3.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  bare-path@3.1.1: {}
+
+  bare-stream@2.13.3(bare-events@2.9.1):
+    dependencies:
+      b4a: 1.8.1
+      streamx: 2.28.0
+      teex: 1.0.1
+    optionalDependencies:
+      bare-events: 2.9.1
+    transitivePeerDependencies:
+      - react-native-b4a
+
+  bare-url@2.5.2:
+    dependencies:
+      bare-path: 3.1.1
 
   base64-js@1.5.1: {}
 
@@ -5003,6 +5110,12 @@ snapshots:
 
   etag@1.8.1: {}
 
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.9.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+
   eventsource-parser@3.0.6: {}
 
   eventsource@3.0.7:
@@ -5090,6 +5203,8 @@ snapshots:
   fast-deep-equal@3.1.3: {}
 
   fast-diff@1.3.0: {}
+
+  fast-fifo@1.3.2: {}
 
   fast-glob@3.3.3:
     dependencies:
@@ -5923,6 +6038,15 @@ snapshots:
 
   stdin-discarder@0.3.2: {}
 
+  streamx@2.28.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
@@ -5972,7 +6096,31 @@ snapshots:
     dependencies:
       '@pkgr/core': 0.3.6
 
+  tar-stream@3.2.0:
+    dependencies:
+      b4a: 1.8.1
+      bare-fs: 4.8.0
+      fast-fifo: 1.3.2
+      streamx: 2.28.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
+  teex@1.0.1:
+    dependencies:
+      streamx: 2.28.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
   term-size@2.2.1: {}
+
+  text-decoder@1.2.7:
+    dependencies:
+      b4a: 1.8.1
+    transitivePeerDependencies:
+      - react-native-b4a
 
   thenify-all@1.6.0:
     dependencies:


### PR DESCRIPTION
## What

- add `ctx7 deploy [dir]` with preview deployments by default and `--prod` for production
- reuse the existing `ctx7 login` credentials and `CONTEXT7_API_KEY`
- create a CLI-owned Docs7 site on the first deploy
- save its site ID in `.docs7/project.json` for later deploys
- upload the local documentation archive through the Context7 app API and wait for the deployment URL

## Why

Users must be able to deploy local docs immediately. They do not need a separate Docs7 account or a prior dashboard connection.

## Checks

- 255 CLI tests
- type check
- lint
- format check
- build
- Standards and spec review completed

## Companion PRs

- Context7 app API: https://github.com/upstash/context7app/pull/881
- Docs7 build service: https://github.com/upstash/docs7/pull/24
