### PR TITLE
ci: use OIDC for ECR deployment

### DIFF
--- a/.github/workflows/ecr-deploy.yml
+++ b/.github/workflows/ecr-deploy.yml
@@ -23,9 +23,10 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          role-to-assume: ${{ vars.AWS_ECR_ROLE_ARN }}
-          aws-region: ${{ vars.AWS_REGION }}
-          allowed-account-ids: "640168447591"
+          role-to-assume: ${{ secrets.AWS_ECR_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          allowed-account-ids: ${{ secrets.AWS_ACCOUNT_ID }}
+          mask-aws-account-id: true
           role-session-name: context7-ecr-${{ github.run_id }}
 
       - name: Login to Amazon ECR
@@ -47,7 +48,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ${{ steps.login-ecr.outputs.registry }}/context7mcp:${{ inputs.version }}
+            ${{ secrets.ECR_REGISTRY }}/${{ secrets.ECR_REPOSITORY }}:${{ inputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/ecr-deploy.yml
+++ b/.github/workflows/ecr-deploy.yml
@@ -8,6 +8,10 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
@@ -19,9 +23,10 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: ${{ vars.AWS_ECR_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+          allowed-account-ids: "640168447591"
+          role-session-name: context7-ecr-${{ github.run_id }}
 
       - name: Login to Amazon ECR
         id: login-ecr
@@ -42,7 +47,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ${{ secrets.ECR_REGISTRY }}/${{ secrets.ECR_REPOSITORY }}:${{ inputs.version }}
+            ${{ steps.login-ecr.outputs.registry }}/context7mcp:${{ inputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
## Summary

- replace static AWS access keys in the ECR deployment workflow with GitHub OIDC role assumption
- grant the workflow only `contents: read` and `id-token: write`
- validate the expected AWS account, mask the account ID in logs, and use a per-run role session name
- retain the ECR registry and repository as GitHub secrets

## Required configuration

Before running the workflow, create these GitHub repository secrets:

- `AWS_ECR_ROLE_ARN`
- `AWS_ACCOUNT_ID`
- `AWS_REGION`
- `ECR_REGISTRY`
- `ECR_REPOSITORY`

The IAM role must trust:

```
repo:upstash/context7:ref:refs/heads/master
```

and grant ECR push access only to:

```
arn:aws:ecr:us-east-1:640168447591:repository/context7mcp
```

After a successful OIDC deployment, only the legacy `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` secrets can be removed and the `github-actions-context7-mcp` IAM user can be retired.

## Validation

- `git diff --check`
- parsed `.github/workflows/ecr-deploy.yml` as YAML
- live deployment not run because the IAM role and repository variables must be configured first
