### PR TITLE
ci: use OIDC for Bedrock tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -64,9 +68,17 @@ jobs:
       - name: Typecheck
         run: pnpm typecheck
 
+      - name: Configure AWS credentials
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_BEDROCK_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          allowed-account-ids: ${{ secrets.AWS_ACCOUNT_ID }}
+          mask-aws-account-id: true
+          role-session-name: context7-bedrock-${{ github.run_id }}
+
       - name: Test
         run: pnpm test
         env:
-          AWS_REGION: ${{ secrets.AWS_REGION }}
-          AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
           CONTEXT7_API_KEY: ${{ secrets.CONTEXT7_API_KEY }}

--- a/packages/tools-ai-sdk/src/index.test.ts
+++ b/packages/tools-ai-sdk/src/index.test.ts
@@ -13,7 +13,6 @@ import {
 
 const bedrock = createAmazonBedrock({
   region: process.env.AWS_REGION,
-  apiKey: process.env.AWS_BEARER_TOKEN_BEDROCK,
 });
 
 describe("@upstash/context7-tools-ai-sdk", () => {


### PR DESCRIPTION
## Summary

- replace the long-term Bedrock bearer token in the test workflow with GitHub OIDC role assumption
- use temporary SigV4 credentials exported by `aws-actions/configure-aws-credentials`
- restrict credential setup to trusted same-repository pull requests, master pushes, and manual runs
- add account allowlisting, account masking, and a per-run role session name

## AWS configuration

The repository secret `AWS_BEDROCK_ROLE_ARN` points to `GitHubActionsContext7BedrockRole`. The role trusts context7 branch and pull-request subjects and can invoke only `anthropic.claude-3-haiku-20240307-v1:0` in `us-east-1`.

## Security impact

Fork pull requests skip AWS credential setup, preventing untrusted fork code from assuming the Bedrock role. Existing fork workflows did not receive the previous bearer-token secret.

## Validation

- `git diff --check`
- YAML parse
- `pnpm format:check`
- `pnpm lint:check`
- `pnpm build`
- `pnpm typecheck`
- IAM policy simulation: intended Bedrock actions allowed; ECR and unrelated resources denied

The live Bedrock invocation is intentionally validated by this PR's GitHub Actions run, where the OIDC identity is available.

## Safe rollout after merge

1. Verify this PR's test workflow succeeds through OIDC.
2. Merge and verify the master workflow succeeds.
3. Deactivate `BedrockAPIKey-v2iu`.
4. Rerun the workflow to prove no bearer-token dependency remains.
5. Remove `AWS_BEARER_TOKEN_BEDROCK` from the repository.
6. Delete the service-specific credential and `BedrockAPIKey-v2iu` IAM user.
