### PR TITLE
docs: add eve integration guide

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -217,7 +217,8 @@
           "integrations/code-rabbit",
           "integrations/factory-ai",
           "integrations/tembo",
-          "integrations/mastra"
+          "integrations/mastra",
+          "integrations/eve"
         ]
       },
       {

--- a/docs/integrations/eve.mdx
+++ b/docs/integrations/eve.mdx
@@ -1,0 +1,84 @@
+---
+title: eve
+sidebarTitle: eve
+description: Filesystem-first framework for building durable AI agents
+---
+
+[eve](https://eve.dev) is Vercel's filesystem-first framework for building durable AI agents. By adding Context7 as an MCP connection, an eve agent can retrieve up-to-date, version-specific library documentation and code examples while it works.
+
+For more details on how eve handles MCP connections, see the [eve MCP connections documentation](https://eve.dev/docs/connections/mcp).
+
+## Setup
+
+<Steps>
+  <Step title="Create the Context7 connection">
+    Create `agent/connections/context7.ts` in your eve project:
+
+    ```typescript
+    import { defineMcpClientConnection } from "eve/connections";
+
+    const apiKey = process.env.CONTEXT7_API_KEY;
+
+    export default defineMcpClientConnection({
+      url: "https://mcp.context7.com/mcp",
+      description:
+        "Context7: up-to-date, version-specific library documentation and code examples.",
+      ...(apiKey
+        ? {
+            auth: {
+              getToken: async () => ({ token: apiKey }),
+            },
+          }
+        : {}),
+      tools: {
+        allow: ["resolve-library-id", "query-docs"],
+      },
+    });
+    ```
+
+    The API key is optional, so the connection can use Context7's anonymous limits when `CONTEXT7_API_KEY` is not set. For higher rate limits, create an API key in the [Context7 dashboard](https://context7.com/dashboard).
+  </Step>
+
+  <Step title="Configure an API key (recommended)">
+    Add the key to `.env.local` for local development. Do not commit this file.
+
+    ```bash
+    CONTEXT7_API_KEY=YOUR_API_KEY
+    ```
+
+    For a deployed eve agent, add the same variable to the linked Vercel project and pull it locally:
+
+    ```bash
+    vercel env add CONTEXT7_API_KEY
+    vercel env pull .env.local
+    ```
+
+    eve's `getToken` callback sends the value as an `Authorization: Bearer` token. Vercel Connect is not required when using an API key.
+  </Step>
+
+  <Step title="Verify the connection">
+    Inspect the agent and confirm that it compiles with `0 errors` and `0 warnings`:
+
+    ```bash
+    npx eve info
+    ```
+
+    Then start the agent and ask a documentation question. When the connection is used, eve discovers only the two tools in the allowlist:
+
+    ```bash
+    pnpm dev
+    ```
+
+    ```text
+    Use Context7 to show me how to configure caching in Next.js.
+    ```
+  </Step>
+</Steps>
+
+## How It Works
+
+The filename registers the connection as `context7`. eve discovers the remote MCP tools and makes them available as `context7__resolve-library-id` and `context7__query-docs` when the model searches for a relevant connection.
+
+The allowlist keeps the connection limited to Context7's documentation tools, including if the server adds more tools later. Both tools are read-only, so they do not require an approval gate.
+
+When a request names a library, the agent first calls `resolve-library-id` to find its Context7 library ID, then calls `query-docs` with that ID and the user's specific question. If the prompt already includes a Context7 library ID such as `/vercel/next.js`, the agent can call `query-docs` directly.


### PR DESCRIPTION
## What changed

- Added a dedicated eve integration guide to the Context7 documentation.
- Added an EVE-native `agent/connections/context7.ts` configuration.
- Documented anonymous access and optional `CONTEXT7_API_KEY` authentication.
- Limited the connection to Context7's `resolve-library-id` and `query-docs` tools.
- Documented local and deployed environment setup, verification, and usage.
- Added the guide to the integrations navigation.

## Why

eve agents consume remote MCP servers through filesystem-discovered connection modules. Context7 did not have a current, copy-pasteable EVE setup based on that connection API.

## Impact

EVE users can now add Context7 as a remote MCP connection and retrieve current, version-specific library documentation while keeping the agent's remote tool surface limited to Context7's two read-only documentation tools.

## Validation

- `pnpm lint:check`
- `pnpm format:check`
- `pnpm exec prettier --check docs/integrations/eve.mdx docs/docs.json`
- `pnpm build`
- `pnpm typecheck`
- `pnpm --filter @upstash/context7-mcp test` (76 tests)
- `pnpm --filter ctx7 test` (254 tests)
- `pnpm --filter @upstash/context7-pi test` (4 tests)
- Fresh EVE 0.38.3 project: `eve info` reported 0 errors and 0 warnings.
- Live EVE MCP smoke test discovered exactly the two allowed tools, resolved `/vercel/eve`, and returned `defineMcpClientConnection` documentation through `query-docs`.

The aggregate `pnpm test` command also includes credentialed SDK and Bedrock tests. Those could not complete locally because `CONTEXT7_API_KEY` and AWS credentials are unavailable in this environment.
