### PR TITLE
docs: add OpenClaw installation guide

### DIFF
--- a/docs/resources/all-clients.mdx
+++ b/docs/resources/all-clients.mdx
@@ -127,6 +127,30 @@ Add this to your Opencode configuration file. See [Opencode MCP docs](https://op
 
 </Accordion>
 
+<Accordion title="OpenClaw">
+
+Add the hosted Context7 server with OpenClaw's MCP client registry. See the [OpenClaw MCP documentation](https://docs.openclaw.ai/tools/mcp) for more details.
+
+```sh
+openclaw mcp add context7 \
+  --url https://mcp.context7.com/mcp \
+  --transport streamable-http
+```
+
+This works without an API key at the anonymous rate limit. For higher limits, create a key in the [Context7 dashboard](https://context7.com/dashboard) and append this option to the command:
+
+```sh
+--header "Authorization: Bearer YOUR_API_KEY"
+```
+
+Verify that OpenClaw can connect and discover the Context7 tools:
+
+```sh
+openclaw mcp doctor context7 --probe
+```
+
+</Accordion>
+
 <Accordion title="OpenAI Codex">
 
 See [OpenAI Codex MCP docs](https://developers.openai.com/codex/mcp) for more info.

--- a/docs/resources/all-clients.mdx
+++ b/docs/resources/all-clients.mdx
@@ -131,6 +131,25 @@ Add this to your Opencode configuration file. See [Opencode MCP docs](https://op
 
 Add the hosted Context7 server with OpenClaw's MCP client registry. See the [OpenClaw MCP documentation](https://docs.openclaw.ai/tools/mcp) for more details.
 
+#### OAuth (Recommended)
+
+Register the Context7 OAuth endpoint, then sign in through your browser:
+
+```sh
+openclaw mcp add context7 \
+  --url https://mcp.context7.com/mcp/oauth \
+  --transport streamable-http \
+  --auth oauth
+
+openclaw mcp login context7
+```
+
+OpenClaw also provides a code-based login fallback for headless or remote environments. See [Set Up OAuth](/howto/oauth) for more details.
+
+#### API Key or Anonymous Access
+
+To connect without OAuth, register the standard endpoint:
+
 ```sh
 openclaw mcp add context7 \
   --url https://mcp.context7.com/mcp \


### PR DESCRIPTION
## What changed

- Added an OpenClaw section to the MCP Clients guide.
- Made OAuth the recommended hosted Context7 setup, including the explicit OpenClaw login command.
- Included API-key and anonymous alternatives plus a live probe command.

## Why

OpenClaw searches currently return no documentation result. The new exact-match section gives users a concise, searchable installation path.

## Validation

- Manually ran the documented add command with OpenClaw `2026.7.1-2` against `https://mcp.context7.com/mcp` using isolated temporary state.
- Ran `openclaw mcp doctor context7 --probe`; result: `context7: ok`.
- Registered `https://mcp.context7.com/mcp/oauth` with `--auth oauth` in a fresh isolated config and verified OpenClaw stored the expected OAuth configuration and exposed `openclaw mcp login context7`.
- Ran Prettier against `docs/resources/all-clients.mdx`.
- Ran `git diff --check`.
