### PR TITLE
chore(mcp): add OAuth issuer changeset

### DIFF
--- a/.changeset/mcp-clerk-oauth-issuer.md
+++ b/.changeset/mcp-clerk-oauth-issuer.md
@@ -1,0 +1,5 @@
+---
+"@upstash/context7-mcp": patch
+---
+
+Advertise Clerk as the OAuth authorization server so clients validate authorization responses against the issuer that Clerk returns.


### PR DESCRIPTION
## Summary

- add the missing patch changeset for the OAuth issuer fix merged in #3050
- bump only `@upstash/context7-mcp`

## Validation

- `pnpm exec changeset status` reports a patch release for `@upstash/context7-mcp`
- `git diff --check` passes