### PR TITLE
fix: handle network errors in pi API client

### DIFF
--- a/packages/pi/__tests__/api.test.ts
+++ b/packages/pi/__tests__/api.test.ts
@@ -63,9 +63,7 @@ describe("searchLibraries", () => {
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: vi.fn().mockResolvedValue({
-        results: [
-          { id: "express-lib", title: "Express", description: "Web framework" },
-        ],
+        results: [{ id: "express-lib", title: "Express", description: "Web framework" }],
       }),
       text: vi.fn(),
     });

--- a/packages/pi/__tests__/api.test.ts
+++ b/packages/pi/__tests__/api.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { searchLibraries, fetchLibraryContext } from "../lib/api";
+
+describe("fetchLibraryContext", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("returns parsed error string when API returns non-ok status", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: vi.fn().mockResolvedValue({ message: "Something went wrong" }),
+      text: vi.fn(),
+    });
+
+    const result = await fetchLibraryContext("express", "express-lib");
+    expect(typeof result).toBe("string");
+    expect(result).toBe("Something went wrong");
+  });
+
+  it("returns library context on successful response", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      text: vi.fn().mockResolvedValue("# Express Docs\n..."),
+    });
+
+    const result = await fetchLibraryContext("express", "express-lib");
+    expect(typeof result).toBe("string");
+    expect(result).toBe("# Express Docs\n...");
+  });
+
+  it("returns error message when response body is empty", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      text: vi.fn().mockResolvedValue(""),
+    });
+
+    const result = await fetchLibraryContext("express", "express-lib");
+    expect(typeof result).toBe("string");
+    expect(result).toContain("Documentation not found");
+  });
+});
+
+describe("searchLibraries", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("returns parsed error string when API returns non-ok status", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: vi.fn().mockResolvedValue({ message: "Search failed" }),
+      text: vi.fn(),
+    });
+
+    const result = await searchLibraries("express", "express");
+    expect(result.error).toBe("Search failed");
+  });
+
+  it("returns search results on successful response", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        results: [
+          { id: "express-lib", title: "Express", description: "Web framework" },
+        ],
+      }),
+      text: vi.fn(),
+    });
+
+    const result = await searchLibraries("express", "express");
+    expect(result.results).toHaveLength(1);
+    expect(result.results?.[0].title).toBe("Express");
+  });
+});
+
+describe("network error handling", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("fetchLibraryContext returns error string on network failure instead of throwing", async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error("Network connection failed"));
+
+    const result = await fetchLibraryContext("express", "express-lib");
+    expect(typeof result).toBe("string");
+    expect(result).toContain("Error");
+  });
+
+  it("searchLibraries returns error result on network failure instead of throwing", async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error("Network connection failed"));
+
+    const result = await searchLibraries("express", "express");
+    expect(result.error).toBeDefined();
+    expect(result.results).toEqual([]);
+  });
+});

--- a/packages/pi/lib/api.ts
+++ b/packages/pi/lib/api.ts
@@ -36,30 +36,38 @@ async function parseErrorResponse(response: Response): Promise<string> {
 }
 
 export async function searchLibraries(query: string, libraryName: string): Promise<SearchResponse> {
-  const url = new URL(`${BASE_URL}/v2/libs/search`);
-  url.searchParams.set("query", query);
-  url.searchParams.set("libraryName", libraryName);
+  try {
+    const url = new URL(`${BASE_URL}/v2/libs/search`);
+    url.searchParams.set("query", query);
+    url.searchParams.set("libraryName", libraryName);
 
-  const response = await fetch(url, { headers: authHeaders() });
-  if (!response.ok) {
-    return { results: [], error: await parseErrorResponse(response) };
+    const response = await fetch(url, { headers: authHeaders() });
+    if (!response.ok) {
+      return { results: [], error: await parseErrorResponse(response) };
+    }
+    return (await response.json()) as SearchResponse;
+  } catch (error) {
+    return { results: [], error: `Error searching libraries: ${error}` };
   }
-  return (await response.json()) as SearchResponse;
 }
 
 export async function fetchLibraryContext(query: string, libraryId: string): Promise<string> {
-  const url = new URL(`${BASE_URL}/v2/context`);
-  url.searchParams.set("query", query);
-  url.searchParams.set("libraryId", libraryId);
+  try {
+    const url = new URL(`${BASE_URL}/v2/context`);
+    url.searchParams.set("query", query);
+    url.searchParams.set("libraryId", libraryId);
 
-  const response = await fetch(url, { headers: authHeaders() });
-  if (!response.ok) {
-    return parseErrorResponse(response);
-  }
+    const response = await fetch(url, { headers: authHeaders() });
+    if (!response.ok) {
+      return await parseErrorResponse(response);
+    }
 
-  const text = await response.text();
-  if (!text) {
-    return "Documentation not found or not finalized for this library. This might have happened because you used an invalid Context7-compatible library ID. To get a valid Context7-compatible library ID, use the 'resolve-library-id' with the package name you wish to retrieve documentation for.";
+    const text = await response.text();
+    if (!text) {
+      return "Documentation not found or not finalized for this library. This might have happened because you used an invalid Context7-compatible library ID. To get a valid Context7-compatible library ID, use the 'resolve-library-id' with the package name you wish to retrieve documentation for.";
+    }
+    return text;
+  } catch (error) {
+    return `Error fetching library context: ${error}`;
   }
-  return text;
 }


### PR DESCRIPTION
## Summary
The pi package API functions called fetch without try-catch, so network failures (DNS errors, timeouts, connection resets) surfaced as unhandled exceptions and crashed the tool call instead of returning a readable error. Wrapped searchLibraries and fetchLibraryContext in try-catch, matching the MCP package implementation, so failures return user-friendly error strings.

## Testing
Reproduced by mocking fetch to reject with a network error; both functions threw before the fix and now return error messages instead. Added packages/pi/__tests__/api.test.ts covering network failures, non-ok statuses, empty bodies, and successful responses. All 11 pi package tests pass.

## Checklist
- [x] bug reproduced before fix
- [x] root cause identified
- [x] bug fixed
- [x] tests passed