### PR TITLE
fix(mcp): consume auth prompt signal

### DIFF
--- a/.changeset/consume-auth-prompt-signal.md
+++ b/.changeset/consume-auth-prompt-signal.md
@@ -1,0 +1,5 @@
+---
+"@upstash/context7-mcp": patch
+---
+
+Consume backend sign-in prompt signals after one elicitation so later tool calls do not reopen the same dialog.

--- a/packages/mcp/src/lib/auth/auth-prompt.ts
+++ b/packages/mcp/src/lib/auth/auth-prompt.ts
@@ -54,10 +54,10 @@ const CHOICE_STAY_ANON = "Continue anonymously with smaller limits";
  * the tool result the LLM reads, so it does not trip prompt-injection guards.
  *
  * The backend owns how often this fires: it sets the header at most once per
- * MCP session, so the server holds no suppression state — it simply shows the
- * dialog whenever the header is present. The command itself is shown in the
- * dialog message for the user to copy; the server does not attempt to drive
- * the client to run it.
+ * MCP session. The server consumes that captured signal when it starts the
+ * elicitation so later tool calls do not reopen the same dialog. The command
+ * itself is shown in the dialog message for the user to copy; the server does
+ * not attempt to drive the client to run it.
  *
  * No-op for authenticated callers, when the signal wasn't set, or when the
  * client did not advertise the `elicitation` capability. Fire-and-forget:
@@ -77,6 +77,7 @@ export function maybeElicitAuthSignIn(server: McpServer, ctx: ClientContext): vo
   if (ctx.apiKey || !ctx.shouldPrompt) return;
   if (!server.server.getClientCapabilities()?.elicitation) return;
 
+  ctx.shouldPrompt = false;
   void server.server
     .elicitInput({
       message: buildElicitMessage(ctx.clientInfo?.ide, ctx.transport),

--- a/packages/mcp/test/auth-prompt.test.ts
+++ b/packages/mcp/test/auth-prompt.test.ts
@@ -1,0 +1,26 @@
+import type { McpServer } from "@modelcontextprotocol/server";
+import { describe, expect, test, vi } from "vitest";
+import { maybeElicitAuthSignIn } from "../src/lib/auth/auth-prompt.js";
+import type { ClientContext } from "../src/lib/types.js";
+
+describe("maybeElicitAuthSignIn", () => {
+  test("consumes the backend prompt signal after eliciting once", () => {
+    const elicitInput = vi.fn().mockResolvedValue(undefined);
+    const server = {
+      server: {
+        getClientCapabilities: () => ({ elicitation: {} }),
+        elicitInput,
+      },
+    } as unknown as McpServer;
+    const context: ClientContext = {
+      shouldPrompt: true,
+      transport: "stdio",
+    };
+
+    maybeElicitAuthSignIn(server, context);
+    maybeElicitAuthSignIn(server, context);
+
+    expect(elicitInput).toHaveBeenCalledTimes(1);
+    expect(context.shouldPrompt).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- consume the backend sign-in prompt signal once elicitation starts
- prevent later stdio tool calls from reopening the same dialog
- add regression coverage and a patch changeset

## Why

The backend sends `X-Context7-Auth-Prompt: 1` at most once per MCP session. The server captured that signal in `ctx.shouldPrompt` but never cleared it, so clients advertising elicitation could reopen the same sign-in dialog after every subsequent tool call.

## Test plan

- `pnpm lint:check`
- `pnpm format:check`
- `pnpm build`
- `pnpm typecheck`
- MCP test suite — 80 passed