### PR TITLE
Fix Codex TOML parsing dropping multi-line/trailing-comma args arrays (silent version wipe on re-setup)

### DIFF
--- a/packages/cli/src/setup/mcp-writer.ts
+++ b/packages/cli/src/setup/mcp-writer.ts
@@ -119,10 +119,69 @@ export async function readTomlServerExists(filePath: string, serverName: string)
 /**
  * Reads the top-level `[mcp_servers.<serverName>]` block from a TOML config
  * file and parses its key-value lines into a JS object. Handles string and
- * array values (TOML array syntax is JSON-compatible). Sub-tables like
+ * array values (TOML array syntax is JSON-compatible), including arrays
+ * formatted across multiple lines. Sub-tables like
  * `[mcp_servers.<serverName>.http_headers]` are ignored. Returns undefined
  * if the file or section is missing.
  */
+/**
+ * True when every `[` outside a double-quoted string has a matching `]`.
+ * Multi-line arrays (taplo / cargo-fmt style) only parse once closed; TOML
+ * basic strings cannot contain an unescaped quote, so tracking string state
+ * is enough to avoid mis-counting brackets inside values like "[global]".
+ */
+function bracketsBalancedOutsideStrings(text: string): boolean {
+  let inString = false;
+  let depth = 0;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (inString) {
+      if (ch === "\\") i++;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') inString = true;
+    else if (ch === "[") depth++;
+    else if (ch === "]") depth--;
+  }
+  return depth <= 0 && !inString;
+}
+
+/**
+ * Removes commas that directly precede a closing `]` outside double-quoted
+ * strings. TOML permits trailing commas in arrays; JSON does not, so
+ * `["-y", "pkg",]` fails JSON.parse and the whole value would be dropped.
+ */
+function stripTrailingCommasOutsideStrings(text: string): string {
+  let result = "";
+  let inString = false;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (inString) {
+      result += ch;
+      if (ch === "\\") {
+        i++;
+        if (i < text.length) result += text[i];
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+      result += ch;
+      continue;
+    }
+    if (ch === ",") {
+      let j = i + 1;
+      while (j < text.length && /\s/.test(text[j])) j++;
+      if (j < text.length && text[j] === "]") continue; // drop the comma
+    }
+    result += ch;
+  }
+  return result;
+}
+
 export async function readTomlServerEntry(
   filePath: string,
   serverName: string
@@ -147,12 +206,29 @@ export async function readTomlServerEntry(
   const block = nextHeader ? rest.slice(0, nextHeader.index) : rest;
 
   const entry: Record<string, unknown> = {};
-  const lineRe = /^([A-Za-z_][\w-]*)\s*=\s*(.+?)\s*$/gm;
-  let lineMatch: RegExpExecArray | null;
-  while ((lineMatch = lineRe.exec(block)) !== null) {
+  const lineRe = /^([A-Za-z_][\w-]*)\s*=\s*(.+?)\s*$/;
+  const lines = block.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const lineMatch = lineRe.exec(lines[i]);
+    if (!lineMatch) continue;
     const [, key, valueText] = lineMatch;
+
+    // Multi-line array (formatted across lines by taplo, cargo fmt, or by
+    // hand): consume lines until brackets balance, then parse the joined
+    // text. JSON allows newlines as whitespace inside arrays, so the joined
+    // text parses directly. Without this, `args` silently disappears from
+    // the entry and callers treat the server as freshly configured.
+    let fullText = valueText;
+    if (valueText.startsWith("[") && !bracketsBalancedOutsideStrings(valueText)) {
+      const parts = [valueText];
+      while (i + 1 < lines.length && !bracketsBalancedOutsideStrings(parts.join("\n"))) {
+        parts.push(lines[++i].trim());
+      }
+      fullText = parts.join("\n");
+    }
+
     try {
-      entry[key] = JSON.parse(valueText);
+      entry[key] = JSON.parse(stripTrailingCommasOutsideStrings(fullText));
     } catch {
       // Skip values we can't parse as JSON (e.g., bare TOML numbers like 20)
     }


### PR DESCRIPTION
Follow-up to #3060 (thanks @fahreddinozcan for the quick ack). Opening this PR so the fix is reviewable directly — no pressure on timing.

## What it fixes

`readTomlServerEntry` in `packages/cli/src/setup/mcp-writer.ts` parses Codex `config.toml` server entries with per-line `JSON.parse`, which silently drops `args` when:

1. **The array is multi-line** — what taplo/Prettier/cargo-fmt produce once a line exceeds print width (any real API key makes this likely).
2. **The array has a trailing comma** — valid TOML, invalid JSON.

Downstream, `isStdioContext7Entry` then fails, `resolveEntryToWrite` falls back to a fresh canonical entry, and a re-setup that was only meant to rotate the API key **silently wipes the user's pinned `@upstash/context7-mcp@<version>` to a floating version**. Full repro chain in #3060.

## The change

- String-aware bracket balancing to join multi-line arrays before parsing.
- String-aware trailing-comma strip (commas inside string literals are untouched).

## Verification

- Repro cases from #3060: 3/3 pass with the patch, fail on unpatched main (git-stash control).
- Edge cases: multi-line array with embedded commas in strings; trailing-comma single-line array — both parse correctly.
- Full CLI suite: **254/254 passing**; `tsc --noEmit` clean.
