### PR TITLE
fix(cli): preserve pinned MCP args from multi-line TOML arrays

### DIFF
--- a/packages/cli/src/__tests__/setup.test.ts
+++ b/packages/cli/src/__tests__/setup.test.ts
@@ -1292,6 +1292,43 @@ describe("agent config integration", () => {
       expect(entry).toEqual({ type: "http", url: "https://mcp.context7.com/mcp" });
     });
 
+    test("parses multi-line array values and trailing commas", async () => {
+      const path = join(tempDir, "config.toml");
+      await writeFile(
+        path,
+        `[mcp_servers.context7]
+command = "npx"
+args = [
+  "-y",
+  "@upstash/context7-mcp@0.6.0",
+  "--api-key",
+  "OLD",
+]
+`,
+        "utf-8"
+      );
+      const entry = await readTomlServerEntry(path, "context7");
+      expect(entry).toEqual({
+        command: "npx",
+        args: ["-y", "@upstash/context7-mcp@0.6.0", "--api-key", "OLD"],
+      });
+      expect(isStdioContext7Entry(entry)).toBe(true);
+    });
+
+    test("parses single-line arrays with trailing commas", async () => {
+      const path = join(tempDir, "config.toml");
+      await writeFile(
+        path,
+        '[mcp_servers.context7]\ncommand = "npx"\nargs = ["-y", "@upstash/context7-mcp@0.6.0",]\n',
+        "utf-8"
+      );
+      const entry = await readTomlServerEntry(path, "context7");
+      expect(entry).toEqual({
+        command: "npx",
+        args: ["-y", "@upstash/context7-mcp@0.6.0"],
+      });
+    });
+
     test("round-trips through patchStdioApiKey + appendTomlServer", async () => {
       const path = join(tempDir, "config.toml");
       await writeFile(

--- a/packages/cli/src/setup/mcp-writer.ts
+++ b/packages/cli/src/setup/mcp-writer.ts
@@ -147,17 +147,54 @@ export async function readTomlServerEntry(
   const block = nextHeader ? rest.slice(0, nextHeader.index) : rest;
 
   const entry: Record<string, unknown> = {};
-  const lineRe = /^([A-Za-z_][\w-]*)\s*=\s*(.+?)\s*$/gm;
-  let lineMatch: RegExpExecArray | null;
-  while ((lineMatch = lineRe.exec(block)) !== null) {
-    const [, key, valueText] = lineMatch;
+  for (const [key, valueText] of parseTomlAssignmentTexts(block)) {
     try {
-      entry[key] = JSON.parse(valueText);
+      entry[key] = JSON.parse(normalizeTomlJsonValue(valueText));
     } catch {
       // Skip values we can't parse as JSON (e.g., bare TOML numbers like 20)
     }
   }
   return Object.keys(entry).length > 0 ? entry : undefined;
+}
+
+function parseTomlAssignmentTexts(block: string): Array<[string, string]> {
+  const assignments: Array<[string, string]> = [];
+  const lines = block.split("\n");
+  let index = 0;
+  while (index < lines.length) {
+    const line = lines[index].trim();
+    index += 1;
+    if (!line || line.startsWith("#")) {
+      continue;
+    }
+    const equalsIndex = line.indexOf("=");
+    if (equalsIndex === -1) {
+      continue;
+    }
+    const key = line.slice(0, equalsIndex).trim();
+    if (!/^[A-Za-z_][\w-]*$/.test(key)) {
+      continue;
+    }
+    let valueText = line.slice(equalsIndex + 1).trim();
+    if (valueText.startsWith("[") && !valueText.endsWith("]")) {
+      const parts = [valueText];
+      while (index < lines.length) {
+        const nextLine = lines[index].trim();
+        index += 1;
+        parts.push(nextLine);
+        if (nextLine.endsWith("]")) {
+          break;
+        }
+      }
+      valueText = parts.join("\n");
+    }
+    assignments.push([key, valueText]);
+  }
+  return assignments;
+}
+
+function normalizeTomlJsonValue(valueText: string): string {
+  return valueText.replace(/,\s*([\]}])/g, "$1");
 }
 
 /**


### PR DESCRIPTION
## Summary
- Parse multi-line TOML array values in `readTomlServerEntry` so re-setup keeps pinned `@upstash/context7-mcp` versions.
- Accept trailing commas in array literals before JSON parsing.

Fixes #3060

## Test plan
- [x] `npm test -- --run src/__tests__/setup.test.ts -t readTomlServerEntry` in `packages/cli`

Made with [Cursor](https://cursor.com)