### PR TITLE
docs: add Intercom chat

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -235,6 +235,11 @@
       "display": "simple"
     }
   },
+  "integrations": {
+    "intercom": {
+      "appId": "rtjkeau6"
+    }
+  },
   "logo": {
     "light": "/public/logo/logo.svg",
     "dark": "/public/logo/logo-dark.svg",


### PR DESCRIPTION
## Summary

- enable Mintlify's native Intercom integration
- use the existing public Intercom app ID shared with Context7 and Upstash

## Validation

- `jq empty docs/docs.json`
- parsed with the current `@mintlify/validation` docs schema
- `git diff --check`