### PR TITLE
fix(cli): recover Scoop Git Bash library IDs

### DIFF
--- a/.changeset/cli-scoop-git-bash-path.md
+++ b/.changeset/cli-scoop-git-bash-path.md
@@ -1,0 +1,5 @@
+---
+"ctx7": patch
+---
+
+Recover library IDs mangled by Git Bash when Git is installed through Scoop.

--- a/packages/cli/src/__tests__/library-id.test.ts
+++ b/packages/cli/src/__tests__/library-id.test.ts
@@ -26,6 +26,17 @@ describe("recoverLibraryId", () => {
     expect(recoverLibraryId("D:/tools/PortableGit/facebook/react")).toBe("/facebook/react");
   });
 
+  test("recovers from a versioned Scoop Git install", () => {
+    expect(recoverLibraryId("D:/Scoop/apps/git/2.54.0/vercel/next.js")).toBe("/vercel/next.js");
+    expect(recoverLibraryId("D:\\Scoop\\apps\\git\\2.54.0.windows.1\\vercel\\next.js")).toBe(
+      "/vercel/next.js"
+    );
+  });
+
+  test("does not treat a version-like owner in a standard Git install as a Scoop version", () => {
+    expect(recoverLibraryId("C:/Program Files/Git/2.54.0/vercel")).toBe("/2.54.0/vercel");
+  });
+
   test("recovers an owner that looks like a system dir", () => {
     expect(recoverLibraryId("C:/Program Files/Git/usr/some-repo")).toBe("/usr/some-repo");
   });

--- a/packages/cli/src/__tests__/library-id.test.ts
+++ b/packages/cli/src/__tests__/library-id.test.ts
@@ -33,6 +33,10 @@ describe("recoverLibraryId", () => {
     );
   });
 
+  test("recovers from an unresolved Scoop current junction", () => {
+    expect(recoverLibraryId("D:/Scoop/apps/git/current/vercel/next.js")).toBe("/vercel/next.js");
+  });
+
   test("does not treat a version-like owner in a standard Git install as a Scoop version", () => {
     expect(recoverLibraryId("C:/Program Files/Git/2.54.0/vercel")).toBe("/2.54.0/vercel");
   });

--- a/packages/cli/src/utils/library-id.ts
+++ b/packages/cli/src/utils/library-id.ts
@@ -17,6 +17,14 @@ export function recoverLibraryId(input: string): string {
 
   // Strip the Git install dir, keeping the "/owner/repo[/version]" tail.
   const normalized = input.replace(/\\/g, "/");
+
+  // Scoop installs Git under apps/git/<version>. MSYS resolves Scoop's "current"
+  // junction, so discard that version segment before recovering the library ID.
+  const scoopMatch = normalized.match(
+    /^[A-Za-z]:\/.*\/apps\/git\/v?\d+(?:\.\d+)+(?:[^/]*)\/(.+)$/i
+  );
+  if (scoopMatch) return `/${scoopMatch[1]}`;
+
   const match = normalized.match(/^[A-Za-z]:\/.*?\/(?:Git|PortableGit|git-bash)\/(.+)$/i);
   return match ? `/${match[1]}` : input;
 }

--- a/packages/cli/src/utils/library-id.ts
+++ b/packages/cli/src/utils/library-id.ts
@@ -18,10 +18,10 @@ export function recoverLibraryId(input: string): string {
   // Strip the Git install dir, keeping the "/owner/repo[/version]" tail.
   const normalized = input.replace(/\\/g, "/");
 
-  // Scoop installs Git under apps/git/<version>. MSYS resolves Scoop's "current"
-  // junction, so discard that version segment before recovering the library ID.
+  // Scoop installs Git under apps/git/<version> with a "current" junction.
+  // Discard either form before recovering the library ID.
   const scoopMatch = normalized.match(
-    /^[A-Za-z]:\/.*\/apps\/git\/v?\d+(?:\.\d+)+(?:[^/]*)\/(.+)$/i
+    /^[A-Za-z]:\/.*\/apps\/git\/(?:v?\d+(?:\.\d+)+[^/]*|current)\/(.+)$/i
   );
   if (scoopMatch) return `/${scoopMatch[1]}`;
 


### PR DESCRIPTION
## Summary

- recognize Scoop Git installs under `apps/git/<version>` when recovering Git Bash-mangled arguments
- remove Scoop's Git version segment without changing standard Git install behavior
- add regression coverage for slash styles, Git version suffixes, and version-like library owners

## Tests

- `pnpm --filter ctx7 test`
- `pnpm --filter ctx7 typecheck`
- `pnpm --filter ctx7 lint:check`
- `pnpm --filter ctx7 format:check`
- `pnpm --filter ctx7 build`

Closes #3082