### PR TITLE
feat(cli): add VS Code setup target

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -25,6 +25,7 @@ ctx7 remove
 ctx7 setup --cursor
 ctx7 setup --claude
 ctx7 setup --opencode
+ctx7 setup --vscode
 ```
 
 ### Library Documentation
@@ -79,6 +80,7 @@ ctx7 setup
 ctx7 setup --cursor
 ctx7 setup --claude
 ctx7 setup --opencode
+ctx7 setup --vscode
 
 # Use an existing API key instead of OAuth
 ctx7 setup --api-key YOUR_API_KEY
@@ -104,6 +106,7 @@ ctx7 remove
 # Target specific agents
 ctx7 remove --cursor
 ctx7 remove --claude --project
+ctx7 remove --vscode --project
 
 # Remove both setup modes explicitly
 ctx7 remove --cursor --all
@@ -139,6 +142,7 @@ The CLI automatically detects which AI coding assistants you have installed and 
 | Universal (Amp, Codex, Gemini CLI, GitHub Copilot, OpenCode + more) | `.agents/skills/` |
 | Claude Code                                                         | `.claude/skills/` |
 | Cursor                                                              | `.cursor/skills/` |
+| VS Code                                                             | `.agents/skills/` |
 | Antigravity                                                         | `.agent/skills/`  |
 
 ## Disabling Telemetry

--- a/packages/cli/src/__tests__/agent-command-registry.test.ts
+++ b/packages/cli/src/__tests__/agent-command-registry.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "vitest";
+import { Command } from "commander";
+
+import { registerSetupCommand } from "../commands/setup.js";
+import { registerRemoveCommand } from "../commands/remove.js";
+import { ALL_AGENT_NAMES, getAgent } from "../setup/agents.js";
+
+function registeredLongOptions(command: Command): string[] {
+  return command.options.flatMap((option) => (option.long ? [option.long] : []));
+}
+
+describe("agent command registry", () => {
+  test.each([
+    ["setup", registerSetupCommand],
+    ["remove", registerRemoveCommand],
+  ] as const)("%s exposes every registered agent flag", (commandName, register) => {
+    const program = new Command();
+    register(program);
+
+    const command = program.commands.find((candidate) => candidate.name() === commandName);
+    expect(command).toBeDefined();
+    expect(registeredLongOptions(command!)).toEqual(
+      expect.arrayContaining(ALL_AGENT_NAMES.map((name) => `--${name}`))
+    );
+  });
+
+  test("file-specific rule formatting belongs to the agent policy", () => {
+    const cursorRule = getAgent("cursor").rule;
+    expect(cursorRule.kind).toBe("file");
+    if (cursorRule.kind === "file") {
+      expect(cursorRule.contentPrefix).toBe(`---\nalwaysApply: true\n---\n\n`);
+    }
+  });
+});

--- a/packages/cli/src/__tests__/remove.test.ts
+++ b/packages/cli/src/__tests__/remove.test.ts
@@ -293,6 +293,32 @@ describe("remove command", () => {
     });
   });
 
+  test("removes only context7 from VS Code MCP config", async () => {
+    const mcpPath = join(tempDir, ".vscode", "mcp.json");
+
+    await mkdir(join(tempDir, ".vscode"), { recursive: true });
+    await writeFile(
+      mcpPath,
+      JSON.stringify(
+        {
+          servers: {
+            other: { type: "http", url: "https://other.com" },
+            context7: { type: "http", url: "https://mcp.context7.com/mcp" },
+          },
+        },
+        null,
+        2
+      ),
+      "utf-8"
+    );
+
+    await runCommand("remove", "--vscode", "--mcp", "--project");
+
+    expect(JSON.parse(await readFile(mcpPath, "utf-8"))).toEqual({
+      servers: { other: { type: "http", url: "https://other.com" } },
+    });
+  });
+
   test("removes only context7 from opencode JSONC MCP config", async () => {
     const configPath = join(tempDir, "opencode.jsonc");
 

--- a/packages/cli/src/__tests__/setup.test.ts
+++ b/packages/cli/src/__tests__/setup.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
 import { mkdir, readFile, writeFile, rm } from "fs/promises";
 import { join } from "path";
-import { homedir, tmpdir } from "os";
+import { tmpdir } from "os";
 
 const MOCK_MCP_RULE = "Use Context7 MCP to fetch docs.\n";
 const MOCK_CLI_RULE = "Use the `ctx7` CLI to fetch docs.\n";
@@ -33,29 +33,17 @@ import {
   isStdioContext7Entry,
   patchStdioApiKey,
 } from "../setup/mcp-writer.js";
-import { getAgent, ALL_AGENT_NAMES, type AuthOptions } from "../setup/agents.js";
+import {
+  getAgent,
+  ALL_AGENT_NAMES,
+  resolveVscodeUserDir,
+  type AuthOptions,
+} from "../setup/agents.js";
 
 describe("getRuleContent", () => {
   test("returns correct content per mode", async () => {
     expect(await getRuleContent("mcp", "claude")).toBe(MOCK_MCP_RULE);
     expect(await getRuleContent("cli", "claude")).toBe(MOCK_CLI_RULE);
-  });
-
-  test("only cursor gets alwaysApply frontmatter", async () => {
-    const cursor = await getRuleContent("mcp", "cursor");
-    expect(cursor).toContain("---\nalwaysApply: true\n---");
-    expect(cursor).toContain(MOCK_MCP_RULE);
-
-    for (const agent of ["claude", "vscode", "antigravity", "codex", "opencode", "gemini"]) {
-      const content = await getRuleContent("mcp", agent);
-      expect(content).not.toContain("alwaysApply");
-    }
-  });
-
-  test("VS Code gets always-on instructions frontmatter", async () => {
-    const content = await getRuleContent("mcp", "vscode");
-    expect(content).toContain('---\napplyTo: "**"\n---');
-    expect(content).toContain(MOCK_MCP_RULE);
   });
 
   test("returns fallback content when all fetch URLs fail", async () => {
@@ -795,12 +783,29 @@ describe("agent config integration", () => {
       });
     });
 
-    test("uses project and platform-specific global MCP paths", () => {
+    test("uses the VS Code project MCP path", () => {
       expect(agent.mcp.projectPaths).toEqual([join(".vscode", "mcp.json")]);
-      if (process.platform === "darwin") {
-        expect(agent.mcp.globalPaths).toEqual([
-          join(homedir(), "Library", "Application Support", "Code", "User", "mcp.json"),
-        ]);
+    });
+
+    test.each([
+      ["darwin", "/home/test", {}, "/home/test/Library/Application Support/Code/User"],
+      [
+        "win32",
+        "/home/test",
+        { APPDATA: "C:\\Users\\test\\AppData\\Roaming" },
+        "C:\\Users\\test\\AppData\\Roaming/Code/User",
+      ],
+      ["win32", "/home/test", {}, "/home/test/AppData/Roaming/Code/User"],
+      ["linux", "/home/test", { XDG_CONFIG_HOME: "/xdg" }, "/xdg/Code/User"],
+      ["linux", "/home/test", {}, "/home/test/.config/Code/User"],
+    ] as const)("resolves the %s user directory", (platform, home, env, expected) => {
+      expect(resolveVscodeUserDir(platform, home, env)).toBe(expected);
+    });
+
+    test("owns its instructions frontmatter in the agent rule policy", () => {
+      expect(agent.rule.kind).toBe("file");
+      if (agent.rule.kind === "file") {
+        expect(agent.rule.contentPrefix).toBe('---\napplyTo: "**"\n---\n\n');
       }
     });
 
@@ -1078,18 +1083,6 @@ describe("agent config integration", () => {
   });
 
   describe("all agents have consistent config", () => {
-    test("all agents are covered", () => {
-      expect(ALL_AGENT_NAMES).toEqual([
-        "claude",
-        "cursor",
-        "vscode",
-        "opencode",
-        "codex",
-        "antigravity",
-        "gemini",
-      ]);
-    });
-
     test.each(ALL_AGENT_NAMES)("%s buildEntry returns url for both auth modes", (name) => {
       const agent = getAgent(name);
       const apiEntry = agent.mcp.buildEntry(apiKeyAuth, "http");

--- a/packages/cli/src/__tests__/setup.test.ts
+++ b/packages/cli/src/__tests__/setup.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
 import { mkdir, readFile, writeFile, rm } from "fs/promises";
 import { join } from "path";
-import { tmpdir } from "os";
+import { homedir, tmpdir } from "os";
 
 const MOCK_MCP_RULE = "Use Context7 MCP to fetch docs.\n";
 const MOCK_CLI_RULE = "Use the `ctx7` CLI to fetch docs.\n";
@@ -46,10 +46,16 @@ describe("getRuleContent", () => {
     expect(cursor).toContain("---\nalwaysApply: true\n---");
     expect(cursor).toContain(MOCK_MCP_RULE);
 
-    for (const agent of ["claude", "antigravity", "codex", "opencode", "gemini"]) {
+    for (const agent of ["claude", "vscode", "antigravity", "codex", "opencode", "gemini"]) {
       const content = await getRuleContent("mcp", agent);
       expect(content).not.toContain("alwaysApply");
     }
+  });
+
+  test("VS Code gets always-on instructions frontmatter", async () => {
+    const content = await getRuleContent("mcp", "vscode");
+    expect(content).toContain('---\napplyTo: "**"\n---');
+    expect(content).toContain(MOCK_MCP_RULE);
   });
 
   test("returns fallback content when all fetch URLs fail", async () => {
@@ -771,6 +777,58 @@ describe("agent config integration", () => {
     });
   });
 
+  describe("vscode", () => {
+    const agent = getAgent("vscode");
+
+    test("buildEntry with api-key produces VS Code HTTP shape", () => {
+      expect(agent.mcp.buildEntry(apiKeyAuth, "http")).toEqual({
+        type: "http",
+        url: "https://mcp.context7.com/mcp",
+        headers: { Authorization: "Bearer sk-test-123" },
+      });
+    });
+
+    test("buildEntry with oauth produces VS Code HTTP shape without headers", () => {
+      expect(agent.mcp.buildEntry(oauthAuth, "http")).toEqual({
+        type: "http",
+        url: "https://mcp.context7.com/mcp/oauth",
+      });
+    });
+
+    test("uses project and platform-specific global MCP paths", () => {
+      expect(agent.mcp.projectPaths).toEqual([join(".vscode", "mcp.json")]);
+      if (process.platform === "darwin") {
+        expect(agent.mcp.globalPaths).toEqual([
+          join(homedir(), "Library", "Application Support", "Code", "User", "mcp.json"),
+        ]);
+      }
+    });
+
+    test("merges into the VS Code servers section", async () => {
+      const path = join(tempDir, "mcp.json");
+      await writeJsonConfig(path, { servers: { other: { url: "https://other.com" } } });
+
+      const existing = await readJsonConfig(path);
+      const { config } = mergeServerEntry(
+        existing,
+        agent.mcp.configKey,
+        "context7",
+        agent.mcp.buildEntry(apiKeyAuth, "http")
+      );
+      await writeJsonConfig(path, config);
+
+      const result = await readJsonConfig(path);
+      expect((result.servers as Record<string, unknown>).context7).toEqual({
+        type: "http",
+        url: "https://mcp.context7.com/mcp",
+        headers: { Authorization: "Bearer sk-test-123" },
+      });
+      expect((result.servers as Record<string, unknown>).other).toEqual({
+        url: "https://other.com",
+      });
+    });
+  });
+
   describe("opencode", () => {
     const agent = getAgent("opencode");
 
@@ -1024,6 +1082,7 @@ describe("agent config integration", () => {
       expect(ALL_AGENT_NAMES).toEqual([
         "claude",
         "cursor",
+        "vscode",
         "opencode",
         "codex",
         "antigravity",
@@ -1072,6 +1131,15 @@ describe("agent config integration", () => {
     test("cursor stdio entry uses npx command with --api-key in args", () => {
       const entry = getAgent("cursor").mcp.buildEntry(apiKeyAuth, "stdio");
       expect(entry).toEqual({
+        command: "npx",
+        args: ["-y", "@upstash/context7-mcp", "--api-key", "sk-test-stdio"],
+      });
+    });
+
+    test("vscode stdio entry includes the stdio transport discriminator", () => {
+      const entry = getAgent("vscode").mcp.buildEntry(apiKeyAuth, "stdio");
+      expect(entry).toEqual({
+        type: "stdio",
         command: "npx",
         args: ["-y", "@upstash/context7-mcp", "--api-key", "sk-test-stdio"],
       });

--- a/packages/cli/src/commands/remove.ts
+++ b/packages/cli/src/commands/remove.ts
@@ -4,7 +4,7 @@ import ora from "ora";
 import { checkboxWithHover } from "../utils/prompts.js";
 import { log } from "../utils/logger.js";
 import { trackEvent } from "../utils/tracking.js";
-import { ALL_AGENT_NAMES, SETUP_AGENT_NAMES, getAgent, type SetupAgent } from "../setup/agents.js";
+import { ALL_AGENT_NAMES, getAgent, type SetupAgent } from "../setup/agents.js";
 import {
   readJsonConfig,
   readTomlServerExists,
@@ -19,20 +19,13 @@ import { access, readFile, rm, writeFile } from "fs/promises";
 type Scope = "global" | "project";
 type UninstallMode = "mcp" | "cli";
 
-interface UninstallOptions {
-  claude?: boolean;
-  cursor?: boolean;
-  vscode?: boolean;
-  opencode?: boolean;
-  codex?: boolean;
-  antigravity?: boolean;
-  gemini?: boolean;
+type UninstallOptions = Partial<Record<SetupAgent, boolean>> & {
   project?: boolean;
   yes?: boolean;
   all?: boolean;
   cli?: boolean;
   mcp?: boolean;
-}
+};
 
 interface CleanupStatus {
   status: string;
@@ -69,17 +62,17 @@ const MODE_LABELS: Record<UninstallMode, string> = {
 };
 
 export function registerRemoveCommand(program: Command): void {
-  program
+  const command = program
     .command("remove")
     .alias("uninstall")
-    .description("Remove Context7 setup from your AI coding agent")
-    .option("--claude", "Remove from Claude Code")
-    .option("--cursor", "Remove from Cursor")
-    .option("--vscode", "Remove from VS Code")
-    .option("--opencode", "Remove from OpenCode")
-    .option("--codex", "Remove from Codex")
-    .option("--antigravity", "Remove from Antigravity")
-    .option("--gemini", "Remove from Gemini CLI")
+    .description("Remove Context7 setup from your AI coding agent");
+
+  for (const name of ALL_AGENT_NAMES) {
+    const agent = getAgent(name);
+    command.option(`--${name}`, `Remove from ${agent.displayName}`);
+  }
+
+  command
     .option("--all", "Remove both MCP setup and CLI + Skills setup")
     .option("--mcp", "Remove MCP setup")
     .option("--cli", "Remove CLI + Skills setup")
@@ -91,25 +84,17 @@ export function registerRemoveCommand(program: Command): void {
 }
 
 function getSelectedAgents(options: UninstallOptions): SetupAgent[] {
-  const agents: SetupAgent[] = [];
-  if (options.claude) agents.push("claude");
-  if (options.cursor) agents.push("cursor");
-  if (options.vscode) agents.push("vscode");
-  if (options.opencode) agents.push("opencode");
-  if (options.codex) agents.push("codex");
-  if (options.antigravity) agents.push("antigravity");
-  if (options.gemini) agents.push("gemini");
-  return agents;
+  return ALL_AGENT_NAMES.filter((name) => options[name]);
 }
 
 async function promptAgents(detected: SetupAgent[]): Promise<SetupAgent[] | null> {
   const choices = detected.map((name) => ({
-    name: SETUP_AGENT_NAMES[name],
+    name: getAgent(name).displayName,
     value: name,
   }));
 
   if (detected.length > 0) {
-    log.dim(`Detected: ${detected.map((agent) => SETUP_AGENT_NAMES[agent]).join(", ")}`);
+    log.dim(`Detected: ${detected.map((agent) => getAgent(agent).displayName).join(", ")}`);
   }
 
   try {
@@ -120,7 +105,7 @@ async function promptAgents(detected: SetupAgent[]): Promise<SetupAgent[] | null
         loop: false,
         theme: CHECKBOX_THEME,
       },
-      { getName: (agent: SetupAgent) => SETUP_AGENT_NAMES[agent] }
+      { getName: (agent: SetupAgent) => getAgent(agent).displayName }
     );
   } catch {
     return null;

--- a/packages/cli/src/commands/remove.ts
+++ b/packages/cli/src/commands/remove.ts
@@ -22,6 +22,7 @@ type UninstallMode = "mcp" | "cli";
 interface UninstallOptions {
   claude?: boolean;
   cursor?: boolean;
+  vscode?: boolean;
   opencode?: boolean;
   codex?: boolean;
   antigravity?: boolean;
@@ -74,6 +75,7 @@ export function registerRemoveCommand(program: Command): void {
     .description("Remove Context7 setup from your AI coding agent")
     .option("--claude", "Remove from Claude Code")
     .option("--cursor", "Remove from Cursor")
+    .option("--vscode", "Remove from VS Code")
     .option("--opencode", "Remove from OpenCode")
     .option("--codex", "Remove from Codex")
     .option("--antigravity", "Remove from Antigravity")
@@ -92,6 +94,7 @@ function getSelectedAgents(options: UninstallOptions): SetupAgent[] {
   const agents: SetupAgent[] = [];
   if (options.claude) agents.push("claude");
   if (options.cursor) agents.push("cursor");
+  if (options.vscode) agents.push("vscode");
   if (options.opencode) agents.push("opencode");
   if (options.codex) agents.push("codex");
   if (options.antigravity) agents.push("antigravity");
@@ -154,7 +157,7 @@ async function resolveAgents(options: UninstallOptions, scope: Scope): Promise<S
 
   if (detected.length === 0) {
     log.warn(
-      "No Context7 setup detected. Pass --claude, --cursor, --opencode, --codex, --antigravity, or --gemini."
+      "No Context7 setup detected. Pass --claude, --cursor, --vscode, --opencode, --codex, --antigravity, or --gemini."
     );
     return [];
   }

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -17,7 +17,6 @@ import {
   type SetupAgent,
   type AuthOptions,
   type Transport,
-  SETUP_AGENT_NAMES,
   AUTH_MODE_LABELS,
   ALL_AGENT_NAMES,
   getAgent,
@@ -39,14 +38,7 @@ import {
 type Scope = "global" | "project";
 type SetupMode = "mcp" | "cli";
 
-interface SetupOptions {
-  claude?: boolean;
-  cursor?: boolean;
-  vscode?: boolean;
-  antigravity?: boolean;
-  opencode?: boolean;
-  codex?: boolean;
-  gemini?: boolean;
+type SetupOptions = Partial<Record<SetupAgent, boolean>> & {
   project?: boolean;
   yes?: boolean;
   apiKey?: string;
@@ -54,7 +46,7 @@ interface SetupOptions {
   cli?: boolean;
   mcp?: boolean;
   stdio?: boolean;
-}
+};
 
 function resolveTransport(options: SetupOptions): Transport {
   return options.stdio ? "stdio" : "http";
@@ -68,28 +60,18 @@ const CHECKBOX_THEME = {
 };
 
 function getSelectedAgents(options: SetupOptions): SetupAgent[] {
-  const agents: SetupAgent[] = [];
-  if (options.claude) agents.push("claude");
-  if (options.cursor) agents.push("cursor");
-  if (options.vscode) agents.push("vscode");
-  if (options.opencode) agents.push("opencode");
-  if (options.codex) agents.push("codex");
-  if (options.antigravity) agents.push("antigravity");
-  if (options.gemini) agents.push("gemini");
-  return agents;
+  return ALL_AGENT_NAMES.filter((name) => options[name]);
 }
 
 export function registerSetupCommand(program: Command): void {
-  program
-    .command("setup")
-    .description("Set up Context7 for your AI coding agent")
-    .option("--claude", "Set up for Claude Code")
-    .option("--cursor", "Set up for Cursor")
-    .option("--vscode", "Set up for VS Code")
-    .option("--antigravity", "Set up for Antigravity (.agent/skills)")
-    .option("--opencode", "Set up for OpenCode")
-    .option("--codex", "Set up for Codex")
-    .option("--gemini", "Set up for Gemini CLI")
+  const command = program.command("setup").description("Set up Context7 for your AI coding agent");
+
+  for (const name of ALL_AGENT_NAMES) {
+    const agent = getAgent(name);
+    command.option(`--${name}`, agent.setupDescription ?? `Set up for ${agent.displayName}`);
+  }
+
+  command
     .option("--mcp", "Set up MCP server mode")
     .option("--cli", "Set up CLI + Skills mode (no MCP server)")
     .option("-p, --project", "Configure for current project instead of globally")
@@ -190,7 +172,7 @@ async function resolveCliAuth(apiKey?: string): Promise<void> {
 
 async function promptAgents(): Promise<SetupAgent[] | null> {
   const choices = ALL_AGENT_NAMES.map((name) => ({
-    name: SETUP_AGENT_NAMES[name],
+    name: getAgent(name).displayName,
     value: name,
   }));
 
@@ -204,7 +186,7 @@ async function promptAgents(): Promise<SetupAgent[] | null> {
         loop: false,
         theme: CHECKBOX_THEME,
       },
-      { getName: (a: SetupAgent) => SETUP_AGENT_NAMES[a] }
+      { getName: (a: SetupAgent) => getAgent(a).displayName }
     );
   } catch {
     return null;
@@ -236,9 +218,10 @@ async function installRule(
 ): Promise<{ status: string; path: string }> {
   const agent = getAgent(agentName);
   const rule = agent.rule;
-  const content = await getRuleContent(mode, agentName);
+  const body = await getRuleContent(mode, agentName);
 
   if (rule.kind === "file") {
+    const content = `${rule.contentPrefix ?? ""}${body}`;
     const ruleDir =
       scope === "global" ? rule.dir("global") : join(process.cwd(), rule.dir("project"));
     const rulePath = join(ruleDir, rule.filename);
@@ -250,7 +233,7 @@ async function installRule(
   const filePath =
     scope === "global" ? rule.file("global") : join(process.cwd(), rule.file("project"));
   const escapedMarker = rule.sectionMarker.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const section = `${rule.sectionMarker}\n${content}${rule.sectionMarker}`;
+  const section = `${rule.sectionMarker}\n${body}${rule.sectionMarker}`;
 
   let existing = "";
   try {

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -42,6 +42,7 @@ type SetupMode = "mcp" | "cli";
 interface SetupOptions {
   claude?: boolean;
   cursor?: boolean;
+  vscode?: boolean;
   antigravity?: boolean;
   opencode?: boolean;
   codex?: boolean;
@@ -70,6 +71,7 @@ function getSelectedAgents(options: SetupOptions): SetupAgent[] {
   const agents: SetupAgent[] = [];
   if (options.claude) agents.push("claude");
   if (options.cursor) agents.push("cursor");
+  if (options.vscode) agents.push("vscode");
   if (options.opencode) agents.push("opencode");
   if (options.codex) agents.push("codex");
   if (options.antigravity) agents.push("antigravity");
@@ -83,6 +85,7 @@ export function registerSetupCommand(program: Command): void {
     .description("Set up Context7 for your AI coding agent")
     .option("--claude", "Set up for Claude Code")
     .option("--cursor", "Set up for Cursor")
+    .option("--vscode", "Set up for VS Code")
     .option("--antigravity", "Set up for Antigravity (.agent/skills)")
     .option("--opencode", "Set up for OpenCode")
     .option("--codex", "Set up for Codex")

--- a/packages/cli/src/setup/agents.ts
+++ b/packages/cli/src/setup/agents.ts
@@ -2,7 +2,14 @@ import { access } from "fs/promises";
 import { join } from "path";
 import { homedir } from "os";
 
-export type SetupAgent = "claude" | "cursor" | "opencode" | "codex" | "antigravity" | "gemini";
+export type SetupAgent =
+  | "claude"
+  | "cursor"
+  | "vscode"
+  | "opencode"
+  | "codex"
+  | "antigravity"
+  | "gemini";
 export type AuthMode = "oauth" | "api-key";
 export type Transport = "http" | "stdio";
 
@@ -14,6 +21,7 @@ export interface AuthOptions {
 export const SETUP_AGENT_NAMES: Record<SetupAgent, string> = {
   claude: "Claude Code",
   cursor: "Cursor",
+  vscode: "VS Code",
   opencode: "OpenCode",
   codex: "Codex",
   antigravity: "Antigravity",
@@ -49,6 +57,16 @@ function claudeGlobalMcpPath(): string {
     return join(claudeConfigDir(), ".claude.json");
   }
   return join(homedir(), ".claude.json");
+}
+
+function vscodeUserDir(): string {
+  if (process.platform === "win32") {
+    return join(process.env.APPDATA || join(homedir(), "AppData", "Roaming"), "Code", "User");
+  }
+  if (process.platform === "darwin") {
+    return join(homedir(), "Library", "Application Support", "Code", "User");
+  }
+  return join(process.env.XDG_CONFIG_HOME || join(homedir(), ".config"), "Code", "User");
 }
 
 export type RuleType =
@@ -163,6 +181,39 @@ const agents: Record<SetupAgent, AgentConfig> = {
     detect: {
       projectPaths: [".cursor"],
       globalPaths: [join(homedir(), ".cursor")],
+    },
+  },
+
+  vscode: {
+    name: "vscode",
+    displayName: "VS Code",
+    mcp: {
+      projectPaths: [join(".vscode", "mcp.json")],
+      get globalPaths() {
+        return [join(vscodeUserDir(), "mcp.json")];
+      },
+      configKey: "servers",
+      buildEntry: (auth, transport) =>
+        transport === "stdio"
+          ? { type: "stdio", ...stdioEntry(auth) }
+          : withHeaders({ type: "http", url: mcpUrl(auth) }, auth),
+    },
+    rule: {
+      kind: "file",
+      dir: (scope) =>
+        scope === "global" ? join(vscodeUserDir(), "prompts") : join(".github", "instructions"),
+      filename: "context7.instructions.md",
+    },
+    skill: {
+      name: "context7-mcp",
+      dir: (scope) =>
+        scope === "global" ? join(homedir(), ".agents", "skills") : join(".agents", "skills"),
+    },
+    detect: {
+      projectPaths: [".vscode"],
+      get globalPaths() {
+        return [vscodeUserDir()];
+      },
     },
   },
 

--- a/packages/cli/src/setup/agents.ts
+++ b/packages/cli/src/setup/agents.ts
@@ -2,14 +2,6 @@ import { access } from "fs/promises";
 import { join } from "path";
 import { homedir } from "os";
 
-export type SetupAgent =
-  | "claude"
-  | "cursor"
-  | "vscode"
-  | "opencode"
-  | "codex"
-  | "antigravity"
-  | "gemini";
 export type AuthMode = "oauth" | "api-key";
 export type Transport = "http" | "stdio";
 
@@ -17,16 +9,6 @@ export interface AuthOptions {
   mode: AuthMode;
   apiKey?: string;
 }
-
-export const SETUP_AGENT_NAMES: Record<SetupAgent, string> = {
-  claude: "Claude Code",
-  cursor: "Cursor",
-  vscode: "VS Code",
-  opencode: "OpenCode",
-  codex: "Codex",
-  antigravity: "Antigravity",
-  gemini: "Gemini CLI",
-};
 
 export const AUTH_MODE_LABELS: Record<AuthMode, string> = {
   oauth: "OAuth",
@@ -59,14 +41,21 @@ function claudeGlobalMcpPath(): string {
   return join(homedir(), ".claude.json");
 }
 
-function vscodeUserDir(): string {
-  if (process.platform === "win32") {
-    return join(process.env.APPDATA || join(homedir(), "AppData", "Roaming"), "Code", "User");
+export function resolveVscodeUserDir(
+  platform: NodeJS.Platform = process.platform,
+  home: string = homedir(),
+  env: { APPDATA?: string; XDG_CONFIG_HOME?: string } = {
+    APPDATA: process.env.APPDATA,
+    XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME,
   }
-  if (process.platform === "darwin") {
-    return join(homedir(), "Library", "Application Support", "Code", "User");
+): string {
+  if (platform === "win32") {
+    return join(env.APPDATA || join(home, "AppData", "Roaming"), "Code", "User");
   }
-  return join(process.env.XDG_CONFIG_HOME || join(homedir(), ".config"), "Code", "User");
+  if (platform === "darwin") {
+    return join(home, "Library", "Application Support", "Code", "User");
+  }
+  return join(env.XDG_CONFIG_HOME || join(home, ".config"), "Code", "User");
 }
 
 export type RuleType =
@@ -74,12 +63,13 @@ export type RuleType =
       kind: "file";
       dir: (scope: "project" | "global") => string;
       filename: string;
+      contentPrefix?: string;
     }
   | { kind: "append"; file: (scope: "project" | "global") => string; sectionMarker: string };
 
 export interface AgentConfig {
-  name: SetupAgent;
   displayName: string;
+  setupDescription?: string;
   mcp: {
     projectPaths: string[];
     globalPaths: string[];
@@ -123,9 +113,8 @@ function withHeaders(base: Record<string, unknown>, auth: AuthOptions): Record<s
   return base;
 }
 
-const agents: Record<SetupAgent, AgentConfig> = {
+const agents = {
   claude: {
-    name: "claude",
     displayName: "Claude Code",
     mcp: {
       projectPaths: [".mcp.json"],
@@ -158,7 +147,6 @@ const agents: Record<SetupAgent, AgentConfig> = {
   },
 
   cursor: {
-    name: "cursor",
     displayName: "Cursor",
     mcp: {
       projectPaths: [join(".cursor", "mcp.json")],
@@ -172,6 +160,7 @@ const agents: Record<SetupAgent, AgentConfig> = {
       dir: (scope) =>
         scope === "global" ? join(homedir(), ".cursor", "rules") : join(".cursor", "rules"),
       filename: "context7.mdc",
+      contentPrefix: `---\nalwaysApply: true\n---\n\n`,
     },
     skill: {
       name: "context7-mcp",
@@ -185,12 +174,11 @@ const agents: Record<SetupAgent, AgentConfig> = {
   },
 
   vscode: {
-    name: "vscode",
     displayName: "VS Code",
     mcp: {
       projectPaths: [join(".vscode", "mcp.json")],
       get globalPaths() {
-        return [join(vscodeUserDir(), "mcp.json")];
+        return [join(resolveVscodeUserDir(), "mcp.json")];
       },
       configKey: "servers",
       buildEntry: (auth, transport) =>
@@ -201,8 +189,11 @@ const agents: Record<SetupAgent, AgentConfig> = {
     rule: {
       kind: "file",
       dir: (scope) =>
-        scope === "global" ? join(vscodeUserDir(), "prompts") : join(".github", "instructions"),
+        scope === "global"
+          ? join(resolveVscodeUserDir(), "prompts")
+          : join(".github", "instructions"),
       filename: "context7.instructions.md",
+      contentPrefix: `---\napplyTo: "**"\n---\n\n`,
     },
     skill: {
       name: "context7-mcp",
@@ -212,13 +203,12 @@ const agents: Record<SetupAgent, AgentConfig> = {
     detect: {
       projectPaths: [".vscode"],
       get globalPaths() {
-        return [vscodeUserDir()];
+        return [resolveVscodeUserDir()];
       },
     },
   },
 
   opencode: {
-    name: "opencode",
     displayName: "OpenCode",
     mcp: {
       projectPaths: ["opencode.json", "opencode.jsonc", ".opencode.json", ".opencode.jsonc"],
@@ -252,7 +242,6 @@ const agents: Record<SetupAgent, AgentConfig> = {
   },
 
   codex: {
-    name: "codex",
     displayName: "Codex",
     mcp: {
       projectPaths: [join(".codex", "config.toml")],
@@ -284,8 +273,8 @@ const agents: Record<SetupAgent, AgentConfig> = {
   // ~/.gemini/config/mcp_config.json globally; there is no project-level MCP
   // config, so projectPaths is empty and setupAgent falls back to global.
   antigravity: {
-    name: "antigravity",
     displayName: "Antigravity",
+    setupDescription: "Set up for Antigravity (.agent/skills)",
     mcp: {
       projectPaths: [],
       globalPaths: [join(homedir(), ".gemini", "config", "mcp_config.json")],
@@ -310,7 +299,6 @@ const agents: Record<SetupAgent, AgentConfig> = {
   },
 
   gemini: {
-    name: "gemini",
     displayName: "Gemini CLI",
     mcp: {
       projectPaths: [join(".gemini", "settings.json")],
@@ -334,7 +322,9 @@ const agents: Record<SetupAgent, AgentConfig> = {
       globalPaths: [join(homedir(), ".gemini")],
     },
   },
-};
+} satisfies Record<string, AgentConfig>;
+
+export type SetupAgent = keyof typeof agents;
 
 export function getAgent(name: SetupAgent): AgentConfig {
   return agents[name];
@@ -354,12 +344,13 @@ async function pathExists(p: string): Promise<boolean> {
 export async function detectAgents(scope: "project" | "global"): Promise<SetupAgent[]> {
   const detected: SetupAgent[] = [];
 
-  for (const agent of Object.values(agents)) {
+  for (const name of ALL_AGENT_NAMES) {
+    const agent = agents[name];
     const paths = scope === "global" ? agent.detect.globalPaths : agent.detect.projectPaths;
     for (const p of paths) {
       const fullPath = scope === "global" ? p : join(process.cwd(), p);
       if (await pathExists(fullPath)) {
-        detected.push(agent.name);
+        detected.push(name);
         break;
       }
     }

--- a/packages/cli/src/setup/templates.ts
+++ b/packages/cli/src/setup/templates.ts
@@ -34,6 +34,7 @@ If a command fails with a quota error, inform the user and suggest \`npx ctx7@la
 `;
 
 const CURSOR_FRONTMATTER = `---\nalwaysApply: true\n---\n\n`;
+const VSCODE_FRONTMATTER = `---\napplyTo: "**"\n---\n\n`;
 const CODEX_CLI_SANDBOX_GUIDANCE = `Run Context7 CLI requests outside Codex's default sandbox. If a Context7 CLI command fails with DNS or network errors such as ENOTFOUND, host resolution failures, or fetch failed, rerun it outside the sandbox instead of retrying inside the sandbox.`;
 
 export type RuleMode = "mcp" | "cli";
@@ -59,7 +60,9 @@ export async function getRuleContent(mode: RuleMode, agent: string): Promise<str
     body = `${body.trimEnd()}\n${CODEX_CLI_SANDBOX_GUIDANCE}\n`;
   }
 
-  return agent === "cursor" ? `${CURSOR_FRONTMATTER}${body}` : body;
+  if (agent === "cursor") return `${CURSOR_FRONTMATTER}${body}`;
+  if (agent === "vscode") return `${VSCODE_FRONTMATTER}${body}`;
+  return body;
 }
 
 export function customizeSkillFilesForAgent(

--- a/packages/cli/src/setup/templates.ts
+++ b/packages/cli/src/setup/templates.ts
@@ -1,3 +1,5 @@
+import type { SetupAgent } from "./agents.js";
+
 const GITHUB_RAW_URLS = [
   "https://raw.githubusercontent.com/upstash/context7/master/rules",
   "https://raw.githubusercontent.com/upstash/context7/main/rules",
@@ -33,8 +35,6 @@ For version-specific docs, use \`/org/project/version\` from the \`library\` out
 If a command fails with a quota error, inform the user and suggest \`npx ctx7@latest login\` or setting \`CONTEXT7_API_KEY\` env var for higher limits. Do not silently fall back to training data.
 `;
 
-const CURSOR_FRONTMATTER = `---\nalwaysApply: true\n---\n\n`;
-const VSCODE_FRONTMATTER = `---\napplyTo: "**"\n---\n\n`;
 const CODEX_CLI_SANDBOX_GUIDANCE = `Run Context7 CLI requests outside Codex's default sandbox. If a Context7 CLI command fails with DNS or network errors such as ENOTFOUND, host resolution failures, or fetch failed, rerun it outside the sandbox instead of retrying inside the sandbox.`;
 
 export type RuleMode = "mcp" | "cli";
@@ -51,7 +51,7 @@ async function fetchRule(filename: string, fallback: string): Promise<string> {
   return fallback;
 }
 
-export async function getRuleContent(mode: RuleMode, agent: string): Promise<string> {
+export async function getRuleContent(mode: RuleMode, agent: SetupAgent): Promise<string> {
   const [filename, fallback] =
     mode === "mcp" ? ["context7-mcp.md", FALLBACK_MCP] : ["context7-cli.md", FALLBACK_CLI];
   let body = await fetchRule(filename, fallback);
@@ -60,13 +60,11 @@ export async function getRuleContent(mode: RuleMode, agent: string): Promise<str
     body = `${body.trimEnd()}\n${CODEX_CLI_SANDBOX_GUIDANCE}\n`;
   }
 
-  if (agent === "cursor") return `${CURSOR_FRONTMATTER}${body}`;
-  if (agent === "vscode") return `${VSCODE_FRONTMATTER}${body}`;
   return body;
 }
 
 export function customizeSkillFilesForAgent(
-  agent: string,
+  agent: SetupAgent,
   skillName: string,
   files: Array<{ path: string; content: string }>
 ): Array<{ path: string; content: string }> {


### PR DESCRIPTION
## Summary

- add VS Code detection and `--vscode` setup/remove flags
- support project `.vscode/mcp.json` and platform-specific global VS Code `User/mcp.json` paths
- write HTTP and stdio entries under VS Code's `servers` key
- install always-on VS Code instructions and Context7 agent skills
- preserve unrelated MCP servers during setup and removal

## Validation

- `pnpm --filter ctx7 typecheck`
- `pnpm --filter ctx7 lint:check`
- `pnpm --filter ctx7 test` — 325 tests passed
- `pnpm --filter ctx7 build`

Linear: [CTX7-2530](https://linear.app/upstash/issue/CTX7-2530/add-vs-code-as-a-ctx7-setup-target)