### PR TITLE
feat(cli): add Devin setup target

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -26,6 +26,7 @@ ctx7 setup --cursor
 ctx7 setup --claude
 ctx7 setup --opencode
 ctx7 setup --vscode
+ctx7 setup --devin
 ```
 
 ### Library Documentation
@@ -81,6 +82,7 @@ ctx7 setup --cursor
 ctx7 setup --claude
 ctx7 setup --opencode
 ctx7 setup --vscode
+ctx7 setup --devin
 
 # Use an existing API key instead of OAuth
 ctx7 setup --api-key YOUR_API_KEY
@@ -107,6 +109,7 @@ ctx7 remove
 ctx7 remove --cursor
 ctx7 remove --claude --project
 ctx7 remove --vscode --project
+ctx7 remove --devin --project
 
 # Remove both setup modes explicitly
 ctx7 remove --cursor --all
@@ -143,6 +146,7 @@ The CLI automatically detects which AI coding assistants you have installed and 
 | Claude Code                                                         | `.claude/skills/` |
 | Cursor                                                              | `.cursor/skills/` |
 | VS Code                                                             | `.agents/skills/` |
+| Devin                                                               | `.devin/skills/`  |
 | Antigravity                                                         | `.agent/skills/`  |
 
 ## Disabling Telemetry

--- a/packages/cli/src/__tests__/remove.test.ts
+++ b/packages/cli/src/__tests__/remove.test.ts
@@ -319,6 +319,32 @@ describe("remove command", () => {
     });
   });
 
+  test("removes only context7 from Devin MCP config", async () => {
+    const configPath = join(tempDir, ".devin", "mcp_config.json");
+
+    await mkdir(join(tempDir, ".devin"), { recursive: true });
+    await writeFile(
+      configPath,
+      JSON.stringify(
+        {
+          mcpServers: {
+            context7: { transport: "http", url: "https://mcp.context7.com/mcp" },
+            other: { command: "other" },
+          },
+        },
+        null,
+        2
+      ),
+      "utf-8"
+    );
+
+    await runCommand("remove", "--devin", "--mcp", "--project");
+
+    expect(JSON.parse(await readFile(configPath, "utf-8"))).toEqual({
+      mcpServers: { other: { command: "other" } },
+    });
+  });
+
   test("removes only context7 from opencode JSONC MCP config", async () => {
     const configPath = join(tempDir, "opencode.jsonc");
 

--- a/packages/cli/src/__tests__/setup.test.ts
+++ b/packages/cli/src/__tests__/setup.test.ts
@@ -37,6 +37,7 @@ import {
   getAgent,
   ALL_AGENT_NAMES,
   resolveVscodeUserDir,
+  resolveDevinConfigDir,
   type AuthOptions,
 } from "../setup/agents.js";
 
@@ -834,6 +835,70 @@ describe("agent config integration", () => {
     });
   });
 
+  describe("devin", () => {
+    const agent = getAgent("devin");
+
+    test("buildEntry with api-key produces Devin HTTP shape", () => {
+      expect(agent.mcp.buildEntry(apiKeyAuth, "http")).toEqual({
+        transport: "http",
+        url: "https://mcp.context7.com/mcp",
+        headers: { Authorization: "Bearer sk-test-123" },
+      });
+    });
+
+    test("buildEntry with oauth produces Devin HTTP shape without headers", () => {
+      expect(agent.mcp.buildEntry(oauthAuth, "http")).toEqual({
+        transport: "http",
+        url: "https://mcp.context7.com/mcp/oauth",
+      });
+    });
+
+    test("uses the dedicated project MCP config introduced in Devin 3000.3", () => {
+      expect(agent.mcp.projectPaths).toEqual([join(".devin", "mcp_config.json")]);
+      expect(agent.skill.dir("project")).toBe(join(".devin", "skills"));
+    });
+
+    test.each([
+      ["darwin", "/home/test", {}, "/home/test/.config/devin"],
+      ["linux", "/home/test", {}, "/home/test/.config/devin"],
+      [
+        "win32",
+        "/home/test",
+        { APPDATA: "C:\\Users\\test\\AppData\\Roaming" },
+        "C:\\Users\\test\\AppData\\Roaming/devin",
+      ],
+      ["win32", "/home/test", {}, "/home/test/AppData/Roaming/devin"],
+    ] as const)("resolves the %s Devin config directory", (platform, home, env, expected) => {
+      expect(resolveDevinConfigDir(platform, home, env)).toBe(expected);
+    });
+
+    test("merges into Devin config without replacing other settings", async () => {
+      const path = join(tempDir, "mcp_config.json");
+      await writeJsonConfig(path, {
+        permissions: { allow: ["git status"] },
+        mcpServers: { other: { command: "other" } },
+      });
+
+      const existing = await readJsonConfig(path);
+      const { config } = mergeServerEntry(
+        existing,
+        agent.mcp.configKey,
+        "context7",
+        agent.mcp.buildEntry(apiKeyAuth, "http")
+      );
+      await writeJsonConfig(path, config);
+
+      const result = await readJsonConfig(path);
+      expect(result.permissions).toEqual({ allow: ["git status"] });
+      expect((result.mcpServers as Record<string, unknown>).context7).toEqual({
+        transport: "http",
+        url: "https://mcp.context7.com/mcp",
+        headers: { Authorization: "Bearer sk-test-123" },
+      });
+      expect((result.mcpServers as Record<string, unknown>).other).toEqual({ command: "other" });
+    });
+  });
+
   describe("opencode", () => {
     const agent = getAgent("opencode");
 
@@ -1133,6 +1198,14 @@ describe("agent config integration", () => {
       const entry = getAgent("vscode").mcp.buildEntry(apiKeyAuth, "stdio");
       expect(entry).toEqual({
         type: "stdio",
+        command: "npx",
+        args: ["-y", "@upstash/context7-mcp", "--api-key", "sk-test-stdio"],
+      });
+    });
+
+    test("devin stdio entry uses npx command with --api-key in args", () => {
+      const entry = getAgent("devin").mcp.buildEntry(apiKeyAuth, "stdio");
+      expect(entry).toEqual({
         command: "npx",
         args: ["-y", "@upstash/context7-mcp", "--api-key", "sk-test-stdio"],
       });

--- a/packages/cli/src/commands/remove.ts
+++ b/packages/cli/src/commands/remove.ts
@@ -142,7 +142,7 @@ async function resolveAgents(options: UninstallOptions, scope: Scope): Promise<S
 
   if (detected.length === 0) {
     log.warn(
-      "No Context7 setup detected. Pass --claude, --cursor, --vscode, --opencode, --codex, --antigravity, or --gemini."
+      `No Context7 setup detected. Pass one of: ${ALL_AGENT_NAMES.map((name) => `--${name}`).join(", ")}.`
     );
     return [];
   }

--- a/packages/cli/src/setup/agents.ts
+++ b/packages/cli/src/setup/agents.ts
@@ -58,6 +58,17 @@ export function resolveVscodeUserDir(
   return join(env.XDG_CONFIG_HOME || join(home, ".config"), "Code", "User");
 }
 
+export function resolveDevinConfigDir(
+  platform: NodeJS.Platform = process.platform,
+  home: string = homedir(),
+  env: { APPDATA?: string } = { APPDATA: process.env.APPDATA }
+): string {
+  if (platform === "win32") {
+    return join(env.APPDATA || join(home, "AppData", "Roaming"), "devin");
+  }
+  return join(home, ".config", "devin");
+}
+
 export type RuleType =
   | {
       kind: "file";
@@ -204,6 +215,38 @@ const agents = {
       projectPaths: [".vscode"],
       get globalPaths() {
         return [resolveVscodeUserDir()];
+      },
+    },
+  },
+
+  devin: {
+    displayName: "Devin",
+    mcp: {
+      projectPaths: [join(".devin", "mcp_config.json")],
+      get globalPaths() {
+        return [join(resolveDevinConfigDir(), "mcp_config.json")];
+      },
+      configKey: "mcpServers",
+      buildEntry: (auth, transport) =>
+        transport === "stdio"
+          ? stdioEntry(auth)
+          : withHeaders({ transport: "http", url: mcpUrl(auth) }, auth),
+    },
+    rule: {
+      kind: "append",
+      file: (scope) =>
+        scope === "global" ? join(resolveDevinConfigDir(), "AGENTS.md") : "AGENTS.md",
+      sectionMarker: "<!-- context7 -->",
+    },
+    skill: {
+      name: "context7-mcp",
+      dir: (scope) =>
+        scope === "global" ? join(resolveDevinConfigDir(), "skills") : join(".devin", "skills"),
+    },
+    detect: {
+      projectPaths: [".devin"],
+      get globalPaths() {
+        return [resolveDevinConfigDir()];
       },
     },
   },


### PR DESCRIPTION
## Summary

- add Devin detection and `--devin` setup/remove flags
- support the dedicated project `.devin/mcp_config.json` and global `~/.config/devin/mcp_config.json` files introduced in Devin 3000.3
- resolve the Windows global directory through `%APPDATA%\devin`
- use Devin's current HTTP `{ transport: "http", url }` configuration shape
- install `AGENTS.md` rules and skills in Devin's platform-specific documented locations
- preserve unrelated Devin configuration during setup and removal

## Validation

- `pnpm --dir packages/cli typecheck`
- `pnpm --dir packages/cli lint:check`
- `pnpm --dir packages/cli test` — 329 tests passed
- `pnpm --dir packages/cli build`
- native Devin CLI 3000.6.2: `devin mcp get context7` reads the generated project configuration
- setup/remove round trip leaves `.devin/mcp_config.json` empty after removal

Linear: [CTX7-2531](https://linear.app/upstash/issue/CTX7-2531/add-devin-as-a-ctx7-setup-target)
