### PR TITLE
fix(mcp): honor advertised X-Context7-API-Key header

### DIFF
--- a/.changeset/honest-keys-authenticate.md
+++ b/.changeset/honest-keys-authenticate.md
@@ -1,0 +1,5 @@
+---
+"@upstash/context7-mcp": patch
+---
+
+Honor the advertised `X-Context7-API-Key` header in HTTP MCP requests.

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -355,6 +355,7 @@ async function main() {
     const extractApiKey = (req: express.Request): string | undefined => {
       return (
         extractBearerToken(req.headers.authorization) ||
+        extractHeaderValue(req.headers["x-context7-api-key"]) ||
         extractHeaderValue(req.headers["context7-api-key"]) ||
         extractHeaderValue(req.headers["x-api-key"]) ||
         extractHeaderValue(req.headers["context7_api_key"]) ||

--- a/packages/mcp/test/integration.test.ts
+++ b/packages/mcp/test/integration.test.ts
@@ -135,6 +135,32 @@ describe("OAuth discovery", () => {
   });
 });
 
+describe("HTTP API key headers", () => {
+  test("accepts the advertised X-Context7-API-Key header", async () => {
+    const apiKey = "ctx7sk-advertised-header-test";
+    const client = new Client({ name: "api-key-header-test", version: "1.0.0" });
+
+    await client.connect(
+      new StreamableHTTPClientTransport(new URL(httpUrl), {
+        requestInit: { headers: { "X-Context7-API-Key": apiKey } },
+      })
+    );
+
+    try {
+      requests.length = 0;
+      await client.callTool({
+        name: "query-docs",
+        arguments: { libraryId: "/vercel/next.js", query: "app router" },
+      });
+
+      const apiCall = requests.find((request) => request.path === "/v2/context");
+      expect(apiCall?.headers.authorization).toBe(`Bearer ${apiKey}`);
+    } finally {
+      await client.close();
+    }
+  });
+});
+
 describe.each([
   ["http", "modern"],
   ["http", "legacy"],


### PR DESCRIPTION
## Summary

- accept `X-Context7-API-Key` in the HTTP MCP credential extractor
- add an end-to-end regression test proving the advertised header is forwarded to the Context7 API
- preserve all existing authentication header aliases

## Validation

- `pnpm --filter @upstash/context7-mcp test` (80 tests)
- `pnpm --filter @upstash/context7-mcp typecheck`
- `pnpm --filter @upstash/context7-mcp lint:check`
- `pnpm --filter @upstash/context7-mcp format:check`

Linear: [CTX7-2534](https://linear.app/upstash/issue/CTX7-2534/honor-advertised-x-context7-api-key-header-in-mcp-auth-pt38659-24)