### PR TITLE
feat(cli): add GitHub Copilot CLI setup target

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -27,6 +27,7 @@ ctx7 setup --claude
 ctx7 setup --opencode
 ctx7 setup --vscode
 ctx7 setup --devin
+ctx7 setup --copilot
 ```
 
 ### Library Documentation
@@ -83,6 +84,7 @@ ctx7 setup --claude
 ctx7 setup --opencode
 ctx7 setup --vscode
 ctx7 setup --devin
+ctx7 setup --copilot
 
 # Use an existing API key instead of OAuth
 ctx7 setup --api-key YOUR_API_KEY
@@ -110,6 +112,7 @@ ctx7 remove --cursor
 ctx7 remove --claude --project
 ctx7 remove --vscode --project
 ctx7 remove --devin --project
+ctx7 remove --copilot --project
 
 # Remove both setup modes explicitly
 ctx7 remove --cursor --all
@@ -147,6 +150,7 @@ The CLI automatically detects which AI coding assistants you have installed and 
 | Cursor                                                              | `.cursor/skills/` |
 | VS Code                                                             | `.agents/skills/` |
 | Devin                                                               | `.devin/skills/`  |
+| GitHub Copilot CLI                                                  | `.agents/skills/` |
 | Antigravity                                                         | `.agent/skills/`  |
 
 ## Disabling Telemetry

--- a/packages/cli/src/__tests__/remove.test.ts
+++ b/packages/cli/src/__tests__/remove.test.ts
@@ -345,6 +345,35 @@ describe("remove command", () => {
     });
   });
 
+  test("removes Copilot CLI project config from .mcp.json", async () => {
+    const configPath = join(tempDir, ".mcp.json");
+
+    await writeFile(
+      configPath,
+      JSON.stringify(
+        {
+          mcpServers: {
+            other: { type: "http", url: "https://other.com" },
+            context7: {
+              type: "http",
+              url: "https://mcp.context7.com/mcp",
+              tools: ["*"],
+            },
+          },
+        },
+        null,
+        2
+      ),
+      "utf-8"
+    );
+
+    await runCommand("remove", "--copilot", "--mcp", "--project");
+
+    expect(JSON.parse(await readFile(configPath, "utf-8"))).toEqual({
+      mcpServers: { other: { type: "http", url: "https://other.com" } },
+    });
+  });
+
   test("removes only context7 from opencode JSONC MCP config", async () => {
     const configPath = join(tempDir, "opencode.jsonc");
 

--- a/packages/cli/src/__tests__/setup.test.ts
+++ b/packages/cli/src/__tests__/setup.test.ts
@@ -35,6 +35,7 @@ import {
 } from "../setup/mcp-writer.js";
 import {
   getAgent,
+  detectAgents,
   ALL_AGENT_NAMES,
   resolveVscodeUserDir,
   resolveDevinConfigDir,
@@ -899,6 +900,62 @@ describe("agent config integration", () => {
     });
   });
 
+  describe("copilot", () => {
+    const agent = getAgent("copilot");
+
+    test("buildEntry produces the Copilot CLI HTTP shape", () => {
+      expect(agent.mcp.buildEntry(apiKeyAuth, "http")).toEqual({
+        type: "http",
+        url: "https://mcp.context7.com/mcp",
+        tools: ["*"],
+        headers: { Authorization: "Bearer sk-test-123" },
+      });
+    });
+
+    test("uses the Copilot CLI mcpServers config section", () => {
+      expect(agent.mcp.configKey).toBe("mcpServers");
+    });
+
+    test("does not claim Claude's shared project .mcp.json during auto-detection", async () => {
+      const previousCwd = process.cwd();
+      await writeFile(join(tempDir, ".mcp.json"), JSON.stringify({ mcpServers: {} }));
+      try {
+        process.chdir(tempDir);
+        const detected = await detectAgents("project");
+        expect(detected).toContain("claude");
+        expect(detected).not.toContain("copilot");
+      } finally {
+        process.chdir(previousCwd);
+      }
+    });
+
+    test("merges an entry without replacing other Copilot configuration", async () => {
+      const path = join(tempDir, "mcp-config.json");
+      await writeJsonConfig(path, {
+        telemetry: { enabled: false },
+        mcpServers: { other: { type: "local", command: "other" } },
+      });
+
+      const existing = await readJsonConfig(path);
+      const { config } = mergeServerEntry(
+        existing,
+        agent.mcp.configKey,
+        "context7",
+        agent.mcp.buildEntry(apiKeyAuth, "http")
+      );
+      await writeJsonConfig(path, config);
+
+      const result = await readJsonConfig(path);
+      expect(result.telemetry).toEqual({ enabled: false });
+      expect((result.mcpServers as Record<string, unknown>).context7).toEqual({
+        type: "http",
+        url: "https://mcp.context7.com/mcp",
+        tools: ["*"],
+        headers: { Authorization: "Bearer sk-test-123" },
+      });
+    });
+  });
+
   describe("opencode", () => {
     const agent = getAgent("opencode");
 
@@ -1208,6 +1265,16 @@ describe("agent config integration", () => {
       expect(entry).toEqual({
         command: "npx",
         args: ["-y", "@upstash/context7-mcp", "--api-key", "sk-test-stdio"],
+      });
+    });
+
+    test("copilot stdio entry includes all tools", () => {
+      const entry = getAgent("copilot").mcp.buildEntry(apiKeyAuth, "stdio");
+      expect(entry).toEqual({
+        type: "stdio",
+        command: "npx",
+        args: ["-y", "@upstash/context7-mcp", "--api-key", "sk-test-stdio"],
+        tools: ["*"],
       });
     });
 

--- a/packages/cli/src/setup/agents.ts
+++ b/packages/cli/src/setup/agents.ts
@@ -251,6 +251,36 @@ const agents = {
     },
   },
 
+  copilot: {
+    displayName: "GitHub Copilot CLI",
+    mcp: {
+      projectPaths: [".mcp.json"],
+      globalPaths: [join(homedir(), ".copilot", "mcp-config.json")],
+      configKey: "mcpServers",
+      buildEntry: (auth, transport) =>
+        transport === "stdio"
+          ? { type: "stdio", ...stdioEntry(auth), tools: ["*"] }
+          : withHeaders({ type: "http", url: mcpUrl(auth), tools: ["*"] }, auth),
+    },
+    rule: {
+      kind: "append",
+      file: (scope) =>
+        scope === "global" ? join(homedir(), ".copilot", "AGENTS.md") : "AGENTS.md",
+      sectionMarker: "<!-- context7 -->",
+    },
+    skill: {
+      name: "context7-mcp",
+      dir: (scope) =>
+        scope === "global" ? join(homedir(), ".agents", "skills") : join(".agents", "skills"),
+    },
+    detect: {
+      // Copilot shares .mcp.json with Claude Code, so project ownership cannot
+      // be inferred safely. Project setup remains available via --copilot.
+      projectPaths: [],
+      globalPaths: [join(homedir(), ".copilot")],
+    },
+  },
+
   opencode: {
     displayName: "OpenCode",
     mcp: {


### PR DESCRIPTION
## Summary

- add GitHub Copilot CLI detection and `--copilot` setup/remove flags
- support global `~/.copilot/mcp-config.json` and project `.mcp.json`, both using `mcpServers`
- write compatible HTTP and stdio entries with the documented `tools: ["*"]` default
- require explicit `--copilot` selection for project setup because `.mcp.json` is shared with Claude Code and cannot identify ownership safely
- preserve unrelated configuration during setup and removal

## Validation

- `pnpm --dir packages/cli typecheck`
- `pnpm --dir packages/cli lint:check`
- `pnpm --dir packages/cli test` — 325 tests passed
- `pnpm --dir packages/cli build`
- native `copilot mcp get` reports the generated entry as an enabled workspace server with all tools

Linear: [CTX7-2532](https://linear.app/upstash/issue/CTX7-2532/add-github-copilot-cli-as-a-ctx7-setup-target)
