### PR TITLE
fix(ci): publish MCP releases to registry

### DIFF
--- a/.github/workflows/mcp-registry.yml
+++ b/.github/workflows/mcp-registry.yml
@@ -1,6 +1,12 @@
 name: Publish to MCP Registry
 
 on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Version to publish"
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       version:
@@ -25,10 +31,11 @@ jobs:
           node-version: lts/*
 
       - name: Set version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
-          if [ -n "${{ inputs.version }}" ]; then
-            VERSION="${{ inputs.version }}"
-            # Remove 'v' prefix if it exists
+          if [ -n "$INPUT_VERSION" ]; then
+            VERSION="$INPUT_VERSION"
             VERSION="${VERSION#v}"
           else
             VERSION=$(node -p "require('./packages/mcp/package.json').version")
@@ -38,14 +45,19 @@ jobs:
 
       - name: Update package version in server.json
         run: |
-          echo $(jq --arg v "${{ env.VERSION }}" '.version = $v | .packages[0].version = $v' server.json) > server.json
+          jq --arg version "$VERSION" \
+            '.version = $version | (.packages[] | select(.registryType == "npm" and .identifier == "@upstash/context7-mcp").version) = $version' \
+            server.json > server.updated.json
+          mv server.updated.json server.json
 
       - name: Validate server.json
-        run: npx mcp-registry-validator validate server.json
+        run: npx --yes mcp-registry-validator@1.0.5 validate server.json
 
       - name: Install MCP Publisher
         run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v1.4.0/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          curl --fail --show-error --location \
+            "https://github.com/modelcontextprotocol/registry/releases/download/v1.8.1/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" \
+            | tar xz mcp-publisher
 
       - name: Login to MCP Registry
         run: ./mcp-publisher login github-oidc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    outputs:
+      mcp-version: ${{ steps.mcp-release.outputs.version }}
     permissions:
       contents: write
       pull-requests: write
@@ -48,3 +50,23 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Find published Context7 MCP version
+        id: mcp-release
+        if: steps.changesets.outputs.published == 'true'
+        env:
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
+        run: |
+          VERSION=$(jq -r 'map(select(.name == "@upstash/context7-mcp")) | first | .version // empty' <<< "$PUBLISHED_PACKAGES")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+  publish-mcp-registry:
+    name: Publish MCP Registry metadata
+    needs: release
+    if: needs.release.outputs.mcp-version != ''
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/mcp-registry.yml
+    with:
+      version: ${{ needs.release.outputs.mcp-version }}

--- a/server.json
+++ b/server.json
@@ -14,29 +14,12 @@
       "mimeType": "image/png"
     }
   ],
-  "version": "2.0.0",
+  "version": "4.0.3",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@upstash/context7-mcp",
-      "version": "2.0.2",
-      "transport": {
-        "type": "stdio"
-      },
-      "environmentVariables": [
-        {
-          "name": "CONTEXT7_API_KEY",
-          "description": "API key for authentication",
-          "isRequired": false,
-          "isSecret": true
-        }
-      ]
-    },
-    {
-      "registryType": "mcpb",
-      "identifier": "https://github.com/upstash/context7/releases/download/@upstash/context7-mcp@2.0.2/context7.mcpb",
-      "version": "2.0.2",
-      "fileSha256": "aea76f179ceb92d22c289147c9d8343fb558d6dec93b144c9794e99239bb8194",
+      "version": "4.0.3",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary

- sync server.json with the published Context7 MCP 4.0.3 package and remote endpoint
- remove the stale MCPB entry whose checksum does not match its release asset
- make the registry workflow reusable from the Changesets release workflow
- publish registry metadata only when Changesets reports that @upstash/context7-mcp was released
- download the latest official MCP Publisher and use it for validation, OIDC login, and publication

## Validation

- official mcp-publisher v1.8.1 validate: server.json is valid
- npm confirms @upstash/context7-mcp@4.0.3 declares mcpName io.github.upstash/context7
- Context7 remote endpoint is reachable and declared as streamable-http
- Changesets action v1 output names verified against its action.yml
- reusable-workflow permissions and OIDC flow verified against GitHub and MCP Registry documentation
- Prettier, actionlint 1.7.12, release-output simulations, and git diff --check pass

## Current registry state

Version 4.0.3 was successfully published from the overlapping #3097 branch while this PR was being prepared, so no manual catch-up publication is needed. This PR overlaps substantially with #3097; only one implementation should be merged.