### PR TITLE
fix(mcp): increase HTTP subscription capacity

### DIFF
--- a/.changeset/quiet-dodos-listen.md
+++ b/.changeset/quiet-dodos-listen.md
@@ -1,0 +1,5 @@
+---
+"@upstash/context7-mcp": patch
+---
+
+Increase the default HTTP subscription capacity and allow deployments to configure it with `MCP_MAX_SUBSCRIPTIONS`.

--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,9 @@ OPENAI_APPS_CHALLENGE_TOKEN=
 # Required for hosted HTTP deployments. Must match context7.com.
 MCP_CLIENT_IP_ASSERTION_KEY=
 
+# Maximum concurrent MCP subscription streams per HTTP process.
+MCP_MAX_SUBSCRIPTIONS=4096
+
 # Temporary legacy rollout key. Removal is tracked by CTX7-2536.
 CLIENT_IP_ENCRYPTION_KEY=
 

--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,7 @@ OPENAI_APPS_CHALLENGE_TOKEN=
 MCP_CLIENT_IP_ASSERTION_KEY=
 
 # Maximum concurrent MCP subscription streams per HTTP process.
-MCP_MAX_SUBSCRIPTIONS=24000
+MCP_MAX_SUBSCRIPTIONS=16000
 
 # Temporary legacy rollout key. Removal is tracked by CTX7-2536.
 CLIENT_IP_ENCRYPTION_KEY=

--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,7 @@ OPENAI_APPS_CHALLENGE_TOKEN=
 MCP_CLIENT_IP_ASSERTION_KEY=
 
 # Maximum concurrent MCP subscription streams per HTTP process.
-MCP_MAX_SUBSCRIPTIONS=24576
+MCP_MAX_SUBSCRIPTIONS=24000
 
 # Temporary legacy rollout key. Removal is tracked by CTX7-2536.
 CLIENT_IP_ENCRYPTION_KEY=

--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,7 @@ OPENAI_APPS_CHALLENGE_TOKEN=
 MCP_CLIENT_IP_ASSERTION_KEY=
 
 # Maximum concurrent MCP subscription streams per HTTP process.
-MCP_MAX_SUBSCRIPTIONS=4096
+MCP_MAX_SUBSCRIPTIONS=24576
 
 # Temporary legacy rollout key. Removal is tracked by CTX7-2536.
 CLIENT_IP_ENCRYPTION_KEY=

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -24,6 +24,7 @@ import {
   OPENAI_APPS_CHALLENGE_TOKEN,
 } from "./lib/constants.js";
 import { maybeElicitAuthSignIn } from "./lib/auth/auth-prompt.js";
+import { getMaxSubscriptions } from "./lib/subscriptions.js";
 
 /** Default HTTP server port */
 const DEFAULT_PORT = 3000;
@@ -380,6 +381,7 @@ async function main() {
     // go idle and the gateway reaps them at streamIdleTimeout (300s).
     const mcpHandler = createMcpHandler(() => createMcpServer(), {
       keepAliveMs: 0,
+      maxSubscriptions: getMaxSubscriptions(),
       onerror: (error) => console.error("MCP handler error:", error),
     });
     // Without onerror, request-conversion / handler.fetch throws are answered

--- a/packages/mcp/src/lib/subscriptions.ts
+++ b/packages/mcp/src/lib/subscriptions.ts
@@ -1,0 +1,8 @@
+export const DEFAULT_MAX_SUBSCRIPTIONS = 4_096;
+
+export function getMaxSubscriptions(value = process.env.MCP_MAX_SUBSCRIPTIONS): number {
+  if (value === undefined) return DEFAULT_MAX_SUBSCRIPTIONS;
+
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : DEFAULT_MAX_SUBSCRIPTIONS;
+}

--- a/packages/mcp/src/lib/subscriptions.ts
+++ b/packages/mcp/src/lib/subscriptions.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_MAX_SUBSCRIPTIONS = 24_576;
+export const DEFAULT_MAX_SUBSCRIPTIONS = 24_000;
 
 export function getMaxSubscriptions(value = process.env.MCP_MAX_SUBSCRIPTIONS): number {
   if (value === undefined) return DEFAULT_MAX_SUBSCRIPTIONS;

--- a/packages/mcp/src/lib/subscriptions.ts
+++ b/packages/mcp/src/lib/subscriptions.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_MAX_SUBSCRIPTIONS = 24_000;
+export const DEFAULT_MAX_SUBSCRIPTIONS = 16_000;
 
 export function getMaxSubscriptions(value = process.env.MCP_MAX_SUBSCRIPTIONS): number {
   if (value === undefined) return DEFAULT_MAX_SUBSCRIPTIONS;

--- a/packages/mcp/src/lib/subscriptions.ts
+++ b/packages/mcp/src/lib/subscriptions.ts
@@ -1,8 +1,12 @@
+// 16k stayed near baseline latency in Docker; 32,768 raised tools/list p95 to ~39 ms.
 export const DEFAULT_MAX_SUBSCRIPTIONS = 16_000;
 
 export function getMaxSubscriptions(value = process.env.MCP_MAX_SUBSCRIPTIONS): number {
   if (value === undefined) return DEFAULT_MAX_SUBSCRIPTIONS;
 
   const parsed = Number(value);
-  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : DEFAULT_MAX_SUBSCRIPTIONS;
+  if (Number.isSafeInteger(parsed) && parsed > 0) return parsed;
+
+  console.warn(`Invalid MCP_MAX_SUBSCRIPTIONS; using the default of ${DEFAULT_MAX_SUBSCRIPTIONS}.`);
+  return DEFAULT_MAX_SUBSCRIPTIONS;
 }

--- a/packages/mcp/src/lib/subscriptions.ts
+++ b/packages/mcp/src/lib/subscriptions.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_MAX_SUBSCRIPTIONS = 4_096;
+export const DEFAULT_MAX_SUBSCRIPTIONS = 24_576;
 
 export function getMaxSubscriptions(value = process.env.MCP_MAX_SUBSCRIPTIONS): number {
   if (value === undefined) return DEFAULT_MAX_SUBSCRIPTIONS;

--- a/packages/mcp/test/subscriptions.test.ts
+++ b/packages/mcp/test/subscriptions.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { DEFAULT_MAX_SUBSCRIPTIONS, getMaxSubscriptions } from "../src/lib/subscriptions.js";
 
 describe("getMaxSubscriptions", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   test("defaults to 16000 subscriptions", () => {
     expect(getMaxSubscriptions(undefined)).toBe(DEFAULT_MAX_SUBSCRIPTIONS);
   });
@@ -13,7 +17,10 @@ describe("getMaxSubscriptions", () => {
   test.each(["0", "-1", "1.5", "invalid", "Infinity"])(
     "falls back for invalid value %s",
     (value) => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
       expect(getMaxSubscriptions(value)).toBe(DEFAULT_MAX_SUBSCRIPTIONS);
+      expect(warn).toHaveBeenCalledOnce();
     }
   );
 });

--- a/packages/mcp/test/subscriptions.test.ts
+++ b/packages/mcp/test/subscriptions.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "vitest";
 import { DEFAULT_MAX_SUBSCRIPTIONS, getMaxSubscriptions } from "../src/lib/subscriptions.js";
 
 describe("getMaxSubscriptions", () => {
-  test("defaults to 24576 subscriptions", () => {
+  test("defaults to 24000 subscriptions", () => {
     expect(getMaxSubscriptions(undefined)).toBe(DEFAULT_MAX_SUBSCRIPTIONS);
   });
 

--- a/packages/mcp/test/subscriptions.test.ts
+++ b/packages/mcp/test/subscriptions.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "vitest";
 import { DEFAULT_MAX_SUBSCRIPTIONS, getMaxSubscriptions } from "../src/lib/subscriptions.js";
 
 describe("getMaxSubscriptions", () => {
-  test("defaults to 4096 subscriptions", () => {
+  test("defaults to 24576 subscriptions", () => {
     expect(getMaxSubscriptions(undefined)).toBe(DEFAULT_MAX_SUBSCRIPTIONS);
   });
 

--- a/packages/mcp/test/subscriptions.test.ts
+++ b/packages/mcp/test/subscriptions.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "vitest";
 import { DEFAULT_MAX_SUBSCRIPTIONS, getMaxSubscriptions } from "../src/lib/subscriptions.js";
 
 describe("getMaxSubscriptions", () => {
-  test("defaults to 24000 subscriptions", () => {
+  test("defaults to 16000 subscriptions", () => {
     expect(getMaxSubscriptions(undefined)).toBe(DEFAULT_MAX_SUBSCRIPTIONS);
   });
 

--- a/packages/mcp/test/subscriptions.test.ts
+++ b/packages/mcp/test/subscriptions.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "vitest";
+import { DEFAULT_MAX_SUBSCRIPTIONS, getMaxSubscriptions } from "../src/lib/subscriptions.js";
+
+describe("getMaxSubscriptions", () => {
+  test("defaults to 4096 subscriptions", () => {
+    expect(getMaxSubscriptions(undefined)).toBe(DEFAULT_MAX_SUBSCRIPTIONS);
+  });
+
+  test("accepts a positive integer override", () => {
+    expect(getMaxSubscriptions("8192")).toBe(8_192);
+  });
+
+  test.each(["0", "-1", "1.5", "invalid", "Infinity"])(
+    "falls back for invalid value %s",
+    (value) => {
+      expect(getMaxSubscriptions(value)).toBe(DEFAULT_MAX_SUBSCRIPTIONS);
+    }
+  );
+});


### PR DESCRIPTION
## Summary

- raise the HTTP `subscriptions/listen` capacity from the SDK default of 1,024 to 16,000 per process
- allow operators to override it with `MCP_MAX_SUBSCRIPTIONS`
- validate overrides, warn on invalid values, and safely fall back to 16,000
- leave stdio transport and existing HTTP keepalive behavior unchanged

## Why

Production MCP pods are healthy at the Envoy layer, but every pod is repeatedly logging `subscription limit reached (1024)`. The SDK reports that rejection as an in-band JSON-RPC error over HTTP 200, which is why connection/request overflow and 5xx metrics remain zero.

The selected default is deliberately conservative: 16,384 streams stayed near baseline request latency in the live-Docker benchmark, while 32,768 raised `tools/list` p95 to about 39 ms. A 16,000 default preserves the capacity guard, provides about 15.6x the SDK default per pod, and allows 160,000 streams across the current 10-pod deployment.

## Docker capacity benchmark

Exact PR image: Node LTS Alpine, arm64 Docker VM with 12 CPUs and 7.65 GiB memory, no container CPU/memory limit, nofile 1,048,576. Server and load generator used an isolated Docker network.

| Open streams | Server memory | Idle CPU | `tools/list` p95 | Result |
| ---: | ---: | ---: | ---: | --- |
| 8,192 | 706 MiB | 0.02% | 3.30 ms | stable |
| 16,384 | 1.04 GiB | 0.00% | 3.37 ms | stable |
| 24,576 | 1.51 GiB | 0.00% | 3.27 ms | stable |
| 32,768 | 1.59 GiB | 0.00% | 38.68 ms steady-state | rejected as default |

At 24,576 streams, an additional 2,000 `tools/list` requests at concurrency 50 completed with 0 errors at 1,745 req/s. The zero-stream control completed at 1,685 req/s in the same setup.

Production MCP workers are m8g.2xlarge nodes with about 30 GiB allocatable memory, two MCP pods per node, and current node memory use around 11–12%, so the tested capacity fits with substantial headroom.

## Verification

- `pnpm --filter @upstash/context7-mcp format:check`
- `pnpm --filter @upstash/context7-mcp typecheck`
- `pnpm --filter @upstash/context7-mcp test` (59/59 passed; HTTP modern/legacy and stdio modern/legacy)
- `pnpm --filter @upstash/context7-mcp build`
- `pnpm --filter @upstash/context7-mcp lint:check`
- live Docker subscription and concurrent-request benchmarks described above
