### PR TITLE
feat: publish ASM selection metadata in MCP server card

### DIFF
--- a/.github/workflows/mcp-registry.yml
+++ b/.github/workflows/mcp-registry.yml
@@ -33,7 +33,7 @@ jobs:
             VERSION=$(node -p "require('./packages/mcp/package.json').version")
           fi
           echo "Publishing version: $VERSION"
-          jq --arg v "$VERSION" '.version = $v | .packages[].version = $v' server.json > server.tmp && mv server.tmp server.json
+          jq --arg v "$VERSION" '.version = $v | .packages[].version = $v | ._meta["io.modelcontextprotocol.registry/publisher-provided"].asm.service_id = "upstash/context7@\($v)"' server.json > server.tmp && mv server.tmp server.json
 
       - name: Install MCP Publisher
         run: |

--- a/server.json
+++ b/server.json
@@ -46,5 +46,81 @@
         }
       ]
     }
-  ]
+  ],
+  "_meta": {
+    "io.modelcontextprotocol.registry/publisher-provided": {
+      "asm": {
+        "asm_version": "0.3",
+        "service_id": "upstash/context7@4.0.3",
+        "taxonomy": "tool.development.documentation",
+        "display_name": "Context7",
+        "provenance": {
+          "source_url": "https://context7.com/plans",
+          "retrieved_at": "2026-08-29T07:28:02Z",
+          "last_verified_at": "2026-08-29T07:28:02Z",
+          "verification_status": "self_reported",
+          "notes": "Publisher claims checked against the official pricing page, MCP documentation, server manifest, and read-only tool annotations. The free-plan allowance does not include the documented post-cap daily bonus. This metadata does not independently attest service quality or availability."
+        },
+        "capabilities": {
+          "description": "Resolve software-library identifiers and retrieve current, version-specific documentation and code examples.",
+          "functions": ["resolve-library-id", "query-docs"],
+          "input_modalities": ["text"],
+          "output_modalities": ["text"]
+        },
+        "invocation": {
+          "interface": "mcp",
+          "reach": "hybrid",
+          "agent_operable": true,
+          "auth_to_invoke": "optional_api_token",
+          "agent_completable_setup": true,
+          "setup_requires": [],
+          "platforms": ["any"],
+          "docs_url": "https://context7.com/docs/resources/developer"
+        },
+        "pricing": {
+          "billing_dimensions": [
+            {
+              "dimension": "seat",
+              "unit": "per_month",
+              "cost_per_unit": 10,
+              "currency": "USD",
+              "conditions": {
+                "when": "Pro plan; includes 5,000 API calls per seat per month",
+                "cost_per_unit": 10
+              }
+            },
+            {
+              "dimension": "api_call",
+              "unit": "per_1K",
+              "cost_per_unit": 10,
+              "currency": "USD",
+              "conditions": {
+                "when": "Pro usage above the 5,000 included API calls per seat per month",
+                "cost_per_unit": 10
+              }
+            }
+          ],
+          "free_tier": {
+            "dimension": "api_call",
+            "limit": 1000,
+            "period": "monthly"
+          },
+          "estimated": false
+        },
+        "sla": {
+          "rate_limit": "Anonymous callers have lower limits; API-key limits vary by plan and current limits are returned in response headers."
+        },
+        "operational_constraints": {
+          "risk_class": "low",
+          "side_effects": ["read_only", "external_api_call", "network_access"],
+          "approval": {
+            "required": "never",
+            "conditions": [],
+            "human_readable": "The published resolve-library-id and query-docs tools are read-only."
+          },
+          "policy_notes": "The published /mcp endpoint supports limited anonymous use; an API key provides higher plan-dependent limits. Context7's separate REST API requires an API key. Clients remain responsible for local approval and data-handling policy."
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Why

Context7 already publishes an MCP Registry `server.json`. This adds a namespaced ASM block under the Registry's publisher-provided metadata container so catalogs and agents can inspect source-linked selection facts without scraping prose.

## Scope

- declares the exact MCP tool names, invocation reach, optional API-token behavior, official pricing, and read-only operational constraints;
- marks the claims `self_reported` and explicitly avoids any independent quality or availability attestation;
- extends the existing release `jq` step so the ASM `service_id` stays aligned with the published Registry version.

There is no runtime behavior change and no new external CI dependency. The committed `service_id` remains `4.0.3` because it matches the current `server.json`; the existing release workflow will stamp all three version fields together on the next publish.

## Source evidence

- [official plans](https://context7.com/plans)
- [API guide](https://context7.com/docs/api-guide)
- [MCP developer guide](https://context7.com/docs/resources/developer)
- [`server.json`](https://github.com/upstash/context7/blob/master/server.json) and the [registered tool annotations](https://github.com/upstash/context7/blob/master/packages/mcp/src/index.ts)

## Verification

- MCP Registry `2025-12-11` schema: PASS
- `asm-protocol==0.6.0` `asm-lint`: valid / complete / fresh / ready
- manifest digest: `sha256:07302a6b78c1d4d6a91e4ded962d41f324e79a687eb7f84a8ee8bec4deef7a7f`
- `asm-mcp-validate`: valid, convertible, no warnings or errors
- release `jq` simulation updates root version, package version, and ASM `service_id` together

Please verify or adjust any publisher-owned claim during review.
