### PR TITLE
fix(mcp): remove legacy client IP encryption

### DIFF
--- a/.changeset/remove-legacy-client-ip.md
+++ b/.changeset/remove-legacy-client-ip.md
@@ -1,0 +1,5 @@
+---
+"@upstash/context7-mcp": patch
+---
+
+Remove the legacy AES-CBC client-IP header now that authenticated assertions are deployed.

--- a/.env.example
+++ b/.env.example
@@ -16,9 +16,6 @@ MCP_CLIENT_IP_ASSERTION_KEY=
 # Maximum concurrent MCP subscription streams per HTTP process.
 MCP_MAX_SUBSCRIPTIONS=16000
 
-# Temporary legacy rollout key. Removal is tracked by CTX7-2536.
-CLIENT_IP_ENCRYPTION_KEY=
-
 # Network / certificates
 HTTPS_PROXY=
 NODE_EXTRA_CA_CERTS=

--- a/docs/security/data-privacy.mdx
+++ b/docs/security/data-privacy.mdx
@@ -23,7 +23,7 @@ When you use Context7 through an MCP client, the AI assistant (not the user dire
 - API key (if provided, for authentication)
 - MCP client name and version (e.g., IDE info, for analytics)
 - Transport type (`stdio` or `http`)
-- Client IP address, encrypted with AES-256-CBC (HTTP transport only, for rate limiting)
+- Client IP address, sent as a short-lived authenticated AES-256-GCM assertion by hosted HTTP deployments (for rate limiting)
 
 <Note>
   The MCP client formulates search queries on your behalf and is instructed not to include

--- a/packages/mcp/src/lib/encryption.ts
+++ b/packages/mcp/src/lib/encryption.ts
@@ -3,7 +3,6 @@ import { isIP } from "node:net";
 import { SERVER_VERSION } from "./constants.js";
 import type { ClientContext } from "./types.js";
 
-const LEGACY_ALGORITHM = "aes-256-cbc";
 const ASSERTION_ALGORITHM = "aes-256-gcm";
 const ASSERTION_VERSION = "v1";
 let reportedInvalidAssertionKey = false;
@@ -13,24 +12,9 @@ function validateEncryptionKey(key: string): boolean {
   return /^[0-9a-fA-F]{64}$/.test(key);
 }
 
-function encryptionKey(name: "MCP_CLIENT_IP_ASSERTION_KEY" | "CLIENT_IP_ENCRYPTION_KEY") {
-  const key = process.env[name];
+function assertionKey() {
+  const key = process.env.MCP_CLIENT_IP_ASSERTION_KEY;
   return key && validateEncryptionKey(key) ? Buffer.from(key, "hex") : null;
-}
-
-/**
- * Temporary compatibility header for API deployments that predate authenticated assertions.
- * This header is ignored by patched API deployments. Removal is tracked by CTX7-2536.
- */
-function encryptLegacyClientIp(clientIp: string, key: Buffer): string | null {
-  try {
-    const iv = randomBytes(16);
-    const cipher = createCipheriv(LEGACY_ALGORITHM, key, iv);
-    const encrypted = Buffer.concat([cipher.update(clientIp, "utf8"), cipher.final()]);
-    return `${iv.toString("hex")}:${encrypted.toString("hex")}`;
-  } catch {
-    return null;
-  }
 }
 
 /**
@@ -42,7 +26,7 @@ export function createClientIpAssertion(
   nowMs = Date.now(),
   nonce = randomBytes(12)
 ): string | null {
-  const key = encryptionKey("MCP_CLIENT_IP_ASSERTION_KEY");
+  const key = assertionKey();
   if (!key) {
     if (!reportedInvalidAssertionKey) {
       reportedInvalidAssertionKey = true;
@@ -79,14 +63,7 @@ export function generateHeaders(context: ClientContext): Record<string, string> 
 
   if (context.clientIp) {
     const assertion = createClientIpAssertion(context.clientIp);
-    if (assertion) {
-      headers["mcp-client-ip-assertion"] = assertion;
-
-      // Producer-first rollout compatibility. Removal is tracked by CTX7-2536.
-      const key = encryptionKey("CLIENT_IP_ENCRYPTION_KEY");
-      const legacyValue = key ? encryptLegacyClientIp(context.clientIp, key) : null;
-      if (legacyValue) headers["mcp-client-ip"] = legacyValue;
-    }
+    if (assertion) headers["mcp-client-ip-assertion"] = assertion;
   }
   if (context.sessionId) {
     headers["mcp-session-id"] = context.sessionId;

--- a/packages/mcp/test/encryption.test.ts
+++ b/packages/mcp/test/encryption.test.ts
@@ -8,12 +8,10 @@ const NONCE = Buffer.from("00112233445566778899aabb", "hex");
 describe("client IP assertions", () => {
   beforeEach(() => {
     process.env.MCP_CLIENT_IP_ASSERTION_KEY = KEY;
-    process.env.CLIENT_IP_ENCRYPTION_KEY = KEY;
   });
 
   afterEach(() => {
     delete process.env.MCP_CLIENT_IP_ASSERTION_KEY;
-    delete process.env.CLIENT_IP_ENCRYPTION_KEY;
   });
 
   test("creates a versioned AES-GCM assertion", () => {
@@ -24,16 +22,15 @@ describe("client IP assertions", () => {
     );
   });
 
-  test("emits authenticated and rollout-compatible headers", () => {
+  test("emits only the authenticated assertion header", () => {
     const headers = generateHeaders({ clientIp: "203.0.113.99" });
 
     expect(headers["mcp-client-ip-assertion"]).toMatch(/^v1:/);
-    expect(headers["mcp-client-ip"]).toMatch(/^[0-9a-f]{32}:[0-9a-f]+$/);
+    expect(headers["mcp-client-ip"]).toBeUndefined();
   });
 
   test("fails closed instead of sending plaintext when the key is absent or invalid", () => {
     delete process.env.MCP_CLIENT_IP_ASSERTION_KEY;
-    delete process.env.CLIENT_IP_ENCRYPTION_KEY;
     expect(
       generateHeaders({ clientIp: "203.0.113.99" })["mcp-client-ip-assertion"]
     ).toBeUndefined();

--- a/packages/mcp/test/integration.test.ts
+++ b/packages/mcp/test/integration.test.ts
@@ -118,7 +118,6 @@ beforeAll(async () => {
     ...getDefaultEnvironment(),
     CONTEXT7_API_URL: stubUrl,
     MCP_CLIENT_IP_ASSERTION_KEY: CLIENT_IP_ASSERTION_KEY,
-    CLIENT_IP_ENCRYPTION_KEY: CLIENT_IP_ASSERTION_KEY,
   };
   ({ child: httpChild, url: httpUrl } = await startHttpChild());
 }, 120_000);
@@ -257,7 +256,7 @@ describe.each([
       expect(
         decryptClientIpAssertion(apiCalls[0].headers["mcp-client-ip-assertion"] as string)
       ).toBe("203.0.113.77");
-      expect(apiCalls[0].headers["mcp-client-ip"]).toMatch(/^[0-9a-f]{32}:[0-9a-f]+$/);
+      expect(apiCalls[0].headers["mcp-client-ip"]).toBeUndefined();
     } else {
       expect(apiCalls[0].headers["mcp-client-ip-assertion"]).toBeUndefined();
     }


### PR DESCRIPTION
## Summary

- remove the transitional AES-CBC `mcp-client-ip` header
- remove MCP-side `CLIENT_IP_ENCRYPTION_KEY` configuration and test setup
- keep the authenticated AES-256-GCM assertion path unchanged
- correct the client-IP encryption description in the privacy documentation

This completes the remaining legacy cleanup for Cobalt PT38659_25 and tracks [CTX7-2580](https://linear.app/upstash/issue/CTX7-2580/harden-mcp-forwarded-client-ip-handling-and-remove-legacy-encryption).

## Validation

- `pnpm typecheck`
- `pnpm lint:check`
- `pnpm test` — 6 files, 59 tests
- `pnpm exec prettier --check ...`
- `git diff --check`

The integration suite builds and runs the real HTTP and stdio servers. It confirms that HTTP requests emit only the authenticated assertion, attacker-controlled forwarded-header prefixes are not selected, and stdio emits no client-IP assertion.

## Deployment

Remove `CLIENT_IP_ENCRYPTION_KEY` from the MCP deployment after rollout. Do not remove or rotate the context7app value used for OAuth token encryption.

Proxy handling and stdio behavior are unchanged.
