### PR TITLE
Document and enable Docs7 attribution

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -3,6 +3,7 @@
   "theme": "mint",
   "name": "Context7 MCP",
   "description": "Up-to-date code docs for any prompt.",
+  "poweredByDocs7": true,
   "redirects": [
     {
       "source": "/enterprise/azure-apim",

--- a/docs/docs7/configuration.mdx
+++ b/docs/docs7/configuration.mdx
@@ -98,3 +98,15 @@ Set `filterSidebar` to `true` to add a filter above the sidebar. Readers can pre
 </Frame>
 
 The default value is `false`.
+
+## Show Docs7 attribution
+
+Set `poweredByDocs7` to `true` to add a **Built with Docs7** link to the footer. The link opens [the Docs7 page](https://context7.com/docs7).
+
+```json docs.json
+{
+  "poweredByDocs7": true
+}
+```
+
+The default value is `false`. Docs7 always shows this link for sites on the Free plan.


### PR DESCRIPTION
## Summary

- enable the Built with Docs7 footer link for Context7 Docs
- document the top-level poweredByDocs7 setting and its false default
- document that Free-plan sites always show the link

## Dependency

Requires upstash/docs7#301 for the renderer behavior. Free-plan enforcement also uses upstash/context7app#1106.

## Validation

- docs/docs.json parses as JSON
- Prettier check passed for both changed files
- the configuration rendered the attribution link with the Docs7 PR branch
- git diff --check passed