### PR TITLE
CTX7-2692: Support Vercel Marketplace OIDC in SDK and MCP

### DIFF
--- a/.changeset/soft-dodos-oidc.md
+++ b/.changeset/soft-dodos-oidc.md
@@ -1,0 +1,6 @@
+---
+"@upstash/context7-sdk": minor
+"@upstash/context7-mcp": minor
+---
+
+Add per-request OIDC bearer token support for Vercel Marketplace connections.

--- a/.changeset/soft-dodos-oidc.md
+++ b/.changeset/soft-dodos-oidc.md
@@ -3,4 +3,4 @@
 "@upstash/context7-mcp": minor
 ---
 
-Add per-request OIDC bearer token support for Vercel Marketplace connections.
+Add per-request bearer-token providers and Vercel Marketplace resource OIDC validation.

--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,10 @@ EMA_ISSUER=
 AUTH_SERVER_URL=
 OPENAI_APPS_CHALLENGE_TOKEN=
 
+# Exact values assigned to the Context7 Vercel Marketplace product.
+VERCEL_MARKETPLACE_OIDC_ISSUER=
+VERCEL_MARKETPLACE_OIDC_AUDIENCE=
+
 # Required for hosted HTTP deployments. Must match context7.com.
 MCP_CLIENT_IP_ASSERTION_KEY=
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -55,27 +55,33 @@ Check out our [project addition guide](https://context7.com/docs/adding-librarie
 - Cursor, Claude Code, VSCode, Devin Desktop or another MCP Client
 - Context7 API Key (Optional) for higher rate limits and private repositories (Get yours by creating an account at [context7.com/dashboard](https://context7.com/dashboard))
 
-### Vercel OIDC
+### Vercel Marketplace OIDC
 
-Vercel Marketplace-connected projects can call the remote MCP server without a
-long-lived Context7 API key. Obtain a fresh deployment token with the
-`https://context7.com` audience and send it as the bearer credential:
+Vercel Marketplace resources can call the remote MCP server without a
+long-lived Context7 API key. Obtain a fresh per-resource access token from
+Vercel's Marketplace integration runtime and send it as the bearer credential:
 
 ```ts
-import { getVercelOidcToken } from "@vercel/oidc";
+// Supplied by Vercel's Marketplace integration runtime.
+declare function getMarketplaceResourceToken(): Promise<string>;
 
-const authorization = `Bearer ${await getVercelOidcToken({
-  audience: "https://context7.com",
-})}`;
+const authorization = `Bearer ${await getMarketplaceResourceToken()}`;
 ```
 
 Use `authorization` as the `Authorization` header when creating the MCP HTTP
 transport. Create the transport inside the request that uses it so a short-lived
-token is not retained across function invocations. The Vercel project must first
-be connected to a Context7 Marketplace resource.
+token is not retained across function invocations. Its `resource` claim must
+match the Context7 resource created during Marketplace provisioning.
 
-> [!TIP]
-> **Recommended Post-Setup: Add a Rule to Auto-Invoke Context7**
+The hosted MCP service must be configured with the exact issuer and audience
+assigned by Vercel when the Context7 Marketplace product is created:
+
+```sh
+VERCEL_MARKETPLACE_OIDC_ISSUER=https://integrations.vercel.com/oac_...
+VERCEL_MARKETPLACE_OIDC_AUDIENCE=https://integrations.vercel.com/context7/icfg_...
+```
+
+> [!TIP] > **Recommended Post-Setup: Add a Rule to Auto-Invoke Context7**
 >
 > After installing Context7 (see instructions below), enhance your workflow by adding a rule so you don't have to type `use context7` in every prompt. Define a simple rule in your MCP client's rule section to automatically invoke Context7 on any code question:
 >
@@ -1409,6 +1415,7 @@ autohand mcp add --transport http context7 https://mcp.context7.com/mcp
 Context7 MCP provides the following tools that LLMs can use:
 
 - `resolve-library-id`: Resolves a general library name into a Context7-compatible library ID.
+
   - `libraryName` (required): The name of the library to search for
 
 - `get-library-docs`: Fetches documentation for a library using a Context7-compatible library ID.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -55,6 +55,25 @@ Check out our [project addition guide](https://context7.com/docs/adding-librarie
 - Cursor, Claude Code, VSCode, Devin Desktop or another MCP Client
 - Context7 API Key (Optional) for higher rate limits and private repositories (Get yours by creating an account at [context7.com/dashboard](https://context7.com/dashboard))
 
+### Vercel OIDC
+
+Vercel Marketplace-connected projects can call the remote MCP server without a
+long-lived Context7 API key. Obtain a fresh deployment token with the
+`https://context7.com` audience and send it as the bearer credential:
+
+```ts
+import { getVercelOidcToken } from "@vercel/oidc";
+
+const authorization = `Bearer ${await getVercelOidcToken({
+  audience: "https://context7.com",
+})}`;
+```
+
+Use `authorization` as the `Authorization` header when creating the MCP HTTP
+transport. Create the transport inside the request that uses it so a short-lived
+token is not retained across function invocations. The Vercel project must first
+be connected to a Context7 Marketplace resource.
+
 > [!TIP]
 > **Recommended Post-Setup: Add a Rule to Auto-Invoke Context7**
 >

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1415,7 +1415,6 @@ autohand mcp add --transport http context7 https://mcp.context7.com/mcp
 Context7 MCP provides the following tools that LLMs can use:
 
 - `resolve-library-id`: Resolves a general library name into a Context7-compatible library ID.
-
   - `libraryName` (required): The name of the library to search for
 
 - `get-library-docs`: Fetches documentation for a library using a Context7-compatible library ID.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -55,33 +55,8 @@ Check out our [project addition guide](https://context7.com/docs/adding-librarie
 - Cursor, Claude Code, VSCode, Devin Desktop or another MCP Client
 - Context7 API Key (Optional) for higher rate limits and private repositories (Get yours by creating an account at [context7.com/dashboard](https://context7.com/dashboard))
 
-### Vercel Marketplace OIDC
-
-Vercel Marketplace resources can call the remote MCP server without a
-long-lived Context7 API key. Obtain a fresh per-resource access token from
-Vercel's Marketplace integration runtime and send it as the bearer credential:
-
-```ts
-// Supplied by Vercel's Marketplace integration runtime.
-declare function getMarketplaceResourceToken(): Promise<string>;
-
-const authorization = `Bearer ${await getMarketplaceResourceToken()}`;
-```
-
-Use `authorization` as the `Authorization` header when creating the MCP HTTP
-transport. Create the transport inside the request that uses it so a short-lived
-token is not retained across function invocations. Its `resource` claim must
-match the Context7 resource created during Marketplace provisioning.
-
-The hosted MCP service must be configured with the exact issuer and audience
-assigned by Vercel when the Context7 Marketplace product is created:
-
-```sh
-VERCEL_MARKETPLACE_OIDC_ISSUER=https://integrations.vercel.com/oac_...
-VERCEL_MARKETPLACE_OIDC_AUDIENCE=https://integrations.vercel.com/context7/icfg_...
-```
-
-> [!TIP] > **Recommended Post-Setup: Add a Rule to Auto-Invoke Context7**
+> [!TIP]
+> **Recommended Post-Setup: Add a Rule to Auto-Invoke Context7**
 >
 > After installing Context7 (see instructions below), enhance your workflow by adding a rule so you don't have to type `use context7` in every prompt. Define a simple rule in your MCP client's rule section to automatically invoke Context7 on any code question:
 >
@@ -1645,6 +1620,34 @@ Stay updated and join our community:
 - [Income Stream Surfers: "Context7: The New MCP Server That Will CHANGE AI Coding"](https://www.youtube.com/watch?v=PS-2Azb-C3M)
 - [AICodeKing: "Context7 + Cline & RooCode: This MCP Server Makes CLINE 100X MORE EFFECTIVE!"](https://www.youtube.com/watch?v=qZfENAPMnyo)
 - [Sean Kochel: "5 MCP Servers For Vibe Coding Glory (Just Plug-In & Go)"](https://www.youtube.com/watch?v=LqTQi8qexJM)
+
+## Vercel Marketplace OIDC
+
+Vercel Marketplace resources can call the remote MCP server without a
+long-lived Context7 API key. Obtain a fresh per-resource access token from
+Vercel's Marketplace integration runtime and send it as the bearer credential:
+
+```ts
+import { getIntegrationToken } from "@vercel/integrations";
+
+const authorization = `Bearer ${await getIntegrationToken("context7")}`;
+```
+
+The `getIntegrationToken` signature is based on Vercel's current provider
+specification and may change before Marketplace OIDC is generally available.
+
+Use `authorization` as the `Authorization` header when creating the MCP HTTP
+transport. Create the transport inside the request that uses it so a short-lived
+token is not retained across function invocations. Its `resource` claim must
+match the Context7 resource created during Marketplace provisioning.
+
+The hosted MCP service must be configured with the exact issuer and audience
+assigned by Vercel when the Context7 Marketplace product is created:
+
+```sh
+VERCEL_MARKETPLACE_OIDC_ISSUER=https://integrations.vercel.com/oac_...
+VERCEL_MARKETPLACE_OIDC_AUDIENCE=https://integrations.vercel.com/context7/icfg_...
+```
 
 ## 📄 License
 

--- a/packages/mcp/src/lib/jwt.ts
+++ b/packages/mcp/src/lib/jwt.ts
@@ -12,9 +12,42 @@ const oauthJwks = jose.createRemoteJWKSet(new URL(OAUTH_JWKS_URL));
 
 const emaJwks = jose.createRemoteJWKSet(new URL(EMA_JWKS_URL));
 
-const vercelOidcJwks = jose.createRemoteJWKSet(new URL("https://oidc.vercel.com/.well-known/jwks"));
-const VERCEL_OIDC_AUDIENCE = "https://context7.com";
-const VERCEL_OIDC_ISSUER_RE = /^https:\/\/oidc\.vercel\.com(?:\/[a-z0-9-]+)?$/i;
+const VERCEL_INTEGRATIONS_ORIGIN = "https://integrations.vercel.com";
+const VERCEL_ISSUER_PATH = /^\/oac_[A-Za-z0-9]+$/;
+const VERCEL_AUDIENCE_PATH = /^\/[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\/icfg_[A-Za-z0-9]+$/;
+const VERCEL_MARKETPLACE_OIDC_ISSUER = process.env.VERCEL_MARKETPLACE_OIDC_ISSUER ?? "";
+const VERCEL_MARKETPLACE_OIDC_AUDIENCE = process.env.VERCEL_MARKETPLACE_OIDC_AUDIENCE ?? "";
+
+let vercelMarketplaceJwks: ReturnType<typeof jose.createRemoteJWKSet> | undefined;
+
+function isExpectedVercelUrl(value: string, pathPattern: RegExp): boolean {
+  try {
+    const url = new URL(value);
+    return (
+      url.origin === VERCEL_INTEGRATIONS_ORIGIN &&
+      !url.username &&
+      !url.password &&
+      !url.search &&
+      !url.hash &&
+      pathPattern.test(url.pathname)
+    );
+  } catch {
+    return false;
+  }
+}
+
+function isVercelMarketplaceIssuer(issuer: string): boolean {
+  return isExpectedVercelUrl(issuer, VERCEL_ISSUER_PATH);
+}
+
+function getVercelMarketplaceJwks() {
+  if (!vercelMarketplaceJwks) {
+    vercelMarketplaceJwks = jose.createRemoteJWKSet(
+      new URL(`${VERCEL_MARKETPLACE_OIDC_ISSUER}/.well-known/jwks`)
+    );
+  }
+  return vercelMarketplaceJwks;
+}
 
 const ENTRA_V2_ISSUER_RE = /^https:\/\/login\.microsoftonline\.com\/[0-9a-f-]{36}\/v2\.0$/;
 
@@ -107,14 +140,25 @@ export async function validateJWT(token: string): Promise<JWTValidationResult> {
       return { valid: true };
     }
 
-    if (VERCEL_OIDC_ISSUER_RE.test(iss)) {
-      const { payload } = await jose.jwtVerify(token, vercelOidcJwks, {
+    if (isVercelMarketplaceIssuer(iss)) {
+      if (
+        !isVercelMarketplaceIssuer(VERCEL_MARKETPLACE_OIDC_ISSUER) ||
+        !isExpectedVercelUrl(VERCEL_MARKETPLACE_OIDC_AUDIENCE, VERCEL_AUDIENCE_PATH)
+      ) {
+        return { valid: false, error: "Vercel Marketplace OIDC not configured" };
+      }
+      if (iss !== VERCEL_MARKETPLACE_OIDC_ISSUER) {
+        return { valid: false, error: "Untrusted Vercel Marketplace issuer" };
+      }
+
+      const { payload } = await jose.jwtVerify(token, getVercelMarketplaceJwks(), {
         algorithms: ["RS256"],
-        audience: VERCEL_OIDC_AUDIENCE,
-        issuer: iss,
+        audience: VERCEL_MARKETPLACE_OIDC_AUDIENCE,
+        issuer: VERCEL_MARKETPLACE_OIDC_ISSUER,
+        clockTolerance: 60,
       });
-      if (typeof payload.owner_id !== "string" || typeof payload.project_id !== "string") {
-        return { valid: false, error: "Missing Vercel project identity" };
+      if (typeof payload.resource !== "string" || !payload.resource) {
+        return { valid: false, error: "Missing Vercel Marketplace resource" };
       }
       return { valid: true };
     }

--- a/packages/mcp/src/lib/jwt.ts
+++ b/packages/mcp/src/lib/jwt.ts
@@ -12,6 +12,10 @@ const oauthJwks = jose.createRemoteJWKSet(new URL(OAUTH_JWKS_URL));
 
 const emaJwks = jose.createRemoteJWKSet(new URL(EMA_JWKS_URL));
 
+const vercelOidcJwks = jose.createRemoteJWKSet(new URL("https://oidc.vercel.com/.well-known/jwks"));
+const VERCEL_OIDC_AUDIENCE = "https://context7.com";
+const VERCEL_OIDC_ISSUER_RE = /^https:\/\/oidc\.vercel\.com(?:\/[a-z0-9-]+)?$/i;
+
 const ENTRA_V2_ISSUER_RE = /^https:\/\/login\.microsoftonline\.com\/[0-9a-f-]{36}\/v2\.0$/;
 
 const jwksByTenant = new Map<string, ReturnType<typeof jose.createRemoteJWKSet>>();
@@ -100,6 +104,18 @@ export async function validateJWT(token: string): Promise<JWTValidationResult> {
 
     if (iss === EMA_ISSUER) {
       await jose.jwtVerify(token, emaJwks, { issuer: EMA_ISSUER, audience: RESOURCE_URL });
+      return { valid: true };
+    }
+
+    if (VERCEL_OIDC_ISSUER_RE.test(iss)) {
+      const { payload } = await jose.jwtVerify(token, vercelOidcJwks, {
+        algorithms: ["RS256"],
+        audience: VERCEL_OIDC_AUDIENCE,
+        issuer: iss,
+      });
+      if (typeof payload.owner_id !== "string" || typeof payload.project_id !== "string") {
+        return { valid: false, error: "Missing Vercel project identity" };
+      }
       return { valid: true };
     }
 

--- a/packages/mcp/src/lib/jwt.ts
+++ b/packages/mcp/src/lib/jwt.ts
@@ -7,47 +7,11 @@ import {
   OAUTH_JWKS_URL,
   RESOURCE_URL,
 } from "./constants.js";
+import { isVercelMarketplaceIssuer, validateVercelMarketplaceJwt } from "./vercelMarketplaceJwt.js";
 
 const oauthJwks = jose.createRemoteJWKSet(new URL(OAUTH_JWKS_URL));
 
 const emaJwks = jose.createRemoteJWKSet(new URL(EMA_JWKS_URL));
-
-const VERCEL_INTEGRATIONS_ORIGIN = "https://integrations.vercel.com";
-const VERCEL_ISSUER_PATH = /^\/oac_[A-Za-z0-9]+$/;
-const VERCEL_AUDIENCE_PATH = /^\/[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\/icfg_[A-Za-z0-9]+$/;
-const VERCEL_MARKETPLACE_OIDC_ISSUER = process.env.VERCEL_MARKETPLACE_OIDC_ISSUER ?? "";
-const VERCEL_MARKETPLACE_OIDC_AUDIENCE = process.env.VERCEL_MARKETPLACE_OIDC_AUDIENCE ?? "";
-
-let vercelMarketplaceJwks: ReturnType<typeof jose.createRemoteJWKSet> | undefined;
-
-function isExpectedVercelUrl(value: string, pathPattern: RegExp): boolean {
-  try {
-    const url = new URL(value);
-    return (
-      url.origin === VERCEL_INTEGRATIONS_ORIGIN &&
-      !url.username &&
-      !url.password &&
-      !url.search &&
-      !url.hash &&
-      pathPattern.test(url.pathname)
-    );
-  } catch {
-    return false;
-  }
-}
-
-function isVercelMarketplaceIssuer(issuer: string): boolean {
-  return isExpectedVercelUrl(issuer, VERCEL_ISSUER_PATH);
-}
-
-function getVercelMarketplaceJwks() {
-  if (!vercelMarketplaceJwks) {
-    vercelMarketplaceJwks = jose.createRemoteJWKSet(
-      new URL(`${VERCEL_MARKETPLACE_OIDC_ISSUER}/.well-known/jwks`)
-    );
-  }
-  return vercelMarketplaceJwks;
-}
 
 const ENTRA_V2_ISSUER_RE = /^https:\/\/login\.microsoftonline\.com\/[0-9a-f-]{36}\/v2\.0$/;
 
@@ -141,26 +105,7 @@ export async function validateJWT(token: string): Promise<JWTValidationResult> {
     }
 
     if (isVercelMarketplaceIssuer(iss)) {
-      if (
-        !isVercelMarketplaceIssuer(VERCEL_MARKETPLACE_OIDC_ISSUER) ||
-        !isExpectedVercelUrl(VERCEL_MARKETPLACE_OIDC_AUDIENCE, VERCEL_AUDIENCE_PATH)
-      ) {
-        return { valid: false, error: "Vercel Marketplace OIDC not configured" };
-      }
-      if (iss !== VERCEL_MARKETPLACE_OIDC_ISSUER) {
-        return { valid: false, error: "Untrusted Vercel Marketplace issuer" };
-      }
-
-      const { payload } = await jose.jwtVerify(token, getVercelMarketplaceJwks(), {
-        algorithms: ["RS256"],
-        audience: VERCEL_MARKETPLACE_OIDC_AUDIENCE,
-        issuer: VERCEL_MARKETPLACE_OIDC_ISSUER,
-        clockTolerance: 60,
-      });
-      if (typeof payload.resource !== "string" || !payload.resource) {
-        return { valid: false, error: "Missing Vercel Marketplace resource" };
-      }
-      return { valid: true };
+      return validateVercelMarketplaceJwt(token, iss);
     }
 
     await jose.jwtVerify(token, oauthJwks, { issuer: OAUTH_AUTH_SERVER_URL });

--- a/packages/mcp/src/lib/vercelMarketplaceJwt.ts
+++ b/packages/mcp/src/lib/vercelMarketplaceJwt.ts
@@ -1,0 +1,76 @@
+import * as jose from "jose";
+
+const VERCEL_INTEGRATIONS_ORIGIN = "https://integrations.vercel.com";
+const VERCEL_ISSUER_PATH = /^\/oac_[A-Za-z0-9]+$/;
+const VERCEL_AUDIENCE_PATH = /^\/[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\/icfg_[A-Za-z0-9]+$/;
+
+interface ValidationResult {
+  valid: boolean;
+  error?: string;
+}
+
+interface VercelMarketplaceConfig {
+  issuer: string;
+  audience: string;
+}
+
+let jwks: ReturnType<typeof jose.createRemoteJWKSet> | undefined;
+
+function isExpectedVercelUrl(value: string, pathPattern: RegExp): boolean {
+  try {
+    const url = new URL(value);
+    return (
+      url.origin === VERCEL_INTEGRATIONS_ORIGIN &&
+      !url.username &&
+      !url.password &&
+      !url.search &&
+      !url.hash &&
+      pathPattern.test(url.pathname)
+    );
+  } catch {
+    return false;
+  }
+}
+
+function getConfig(): VercelMarketplaceConfig | null {
+  const issuer = process.env.VERCEL_MARKETPLACE_OIDC_ISSUER ?? "";
+  const audience = process.env.VERCEL_MARKETPLACE_OIDC_AUDIENCE ?? "";
+
+  if (!isVercelMarketplaceIssuer(issuer) || !isExpectedVercelUrl(audience, VERCEL_AUDIENCE_PATH)) {
+    return null;
+  }
+  return { issuer, audience };
+}
+
+function getJwks(issuer: string) {
+  if (!jwks) {
+    jwks = jose.createRemoteJWKSet(new URL(`${issuer}/.well-known/jwks`));
+  }
+  return jwks;
+}
+
+export function isVercelMarketplaceIssuer(issuer: string): boolean {
+  return isExpectedVercelUrl(issuer, VERCEL_ISSUER_PATH);
+}
+
+export async function validateVercelMarketplaceJwt(
+  token: string,
+  tokenIssuer: string
+): Promise<ValidationResult> {
+  const config = getConfig();
+  if (!config) return { valid: false, error: "Vercel Marketplace OIDC not configured" };
+  if (tokenIssuer !== config.issuer) {
+    return { valid: false, error: "Untrusted Vercel Marketplace issuer" };
+  }
+
+  const { payload } = await jose.jwtVerify(token, getJwks(config.issuer), {
+    algorithms: ["RS256"],
+    audience: config.audience,
+    issuer: config.issuer,
+    clockTolerance: 60,
+  });
+  if (typeof payload.resource !== "string" || !payload.resource) {
+    return { valid: false, error: "Missing Vercel Marketplace resource" };
+  }
+  return { valid: true };
+}

--- a/packages/mcp/test/jwt.test.ts
+++ b/packages/mcp/test/jwt.test.ts
@@ -17,6 +17,8 @@ const ENTRA_ISSUER = `https://login.microsoftonline.com/${TENANT_ID}/v2.0`;
 const AUDIENCE = "6ff6a635-03d9-472d-a7f1-dc98a4e5fde2";
 const originalOAuthAuthServerUrl = process.env.OAUTH_AUTH_SERVER_URL;
 const originalOAuthJwksUrl = process.env.OAUTH_JWKS_URL;
+const VERCEL_ISSUER = "https://integrations.vercel.com/oac_123456789";
+const VERCEL_AUDIENCE = "https://integrations.vercel.com/context7/icfg_1234567890";
 
 async function loadModule() {
   vi.resetModules();
@@ -41,6 +43,8 @@ function makeEntraToken(payload: jose.JWTPayload): string {
 
 beforeEach(() => {
   vi.stubGlobal("fetch", vi.fn());
+  vi.stubEnv("VERCEL_MARKETPLACE_OIDC_ISSUER", VERCEL_ISSUER);
+  vi.stubEnv("VERCEL_MARKETPLACE_OIDC_AUDIENCE", VERCEL_AUDIENCE);
 });
 
 afterEach(() => {
@@ -55,6 +59,7 @@ afterEach(() => {
     process.env.OAUTH_JWKS_URL = originalOAuthJwksUrl;
   }
   vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
   vi.clearAllMocks();
 });
 
@@ -236,32 +241,42 @@ describe("validateJWT - Clerk path", () => {
   });
 });
 
-describe("validateJWT - Vercel OIDC path", () => {
-  test("verifies the Vercel signature, issuer, algorithm, and Context7 audience", async () => {
+describe("validateJWT - Vercel Marketplace OIDC path", () => {
+  test("verifies the exact issuer, audience, time window, and resource", async () => {
     vi.mocked(jose.jwtVerify).mockResolvedValue({
-      payload: { owner_id: "team_123", project_id: "prj_123" },
+      payload: {
+        resource: "teamspace-resource-123",
+        sub: "user_123",
+        act: "owner:team1:project:p1:environment:production",
+      },
       protectedHeader: { alg: "RS256" },
     } as unknown as Awaited<ReturnType<typeof jose.jwtVerify>>);
 
     const { validateJWT } = await loadModule();
-    const token = makeEntraToken({ iss: "https://oidc.vercel.com/acme-team" });
+    const token = makeEntraToken({ iss: VERCEL_ISSUER, aud: VERCEL_AUDIENCE });
 
     await expect(validateJWT(token)).resolves.toEqual({ valid: true });
+    expect(jose.createRemoteJWKSet).toHaveBeenCalledWith(
+      new URL(`${VERCEL_ISSUER}/.well-known/jwks`)
+    );
     expect(jose.jwtVerify).toHaveBeenCalledWith(token, "fake-jwks", {
       algorithms: ["RS256"],
-      audience: "https://context7.com",
-      issuer: "https://oidc.vercel.com/acme-team",
+      audience: VERCEL_AUDIENCE,
+      issuer: VERCEL_ISSUER,
+      clockTolerance: 60,
     });
   });
 
-  test("does not trust lookalike Vercel issuers", async () => {
+  test("does not trust lookalike Vercel hosts", async () => {
     vi.mocked(jose.jwtVerify).mockResolvedValue({
       payload: {},
       protectedHeader: { alg: "RS256" },
     } as unknown as Awaited<ReturnType<typeof jose.jwtVerify>>);
 
     const { validateJWT } = await loadModule();
-    const token = makeEntraToken({ iss: "https://oidc.vercel.com.attacker.test" });
+    const token = makeEntraToken({
+      iss: "https://integrations.vercel.com.attacker.test/oac_123456789",
+    });
 
     await validateJWT(token);
     expect(jose.jwtVerify).toHaveBeenCalledWith(token, "fake-jwks", {
@@ -269,18 +284,43 @@ describe("validateJWT - Vercel OIDC path", () => {
     });
   });
 
-  test("requires stable Vercel owner and project IDs", async () => {
+  test("rejects tokens from another Vercel integration", async () => {
+    const { validateJWT } = await loadModule();
+    const token = makeEntraToken({ iss: "https://integrations.vercel.com/oac_987654321" });
+
+    await expect(validateJWT(token)).resolves.toEqual({
+      valid: false,
+      error: "Untrusted Vercel Marketplace issuer",
+    });
+    expect(jose.jwtVerify).not.toHaveBeenCalled();
+  });
+
+  test("fails closed when Marketplace OIDC is not configured", async () => {
+    vi.stubEnv("VERCEL_MARKETPLACE_OIDC_ISSUER", "");
+    vi.stubEnv("VERCEL_MARKETPLACE_OIDC_AUDIENCE", "");
+
+    const { validateJWT } = await loadModule();
+    const token = makeEntraToken({ iss: VERCEL_ISSUER });
+
+    await expect(validateJWT(token)).resolves.toEqual({
+      valid: false,
+      error: "Vercel Marketplace OIDC not configured",
+    });
+    expect(jose.jwtVerify).not.toHaveBeenCalled();
+  });
+
+  test("requires Vercel's immutable resource claim", async () => {
     vi.mocked(jose.jwtVerify).mockResolvedValue({
       payload: {},
       protectedHeader: { alg: "RS256" },
     } as unknown as Awaited<ReturnType<typeof jose.jwtVerify>>);
 
     const { validateJWT } = await loadModule();
-    const token = makeEntraToken({ iss: "https://oidc.vercel.com" });
+    const token = makeEntraToken({ iss: VERCEL_ISSUER, aud: VERCEL_AUDIENCE });
 
     await expect(validateJWT(token)).resolves.toEqual({
       valid: false,
-      error: "Missing Vercel project identity",
+      error: "Missing Vercel Marketplace resource",
     });
   });
 });

--- a/packages/mcp/test/jwt.test.ts
+++ b/packages/mcp/test/jwt.test.ts
@@ -235,3 +235,52 @@ describe("validateJWT - Clerk path", () => {
     );
   });
 });
+
+describe("validateJWT - Vercel OIDC path", () => {
+  test("verifies the Vercel signature, issuer, algorithm, and Context7 audience", async () => {
+    vi.mocked(jose.jwtVerify).mockResolvedValue({
+      payload: { owner_id: "team_123", project_id: "prj_123" },
+      protectedHeader: { alg: "RS256" },
+    } as unknown as Awaited<ReturnType<typeof jose.jwtVerify>>);
+
+    const { validateJWT } = await loadModule();
+    const token = makeEntraToken({ iss: "https://oidc.vercel.com/acme-team" });
+
+    await expect(validateJWT(token)).resolves.toEqual({ valid: true });
+    expect(jose.jwtVerify).toHaveBeenCalledWith(token, "fake-jwks", {
+      algorithms: ["RS256"],
+      audience: "https://context7.com",
+      issuer: "https://oidc.vercel.com/acme-team",
+    });
+  });
+
+  test("does not trust lookalike Vercel issuers", async () => {
+    vi.mocked(jose.jwtVerify).mockResolvedValue({
+      payload: {},
+      protectedHeader: { alg: "RS256" },
+    } as unknown as Awaited<ReturnType<typeof jose.jwtVerify>>);
+
+    const { validateJWT } = await loadModule();
+    const token = makeEntraToken({ iss: "https://oidc.vercel.com.attacker.test" });
+
+    await validateJWT(token);
+    expect(jose.jwtVerify).toHaveBeenCalledWith(token, "fake-jwks", {
+      issuer: "https://clerk.context7.com",
+    });
+  });
+
+  test("requires stable Vercel owner and project IDs", async () => {
+    vi.mocked(jose.jwtVerify).mockResolvedValue({
+      payload: {},
+      protectedHeader: { alg: "RS256" },
+    } as unknown as Awaited<ReturnType<typeof jose.jwtVerify>>);
+
+    const { validateJWT } = await loadModule();
+    const token = makeEntraToken({ iss: "https://oidc.vercel.com" });
+
+    await expect(validateJWT(token)).resolves.toEqual({
+      valid: false,
+      error: "Missing Vercel project identity",
+    });
+  });
+});

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -68,6 +68,26 @@ Then initialize without options:
 const client = new Context7();
 ```
 
+### Vercel OIDC
+
+Vercel deployments can authenticate without a long-lived Context7 API key.
+Pass a token provider so each request receives a current OIDC token:
+
+```ts
+import { getVercelOidcToken } from "@vercel/oidc";
+import { Context7 } from "@upstash/context7-sdk";
+
+const client = new Context7({
+  authToken: () =>
+    getVercelOidcToken({
+      audience: "https://context7.com",
+    }),
+});
+```
+
+The Vercel project must first be connected to a Context7 Marketplace resource.
+Do not resolve the token once at startup: Vercel OIDC tokens are short-lived.
+
 ### Production HTTP options
 
 Requests time out after 30 seconds and retry transient network errors, `408`, `425`, `429`,

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -68,25 +68,26 @@ Then initialize without options:
 const client = new Context7();
 ```
 
-### Vercel OIDC
+### Vercel Marketplace OIDC
 
-Vercel deployments can authenticate without a long-lived Context7 API key.
-Pass a token provider so each request receives a current OIDC token:
+Vercel Marketplace resources can authenticate without a long-lived Context7
+API key. Pass Vercel's per-resource access-token callback as a token provider
+so each request receives a current token:
 
 ```ts
-import { getVercelOidcToken } from "@vercel/oidc";
 import { Context7 } from "@upstash/context7-sdk";
 
+// Supplied by Vercel's Marketplace integration runtime.
+declare function getMarketplaceResourceToken(): Promise<string>;
+
 const client = new Context7({
-  authToken: () =>
-    getVercelOidcToken({
-      audience: "https://context7.com",
-    }),
+  authToken: getMarketplaceResourceToken,
 });
 ```
 
-The Vercel project must first be connected to a Context7 Marketplace resource.
-Do not resolve the token once at startup: Vercel OIDC tokens are short-lived.
+The token's `resource` claim must match the Context7 resource created during
+Marketplace provisioning. Do not resolve the token once at startup: Vercel
+Marketplace OIDC tokens are short-lived.
 
 ### Production HTTP options
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -76,14 +76,15 @@ so each request receives a current token:
 
 ```ts
 import { Context7 } from "@upstash/context7-sdk";
-
-// Supplied by Vercel's Marketplace integration runtime.
-declare function getMarketplaceResourceToken(): Promise<string>;
+import { getIntegrationToken } from "@vercel/integrations";
 
 const client = new Context7({
-  authToken: getMarketplaceResourceToken,
+  authToken: () => getIntegrationToken("context7"),
 });
 ```
+
+The `getIntegrationToken` signature is based on Vercel's current provider
+specification and may change before Marketplace OIDC is generally available.
 
 The token's `resource` claim must match the Context7 resource created during
 Marketplace provisioning. Do not resolve the token once at startup: Vercel

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -89,6 +89,10 @@ The token's `resource` claim must match the Context7 resource created during
 Marketplace provisioning. Do not resolve the token once at startup: Vercel
 Marketplace OIDC tokens are short-lived.
 
+Explicit credentials take precedence in this order: `apiKey`, `authToken`, then
+`CONTEXT7_API_KEY`. This allows OIDC to be tested while a legacy API key remains
+available during a dual-auth migration.
+
 ### Production HTTP options
 
 Requests time out after 30 seconds and retry transient network errors, `408`, `425`, `429`,

--- a/packages/sdk/src/client.test.ts
+++ b/packages/sdk/src/client.test.ts
@@ -19,11 +19,48 @@ describe("Context7 Client", () => {
     expect(new Context7()).toBeDefined();
   });
 
-  test("requires an API key", () => {
+  test("requires an API key or auth token", () => {
     vi.stubEnv("CONTEXT7_API_KEY", "");
 
     expect(() => new Context7({ apiKey: "" })).toThrow(Context7Error);
-    expect(() => new Context7()).toThrow("API key is required");
+    expect(() => new Context7()).toThrow("Authentication is required");
+  });
+
+  test("resolves a fresh OIDC token for every request", async () => {
+    const fetchMock = vi.fn().mockImplementation(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ results: [] }), {
+          headers: { "content-type": "application/json" },
+        })
+      )
+    );
+    const authToken = vi
+      .fn<() => Promise<string>>()
+      .mockResolvedValueOnce("oidc-token-1")
+      .mockResolvedValueOnce("oidc-token-2");
+    const client = new Context7({ authToken, fetch: fetchMock, retry: false });
+
+    await client.searchLibrary("state management", "react");
+    await client.searchLibrary("routing", "next.js");
+
+    expect(authToken).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({
+      headers: expect.objectContaining({ Authorization: "Bearer oidc-token-1" }),
+    });
+    expect(fetchMock.mock.calls[1]?.[1]).toMatchObject({
+      headers: expect.objectContaining({ Authorization: "Bearer oidc-token-2" }),
+    });
+  });
+
+  test("rejects an empty token returned by a provider", async () => {
+    const fetchMock = vi.fn();
+    const client = new Context7({ authToken: () => "", fetch: fetchMock });
+
+    await expect(client.searchLibrary("routing", "next.js")).rejects.toMatchObject({
+      code: "authentication_error",
+      retryable: false,
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   test("prefers the configured API key over the environment", () => {

--- a/packages/sdk/src/client.test.ts
+++ b/packages/sdk/src/client.test.ts
@@ -74,6 +74,28 @@ describe("Context7 Client", () => {
     expect(warn).not.toHaveBeenCalled();
   });
 
+  test("prefers an explicit API key when both credential forms are provided", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ results: [] }), {
+        headers: { "content-type": "application/json" },
+      })
+    );
+    const authToken = vi.fn(() => "oidc-token");
+    const client = new Context7({
+      apiKey: "ctx7sk-config",
+      authToken,
+      fetch: fetchMock,
+      retry: false,
+    });
+
+    await client.searchLibrary("routing", "next.js");
+
+    expect(authToken).not.toHaveBeenCalled();
+    expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({
+      headers: expect.objectContaining({ Authorization: "Bearer ctx7sk-config" }),
+    });
+  });
+
   test("works in runtimes without process when an API key is configured", () => {
     vi.stubGlobal("process", undefined);
 

--- a/packages/sdk/src/client.test.ts
+++ b/packages/sdk/src/client.test.ts
@@ -26,7 +26,8 @@ describe("Context7 Client", () => {
     expect(() => new Context7()).toThrow("Authentication is required");
   });
 
-  test("resolves a fresh OIDC token for every request", async () => {
+  test("prefers an explicit OIDC provider over the environment and refreshes every request", async () => {
+    vi.stubEnv("CONTEXT7_API_KEY", "ctx7sk-legacy-environment-key");
     const fetchMock = vi.fn().mockImplementation(() =>
       Promise.resolve(
         new Response(JSON.stringify({ results: [] }), {
@@ -53,6 +54,7 @@ describe("Context7 Client", () => {
   });
 
   test("rejects an empty token returned by a provider", async () => {
+    vi.stubEnv("CONTEXT7_API_KEY", "ctx7sk-legacy-environment-key");
     const fetchMock = vi.fn();
     const client = new Context7({ authToken: () => "", fetch: fetchMock });
 

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -14,6 +14,7 @@ const API_KEY_PREFIX = "ctx7sk";
 
 export type * from "@commands/types";
 export type {
+  AuthTokenProvider,
   CacheSetting,
   Context7Fetch,
   Context7ResponseMetadata,
@@ -28,13 +29,13 @@ export class Context7 {
   constructor(config: Context7Config = {}) {
     const apiKey = config.apiKey || getEnvironmentApiKey();
 
-    if (!apiKey) {
+    if (!apiKey && !config.authToken) {
       throw new Context7Error(
-        "API key is required. Pass it in the config or set CONTEXT7_API_KEY environment variable."
+        "Authentication is required. Pass apiKey or authToken, or set CONTEXT7_API_KEY."
       );
     }
 
-    if (!apiKey.startsWith(API_KEY_PREFIX)) {
+    if (apiKey && !apiKey.startsWith(API_KEY_PREFIX)) {
       console.warn(`API key should start with '${API_KEY_PREFIX}'`);
     }
 
@@ -42,8 +43,8 @@ export class Context7 {
       baseUrl: config.baseUrl ?? DEFAULT_BASE_URL,
       headers: {
         ...withoutAuthorizationHeader(config.headers),
-        Authorization: `Bearer ${apiKey}`,
       },
+      authToken: apiKey ?? config.authToken,
       retry: config.retry,
       cache: config.cache ?? "no-store",
       timeout: config.timeout,

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -7,10 +7,15 @@ import type {
 } from "@commands/types";
 import { Context7Error } from "@error";
 import { HttpClient } from "@http";
+import type { AuthTokenProvider } from "@http";
 import { SearchLibraryCommand, GetContextCommand } from "@commands/index";
 
 const DEFAULT_BASE_URL = "https://context7.com/api";
 const API_KEY_PREFIX = "ctx7sk";
+
+type Credential =
+  | { kind: "apiKey"; value: string }
+  | { kind: "authToken"; value: string | AuthTokenProvider };
 
 export type * from "@commands/types";
 export type {
@@ -27,18 +32,9 @@ export class Context7 {
   private readonly httpClient: HttpClient;
 
   constructor(config: Context7Config = {}) {
-    // Explicit credentials must win over the environment. This lets callers
-    // exercise short-lived OIDC during Vercel's dual-auth migration even when
-    // a legacy CONTEXT7_API_KEY is still present.
-    const apiKey = config.apiKey || (config.authToken ? undefined : getEnvironmentApiKey());
+    const credential = resolveCredential(config);
 
-    if (!apiKey && !config.authToken) {
-      throw new Context7Error(
-        "Authentication is required. Pass apiKey or authToken, or set CONTEXT7_API_KEY."
-      );
-    }
-
-    if (apiKey && !apiKey.startsWith(API_KEY_PREFIX)) {
+    if (credential.kind === "apiKey" && !credential.value.startsWith(API_KEY_PREFIX)) {
       console.warn(`API key should start with '${API_KEY_PREFIX}'`);
     }
 
@@ -47,7 +43,7 @@ export class Context7 {
       headers: {
         ...withoutAuthorizationHeader(config.headers),
       },
-      authToken: apiKey ?? config.authToken,
+      authToken: credential.value,
       retry: config.retry,
       cache: config.cache ?? "no-store",
       timeout: config.timeout,
@@ -143,6 +139,18 @@ export class Context7 {
     const command = new GetContextCommand(query, libraryId, options);
     return command.exec(this.httpClient);
   }
+}
+
+function resolveCredential(config: Context7Config): Credential {
+  if (config.apiKey) return { kind: "apiKey", value: config.apiKey };
+  if (config.authToken) return { kind: "authToken", value: config.authToken };
+
+  const environmentApiKey = getEnvironmentApiKey();
+  if (environmentApiKey) return { kind: "apiKey", value: environmentApiKey };
+
+  throw new Context7Error(
+    "Authentication is required. Pass apiKey or authToken, or set CONTEXT7_API_KEY."
+  );
 }
 
 function getEnvironmentApiKey(): string | undefined {

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -27,7 +27,10 @@ export class Context7 {
   private readonly httpClient: HttpClient;
 
   constructor(config: Context7Config = {}) {
-    const apiKey = config.apiKey || getEnvironmentApiKey();
+    // Explicit credentials must win over the environment. This lets callers
+    // exercise short-lived OIDC during Vercel's dual-auth migration even when
+    // a legacy CONTEXT7_API_KEY is still present.
+    const apiKey = config.apiKey || (config.authToken ? undefined : getEnvironmentApiKey());
 
     if (!apiKey && !config.authToken) {
       throw new Context7Error(

--- a/packages/sdk/src/commands/types.ts
+++ b/packages/sdk/src/commands/types.ts
@@ -1,7 +1,18 @@
-import type { CacheSetting, Context7Fetch, Context7ResponseMetadata, RetryConfig } from "@http";
+import type {
+  AuthTokenProvider,
+  CacheSetting,
+  Context7Fetch,
+  Context7ResponseMetadata,
+  RetryConfig,
+} from "@http";
 
 export interface Context7Config {
   apiKey?: string;
+  /**
+   * Bearer token or per-request token provider. Use a provider for short-lived
+   * OIDC tokens so the SDK never caches an expired credential.
+   */
+  authToken?: string | AuthTokenProvider;
   /** Override the Context7 API URL, for example when using a proxy. */
   baseUrl?: string;
   /** Retry transient network and HTTP failures. Set to false to disable retries. */

--- a/packages/sdk/src/http/index.test.ts
+++ b/packages/sdk/src/http/index.test.ts
@@ -70,6 +70,36 @@ describe("HttpClient error handling", () => {
     });
   });
 
+  test("resolves a fresh auth token for every retry attempt", async () => {
+    const authToken = vi
+      .fn<() => Promise<string>>()
+      .mockResolvedValueOnce("oidc-token-1")
+      .mockResolvedValueOnce("oidc-token-2");
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("unavailable", { status: 503 }))
+      .mockResolvedValueOnce(new Response("ok"));
+    const client = new HttpClient({
+      baseUrl: "https://example.com/api",
+      authToken,
+      fetch: fetchMock,
+      retry: { retries: 1, backoff: () => 0 },
+    });
+
+    await expect(client.request({ method: "GET", path: ["search"] })).resolves.toEqual({
+      result: "ok",
+      headers: undefined,
+    });
+
+    expect(authToken).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({
+      headers: expect.objectContaining({ Authorization: "Bearer oidc-token-1" }),
+    });
+    expect(fetchMock.mock.calls[1]?.[1]).toMatchObject({
+      headers: expect.objectContaining({ Authorization: "Bearer oidc-token-2" }),
+    });
+  });
+
   test("honors Retry-After before retrying a rate-limited request", async () => {
     vi.useFakeTimers();
     const fetchMock = vi

--- a/packages/sdk/src/http/index.ts
+++ b/packages/sdk/src/http/index.ts
@@ -19,6 +19,7 @@ import type {
   HttpClientConfig,
   Requester,
   RetryPolicy,
+  AuthTokenProvider,
 } from "./types";
 
 export * from "./types";
@@ -42,6 +43,7 @@ export class HttpClient implements Requester {
   public readonly retry: RetryPolicy;
 
   private readonly fetch: Context7Fetch;
+  private readonly authToken?: string | AuthTokenProvider;
   private readonly onResponse?: (metadata: Context7ResponseMetadata) => void;
 
   public constructor(config: HttpClientConfig) {
@@ -57,6 +59,7 @@ export class HttpClient implements Requester {
     if (!isHttpUrl(this.baseUrl)) throw new Context7UrlError(this.baseUrl);
 
     this.headers = { "Content-Type": "application/json", ...config.headers };
+    this.authToken = config.authToken;
     if (!config.fetch && !globalThis.fetch) {
       throw new TypeError("A fetch implementation is required");
     }
@@ -71,19 +74,29 @@ export class HttpClient implements Requester {
       [resolveSignal(this.options.signal), request.signal],
       request.timeout ?? this.options.timeout
     );
-    const init: RequestInit = {
-      cache: normalizeCache(request.cache ?? this.options.cache),
-      method,
-      headers: this.headers,
-      body: request.body === undefined ? undefined : JSON.stringify(request.body),
-      keepalive: this.options.keepAlive,
-      signal: abortState.signal,
-    };
-
     try {
       if (abortState.signal?.aborted) {
         throw abortError(abortState.signal.reason, abortState.timedOut());
       }
+
+      const authToken =
+        typeof this.authToken === "function" ? await this.authToken() : this.authToken;
+      if (this.authToken !== undefined && !authToken) {
+        throw new Context7Error("The auth token provider returned an empty token", {
+          code: "authentication_error",
+          retryable: false,
+        });
+      }
+      const init: RequestInit = {
+        cache: normalizeCache(request.cache ?? this.options.cache),
+        method,
+        headers: authToken
+          ? { ...this.headers, Authorization: `Bearer ${authToken}` }
+          : this.headers,
+        body: request.body === undefined ? undefined : JSON.stringify(request.body),
+        keepalive: this.options.keepAlive,
+        signal: abortState.signal,
+      };
 
       const { response, metadata } = await this.fetchWithRetry(
         buildUrl(this.baseUrl, method, request),

--- a/packages/sdk/src/http/index.ts
+++ b/packages/sdk/src/http/index.ts
@@ -79,20 +79,9 @@ export class HttpClient implements Requester {
         throw abortError(abortState.signal.reason, abortState.timedOut());
       }
 
-      const authToken =
-        typeof this.authToken === "function" ? await this.authToken() : this.authToken;
-      if (this.authToken !== undefined && !authToken) {
-        throw new Context7Error("The auth token provider returned an empty token", {
-          code: "authentication_error",
-          retryable: false,
-        });
-      }
       const init: RequestInit = {
         cache: normalizeCache(request.cache ?? this.options.cache),
         method,
-        headers: authToken
-          ? { ...this.headers, Authorization: `Bearer ${authToken}` }
-          : this.headers,
         body: request.body === undefined ? undefined : JSON.stringify(request.body),
         keepalive: this.options.keepAlive,
         signal: abortState.signal,
@@ -131,9 +120,16 @@ export class HttpClient implements Requester {
     const canRetry = method === "GET";
 
     for (let attempt = 0; attempt <= this.retry.retries; attempt++) {
+      const headers =
+        typeof this.authToken === "function"
+          ? this.headersForToken(await this.authToken())
+          : this.headersForToken(this.authToken);
+      if (abortState.signal?.aborted) {
+        throw abortError(abortState.signal.reason, abortState.timedOut());
+      }
       let response: Response;
       try {
-        response = await this.fetch(url, init);
+        response = await this.fetch(url, { ...init, headers });
       } catch (cause) {
         if (abortState.signal?.aborted) {
           throw abortError(cause, abortState.timedOut());
@@ -163,6 +159,17 @@ export class HttpClient implements Requester {
     }
 
     throw new Error("Unreachable retry state");
+  }
+
+  private headersForToken(authToken: string | undefined): Record<string, string> {
+    if (this.authToken !== undefined && !authToken) {
+      throw new Context7Error("The auth token provider returned an empty token", {
+        code: "authentication_error",
+        retryable: false,
+      });
+    }
+
+    return authToken ? { ...this.headers, Authorization: `Bearer ${authToken}` } : this.headers;
   }
 }
 

--- a/packages/sdk/src/http/types.ts
+++ b/packages/sdk/src/http/types.ts
@@ -8,6 +8,7 @@ export type CacheSetting =
   | false;
 
 export type Context7Fetch = (input: string | URL, init?: RequestInit) => Promise<Response>;
+export type AuthTokenProvider = () => string | Promise<string>;
 
 export type RateLimitMetadata = {
   /** Maximum requests allowed in the current rate-limit window. */
@@ -85,6 +86,7 @@ export type RequesterConfig = {
 
 export type HttpClientConfig = {
   headers?: Record<string, string>;
+  authToken?: string | AuthTokenProvider;
   baseUrl: string;
   signal?: AbortSignal | (() => AbortSignal);
   timeout?: number | false;


### PR DESCRIPTION
## Summary

- add an SDK `authToken` value/provider alongside API-key authentication
- resolve async token providers once per Context7 request so short-lived Marketplace credentials are refreshed instead of cached for the client lifetime
- validate Vercel Marketplace tokens at the MCP edge using the configured integration issuer JWKS, exact product audience, RS256, `nbf`/`exp`, and immutable `resource` claim
- document per-resource bearer-token use without depending on the not-yet-released Vercel token-minting API signature

## Compatibility

- explicit credentials take precedence as `apiKey`, `authToken`, then `CONTEXT7_API_KEY`, allowing Vercel's Phase 1 dual-auth rollout to exercise OIDC while the legacy secret remains
- custom `Authorization` headers remain protected from override
- no production data or credentials are changed

## Verification

- SDK: 40 tests (including a legacy environment key), typecheck, ESLint, and tsup build
- MCP Marketplace auth: 17 tests, typecheck, ESLint, and TypeScript build
- `git diff --check`

## Rollout dependency

The final Vercel Marketplace token-minting API is not yet available. The SDK accepts its short-lived bearer tokens through a stable provider callback; the README can be updated to the final Vercel helper signature once Vercel publishes it.

Linear: https://linear.app/upstash/issue/CTX7-2692/oidc-support
