### PR TITLE
fix(pi): preserve requested coverage within Context7 call budget

### DIFF
--- a/packages/pi/skills/context7-docs/SKILL.md
+++ b/packages/pi/skills/context7-docs/SKILL.md
@@ -40,6 +40,6 @@ If the user supplies a library ID in `/org/project` or `/org/project/version` fo
 
 ## Constraints
 
-- Do not call either tool more than 3 times per question.
+- Do not call either tool more than 3 times per question. This limits Context7 calls, not requested coverage: use other authorized sources for remaining concepts, or identify the unresolved coverage without claiming completion.
 - Do not pass API keys, passwords, credentials, personal data, or proprietary code as the `query` argument — it is sent to the Context7 API.
 - Authentication uses the `CONTEXT7_API_KEY` environment variable. Get a key at https://context7.com/dashboard if requests fail with an auth error.


### PR DESCRIPTION
The packaged Pi skill says "Do not call either tool more than 3 times per question." For a multi-concept question, that cap can silently drop explicitly requested coverage: the skill also requires one query-docs call per distinct concept, so four concepts cannot all be covered within three calls. This keeps the call budget but clarifies that it limits Context7 calls, not requested coverage — use other authorized sources for remaining concepts, or state the unresolved coverage instead of claiming completion. Verified: the only behavioral change is one sentence in the skill guidance; no runtime code touched.