### PR TITLE
fix(mcp): surface API error field when message is missing

### DIFF
--- a/packages/mcp/src/lib/api.ts
+++ b/packages/mcp/src/lib/api.ts
@@ -22,9 +22,12 @@ const API_TIMEOUT_MS = 60_000;
  */
 async function parseErrorResponse(response: Response, apiKey?: string): Promise<string> {
   try {
-    const json = (await response.json()) as { message?: string };
+    const json = (await response.json()) as { message?: string; error?: string };
     if (json.message) {
       return json.message;
+    }
+    if (json.error) {
+      return json.error;
     }
   } catch {
     // JSON parsing failed, fall through to default

--- a/packages/pi/lib/api.ts
+++ b/packages/pi/lib/api.ts
@@ -14,8 +14,9 @@ function authHeaders(): Record<string, string> {
 
 async function parseErrorResponse(response: Response): Promise<string> {
   try {
-    const json = (await response.json()) as { message?: string };
+    const json = (await response.json()) as { message?: string; error?: string };
     if (json.message) return json.message;
+    if (json.error) return json.error;
   } catch {
     // JSON parsing failed, fall through to status-based message
   }


### PR DESCRIPTION
﻿SDK already uses message || error. MCP/pi only read message, so bodies like {"error":"..."} became a generic status string.
