### PR TITLE
docs: add FLUJO manual client setup

### DIFF
--- a/docs/resources/all-clients.mdx
+++ b/docs/resources/all-clients.mdx
@@ -1382,6 +1382,19 @@ Install the [context7.mcpb](https://github.com/upstash/context7/tree/master/pack
 
 </Accordion>
 
+<Accordion title="FLUJO">
+
+[FLUJO](https://github.com/mario-andreschak/FLUJO) connects to Context7 through its remote-server setup.
+
+1. Open **Connected Apps** and select **Connect App** → **I have connection details** → **At a remote URL**.
+2. Enter `https://mcp.context7.com/mcp` as the **Server URL** and click **Connect**.
+3. Select **Continue to setup** if prompted. In **Configure & Test**, confirm that **Streamable HTTP** is selected.
+4. To use a Context7 API key, add an `Authorization` header under **Custom HTTP headers** with the value `Bearer YOUR_API_KEY`. Select **Secret** to mask the value. Leave the optional OAuth client credentials blank for this endpoint.
+5. Run **3) Test run** if the connection test has not started automatically. After the test passes, click **Update server** to save.
+6. Open the connected server's **Tools** tab. Select `resolve-library-id`, provide a library name and a documentation query, and click **Test tool**. Use a returned library ID with `query-docs` to retrieve documentation.
+
+</Accordion>
+
 <Accordion title="AnythingLLM">
 
 AnythingLLM supports MCP Servers through GUI. 


### PR DESCRIPTION
FLUJO users currently have no configuration example in the MCP Clients page. This adds a manual Streamable HTTP setup using the current Connected Apps wizard, the API-key header fields, and the built-in tool tester.

Validated with a fresh FLUJO 3.45.2 installation and browser profile on an isolated Debian cloud machine: MCP handshake and two-tool discovery passed, the connection saved, `resolve-library-id` returned React matches, and `query-docs` returned documentation for `/reactjs/react.dev`. Those UI tests used the anonymous endpoint; API-key/OAuth authentication was not tested.

[Validation details and screenshots](https://github.com/flujo-app/flujo-mcp-client-validation#context7--2026-09-07).

Checks: Prettier 3.6.2 and `git diff --check` pass. The change adds one 13-line accordion. No CLI installer adapter is added.

Prepared with Codex assistance.

