### PR TITLE
Add Cloud Agent dev environment config

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,17 @@
+{
+  "name": "Context7 monorepo",
+  "install": "pnpm install --frozen-lockfile && pnpm build",
+  "terminals": [
+    {
+      "name": "mcp-http-server",
+      "command": "node packages/mcp/dist/index.js --transport http --port 3000",
+      "description": "Context7 MCP server (HTTP transport) on port 3000. Health check: GET http://localhost:3000/ping"
+    }
+  ],
+  "ports": [
+    {
+      "name": "mcp-http",
+      "port": 3000
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -172,6 +172,9 @@ dist
 .idea
 
 .cursor
+!.cursor/
+.cursor/*
+!.cursor/environment.json
 !plugins/cursor/context7/.cursor
 .opencode
 .claude


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cursor Cloud Agent development environment for the Context7 monorepo by adding `.cursor/environment.json`.

The default Cursor image already provides Node 22 and pnpm 10, so no custom Dockerfile is needed. The config:

- `install`: `pnpm install --frozen-lockfile && pnpm build` — installs workspace dependencies and builds all packages (`sdk`, `mcp`, `cli`, `opencode`, `pi`, `tools-ai-sdk`).
- `terminals`: runs the Context7 MCP server over HTTP on port `3000` (`node packages/mcp/dist/index.js --transport http --port 3000`) so it's available and inspectable when an agent starts.
- `ports`: exposes port `3000`.

Also adds a targeted `.gitignore` exception so `.cursor/environment.json` is tracked while the rest of `.cursor` stays ignored.

## Verification

Ran end-to-end in the environment:

- `pnpm install --frozen-lockfile` — success (Node v22.14.0, pnpm 10.33.3)
- `pnpm build` — all 6 packages built
- `pnpm typecheck` — clean
- `pnpm lint:check` — clean
- `pnpm test` — 447 tests pass (368 CLI, 74 MCP, 4 pi, 11 tools-ai-sdk unit). The 5 failing `tools-ai-sdk` tests are integration tests that call a live AWS Bedrock model and require `AWS_REGION` + AWS credentials; they are unrelated to environment setup.
- MCP server: `GET /ping` returns `{"status":"ok","message":"pong"}` and the `initialize` handshake returns `serverInfo` for Context7 v4.0.6.
- CLI: `ctx7 --version` → `0.5.11`, help/commands render correctly.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2f2e6888-d83a-4f3d-bb58-3bc6bcd45b21?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2f2e6888-d83a-4f3d-bb58-3bc6bcd45b21&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

