### PR TITLE
fix(mcp): allow empty Claude plugin API key

### DIFF
--- a/.changeset/tidy-dogs-connect.md
+++ b/.changeset/tidy-dogs-connect.md
@@ -1,0 +1,5 @@
+---
+"@upstash/context7-mcp": patch
+---
+
+Allow the Claude Code plugin to use anonymous access when its API key header is empty.

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -37,7 +37,12 @@ function getPluginFromRequest(req: express.Request): typeof CLAUDE_CODE_PLUGIN |
 
 function requiresAuthentication(req: express.Request, plugin?: typeof CLAUDE_CODE_PLUGIN): boolean {
   // The MCP routes live on a router mounted at /mcp, so req.path is relative to it.
-  return `${req.baseUrl}${req.path}` === "/mcp/oauth" || Boolean(plugin);
+  const isOAuthEndpoint = `${req.baseUrl}${req.path}` === "/mcp/oauth";
+  // The current official Claude plugin expands an unset API key to an empty header.
+  const hasEmptyPluginAuthorization =
+    plugin === CLAUDE_CODE_PLUGIN && req.headers.authorization === "";
+
+  return isOAuthEndpoint || (Boolean(plugin) && !hasEmptyPluginAuthorization);
 }
 
 // Parse CLI arguments using commander

--- a/packages/mcp/test/integration.test.ts
+++ b/packages/mcp/test/integration.test.ts
@@ -455,10 +455,22 @@ describe("plugin authentication", () => {
     expect(res.wwwAuthenticate).toContain("/.well-known/oauth-protected-resource");
   });
 
-  test("keeps the OAuth endpoint protected", async () => {
-    const res = await postMcp(httpUrl.replace(/\/mcp$/, "/mcp/oauth"));
+  test("allows the Claude Code plugin's empty API key fallback", async () => {
+    const res = await postMcp(`${httpUrl}?client=claude-code-plugin`, {
+      Authorization: "",
+    });
 
-    expect(res.status).toBe(401);
+    expect(res.status).toBe(200);
+  });
+
+  test("keeps the OAuth endpoint protected", async () => {
+    const oauthUrl = httpUrl.replace(/\/mcp$/, "/mcp/oauth");
+    const emptyHeaderRes = await postMcp(`${oauthUrl}?client=claude-code-plugin`, {
+      Authorization: "",
+    });
+
+    expect((await postMcp(oauthUrl)).status).toBe(401);
+    expect(emptyHeaderRes.status).toBe(401);
   });
 
   test("tracks authenticated plugin requests separately", async () => {


### PR DESCRIPTION
## Summary

- allow the Claude Code plugin's explicitly empty Authorization header through anonymously
- keep requests without that header and `/mcp/oauth` protected

This keeps the current official plugin usable until its OAuth configuration is updated.

## Validation

- `pnpm --filter @upstash/context7-mcp test`
- `pnpm --filter @upstash/context7-mcp typecheck`
- `pnpm --filter @upstash/context7-mcp lint`
- `pnpm changeset status`
- Claude Code 2.1.266 reports `Connected` with the current official plugin configuration