### PR TITLE
fix(pnpm): classify ignored dependency builds

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,9 @@ packages:
   - "packages/*"
 
 allowBuilds:
+  "@google/genai": false
   esbuild: true
+  msgpackr-extract: false
+  protobufjs: false
 
 minimumReleaseAge: 10080


### PR DESCRIPTION
## Summary

Explicitly deny build scripts that were already skipped by pnpm 11. This prevents pnpm 12 from failing Docker installs with `ERR_PNPM_IGNORED_BUILDS`.

## Test

- `npx --yes pnpm@12.3.4 install --frozen-lockfile`