### PR TITLE
docs: enable page feedback controls

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -4,6 +4,11 @@
   "name": "Context7 MCP",
   "description": "Up-to-date code docs for any prompt.",
   "poweredByDocs7": true,
+  "feedback": {
+    "thumbsRating": true,
+    "suggestEdit": true,
+    "raiseIssue": true
+  },
   "redirects": [
     {
       "source": "/enterprise/azure-apim",


### PR DESCRIPTION
Enable Yes/No page ratings, Suggest edits, and Raise issue in the Context7 docs. Set the three existing feedback options to true in `docs/docs.json`.

Validation passed:
- Full configuration validation with the Docs7 renderer.
- Feedback link checks for the `docs` directory and `master` branch.
- All five existing page feedback tests.
- `git diff --check`.
