### PR TITLE
fix(cursor-plugin): point the rule and README at the skill that ships

### DIFF
--- a/packages/cli/src/__tests__/plugin-manifests.test.ts
+++ b/packages/cli/src/__tests__/plugin-manifests.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "vitest";
-import { readFile } from "fs/promises";
+import { access, readdir, readFile } from "fs/promises";
 import { join } from "path";
 import { execFile } from "child_process";
 import { promisify } from "util";
@@ -39,5 +39,30 @@ describe("plugin MCP manifests", () => {
     expect(config.mcpServers.context7.headers).toEqual({
       Authorization: "${CONTEXT7_API_KEY:-}",
     });
+  });
+
+  test("Cursor plugin names a skill it actually ships", async () => {
+    const relPath = "plugins/cursor/context7/rules/use-context7.mdc";
+    const rule = await readFile(join(REPO_ROOT, relPath), "utf-8");
+    const readme = await readFile(join(REPO_ROOT, "plugins/cursor/context7/README.md"), "utf-8");
+    const shipped = (await readdir(join(REPO_ROOT, "plugins/cursor/context7/skills"))).sort();
+
+    // Both files point the reader at a skill by name; a rename that misses one
+    // of them leaves a dangling reference the agent cannot resolve.
+    for (const [file, content] of [
+      [relPath, rule],
+      ["plugins/cursor/context7/README.md", readme],
+    ] as const) {
+      const reference = content.match(/`(context7-[a-z0-9-]+)` skill/)?.[1];
+      expect(reference, `${file} should reference a skill by name`).toBeDefined();
+      expect(shipped, `${file} references "${reference}"`).toContain(reference);
+    }
+  });
+
+  test("Cursor plugin's skill directories all contain a SKILL.md", async () => {
+    const dir = join(REPO_ROOT, "plugins/cursor/context7/skills");
+    for (const entry of await readdir(dir)) {
+      await expect(access(join(dir, entry, "SKILL.md"))).resolves.toBeUndefined();
+    }
   });
 });

--- a/plugins/cursor/context7/README.md
+++ b/plugins/cursor/context7/README.md
@@ -8,7 +8,7 @@ This plugin provides:
 
 - **MCP Server** — Connects Cursor to Context7's documentation service
 - **Rules** — An always-on `use-context7` rule that nudges the agent to fetch docs when unsure about library APIs
-- **Skills** — A `context7-docs-lookup` skill with detailed instructions on resolving libraries and fetching documentation
+- **Skills** — A `context7-mcp` skill with detailed instructions on resolving libraries and fetching documentation
 - **Agents** — A dedicated `docs-researcher` agent for focused lookups
 
 ## Available Tools

--- a/plugins/cursor/context7/rules/use-context7.mdc
+++ b/plugins/cursor/context7/rules/use-context7.mdc
@@ -15,4 +15,4 @@ You don't need to use Context7 for:
 - Well-established language features (e.g., JavaScript array methods, Python builtins)
 - Conversations where the user has already provided the relevant code or docs
 
-See the `context7-docs-lookup` skill for detailed instructions on how to resolve libraries and fetch documentation.
+See the `context7-mcp` skill for detailed instructions on how to resolve libraries and fetch documentation.


### PR DESCRIPTION
## Summary

The Cursor plugin's always-on rule and its README both point the reader at a skill named `context7-docs-lookup`. That skill does not exist in the plugin.

`context7-docs-lookup` was the original skill name when the plugin was added (#1659). #2191 consolidated the plugin skills under a canonical `context7-mcp` source and the directory was renamed — `plugins/cursor/context7/skills/context7-mcp/SKILL.md`. The rename updated the directory but not these two prose references, so both now name a skill the plugin does not ship.

Concretely, the rule ends with:

> See the `context7-docs-lookup` skill for detailed instructions on how to resolve libraries and fetch documentation.

and `README.md` lists:

> **Skills** — A `context7-docs-lookup` skill with detailed instructions on resolving libraries and fetching documentation

The rule is `alwaysApply: true`, so the pointer is in context on every request and an agent that follows it looks for a skill that is absent. The only shipped skill is `context7-mcp`; every other plugin in this repo already refers to it by that name.

## Change

- `plugins/cursor/context7/rules/use-context7.mdc` and `plugins/cursor/context7/README.md` now reference `context7-mcp`.
- `packages/cli/src/__tests__/plugin-manifests.test.ts` gains a test pinning the invariant: the skill name mentioned in each file must exist as a directory under `plugins/cursor/context7/skills/`, and every shipped skill directory must contain a `SKILL.md`. The existing file already reads `plugins/` from the repo root, so it is the natural home; the name this repo keeps in prose is now checked against the name it ships.

## Verification

The new test fails on the unfixed tree and passes after the fix. Both directions were exercised by reverting each reference and each shipped skill directory in turn:

| Mutation | Result |
| --- | --- |
| Revert the rule line only | FAIL — `use-context7.mdc references "context7-docs-lookup": expected [ 'context7-mcp' ] to include 'context7-docs-lookup'` |
| Revert the README line only | FAIL — `README.md references "context7-docs-lookup": ...` |
| Rename the shipped skill dir | FAIL — `use-context7.mdc references "context7-mcp": expected [ 'renamed-skill' ] to include 'context7-mcp'` |

The first two confirm the assertion detects the regression this PR fixes; the third confirms it is not a rubber stamp — it reads the shipped directory rather than a hardcoded string.

Repo checks on the final commit:

- `pnpm lint:check` — clean
- `pnpm format:check` — clean
- `pnpm typecheck` — clean
- `pnpm --filter ./packages/cli test` — 19 files, 370 tests passed (368 on `master`; the 2 added here)

`grep -rn "context7-docs-lookup"` over the tree now returns nothing.

No changeset: this touches no published package code, matching how the other plugin-only fixes in this repo (#2752) landed.
