### PR TITLE
CTX7-2712: Add single Search API MCP mode

### DIFF
--- a/.changeset/context7-search-api.md
+++ b/.changeset/context7-search-api.md
@@ -1,0 +1,11 @@
+---
+"@upstash/context7-mcp": minor
+---
+
+Add the experimental Context7 Search API tool mode. `--tool-mode single` (or
+`CONTEXT7_MCP_TOOL_MODE=single`) exposes one natural-language `query-docs` tool
+that selects and retrieves documentation in one bounded backend request.
+Optional fuzzy library, exact library ID, and version hints improve explicit
+requests without adding another tool call. Retry metadata prevents repeated
+calls for terminal misses while preserving retry behavior for transient
+failures. The existing two-tool flow remains the default.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1444,6 +1444,7 @@ bun run dist/index.js
 - `--transport <stdio|http>` – Transport to use (`stdio` by default). Use `http` for remote HTTP server or `stdio` for local integration.
 - `--port <number>` – Port to listen on when using `http` transport (default `3000`).
 - `--api-key <key>` – API key for authentication (or set `CONTEXT7_API_KEY` env var). You can get your API key by creating an account at [context7.com/dashboard](https://context7.com/dashboard).
+- `--tool-mode <two-step|single>` – Tool surface to expose (`two-step` by default). The experimental `single` mode uses the Context7 Search API to select and retrieve documentation in one request. It can also be set with `CONTEXT7_MCP_TOOL_MODE`.
 
 Example with HTTP transport and port 8080:
 
@@ -1456,6 +1457,14 @@ Another example with stdio transport:
 ```bash
 bun run dist/index.js --transport stdio --api-key YOUR_API_KEY
 ```
+
+Experimental one-call Search API mode:
+
+```bash
+bun run dist/index.js --transport stdio --tool-mode single --api-key YOUR_API_KEY
+```
+
+In single mode, keep language and framework details in `query`. Use `library` for a fuzzy package, repository, or documentation-domain name; it does not need to be exact. Use `libraryId` only when the exact Context7 ID is already known. A `version` must be paired with one of those hints. Terminal misses tell the agent to refine the query or check the hint, while transient failures explicitly permit retrying the same request.
 
 ### Environment Variables
 

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -248,9 +248,7 @@ Call this tool exactly once per user question. This still means one invocation w
                 ),
               libraryIds: z
                 .array(
-                  z
-                    .string()
-                    .regex(/^\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+(?:[\/@][A-Za-z0-9_.-]+)?$/)
+                  z.string().regex(/^\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+(?:[\/@][A-Za-z0-9_.-]+)?$/)
                 )
                 .min(1)
                 .max(4)
@@ -263,19 +261,28 @@ Call this tool exactly once per user question. This still means one invocation w
                 .regex(/^v?\d+(?:[._]\d+){0,2}(?:[-+][a-z0-9.-]+)?$/i)
                 .optional()
                 .describe(
-                  "Optional library version supplied by the user. Requires one library or libraryId hint."
+                  "Optional version supplied by the user. It may accompany one or more fuzzy library names, but at most one exact libraryId. For fuzzy names it is retrieval context, so include the complete version-qualified product wording in query."
                 ),
             })
             .superRefine((value, context) => {
               const fuzzyHintCount = value.libraries?.length ?? 0;
               const exactHintCount = value.libraryIds?.length ?? 0;
               if (fuzzyHintCount > 0 && exactHintCount > 0) {
-                context.addIssue({ code: "custom", message: "Use library names or library IDs, not both" });
-              }
-              if (value.version && fuzzyHintCount + exactHintCount !== 1) {
                 context.addIssue({
                   code: "custom",
-                  message: "Version requires exactly one library or libraryId hint",
+                  message: "Use library names or library IDs, not both",
+                });
+              }
+              if (value.version && fuzzyHintCount + exactHintCount === 0) {
+                context.addIssue({
+                  code: "custom",
+                  message: "Version requires a library or libraryId hint",
+                });
+              }
+              if (value.version && exactHintCount > 1) {
+                context.addIssue({
+                  code: "custom",
+                  message: "Version can accompany at most one exact libraryId",
                 });
               }
             })

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -177,6 +177,21 @@ function aliasArgs(aliases: AliasMap) {
   };
 }
 
+function normalizeAutoQueryArgs(value: unknown) {
+  const aliased = aliasArgs(AUTO_QUERY_ALIASES)(value);
+  if (!aliased || typeof aliased !== "object") return aliased;
+  const args: Record<string, unknown> = { ...aliased };
+  if (typeof args.library === "string" && !("libraries" in args)) {
+    args.libraries = [args.library];
+  }
+  if (typeof args.libraryId === "string" && !("libraryIds" in args)) {
+    args.libraryIds = [args.libraryId];
+  }
+  delete args.library;
+  delete args.libraryId;
+  return args;
+}
+
 function createMcpServer() {
   const server = new McpServer(
     {
@@ -213,30 +228,35 @@ Do not use for: refactoring, writing scripts from scratch, debugging business lo
 
 Context7 selects up to four relevant documentation libraries, searches their namespaces in parallel, deduplicates the evidence, and reranks the combined snippets. Explicit Context7 IDs are used directly within the response safety cap.
 
-Call this tool exactly once per user question. Put the complete question in query, including product names, versions, languages, and all concepts needed to answer. Optional library and version fields are routing hints only: pass them when the user supplied that information, but do not guess a Context7 library ID. Use the returned context to answer without calling this tool again.`,
+Call this tool exactly once per user question. This still means one invocation when the question compares, integrates, or migrates between multiple libraries: keep every named product in the single complete query and, when useful, put the user-supplied names in libraries. Never split one user question into parallel or sequential query-docs calls. Put the complete question in query, including product names, versions, languages, and all concepts needed to answer. Optional library/libraries and version fields are routing hints only; do not guess a Context7 library ID. Use the returned context to answer without calling this tool again.`,
         inputSchema: z.preprocess(
-          aliasArgs(AUTO_QUERY_ALIASES),
+          normalizeAutoQueryArgs,
           z
             .object({
               query: z
                 .string()
                 .describe(
-                  "The user's complete implementation question, including the exact library or product name, version, language, and all requested concepts. Do not shorten or split it. Do not include secrets, personal data, or proprietary code."
+                  "The user's complete implementation question, including every named library or product, version, language, and all requested concepts. For comparisons, integrations, and migrations, put all products here and make one tool call. Do not shorten or split it. Do not include secrets, personal data, or proprietary code."
                 ),
-              library: z
-                .string()
+              libraries: z
+                .array(z.string().min(1).max(120))
                 .min(1)
-                .max(120)
+                .max(4)
                 .optional()
                 .describe(
-                  "Optional fuzzy package, product, repository, or documentation-domain hint supplied by the user. The name does not need to be exact."
+                  "Optional fuzzy product names supplied by the user for a comparison, integration, or migration. Keep the complete multi-product question in query and make only one tool call."
                 ),
-              libraryId: z
-                .string()
-                .regex(/^\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+(?:[\/@][A-Za-z0-9_.-]+)?$/)
+              libraryIds: z
+                .array(
+                  z
+                    .string()
+                    .regex(/^\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+(?:[\/@][A-Za-z0-9_.-]+)?$/)
+                )
+                .min(1)
+                .max(4)
                 .optional()
                 .describe(
-                  "Optional exact Context7 library ID supplied by the user or a trusted source. Never guess this value."
+                  "Optional exact Context7 IDs supplied by the user or trusted sources for one multi-library question. Never guess these values."
                 ),
               version: z
                 .string()
@@ -247,13 +267,15 @@ Call this tool exactly once per user question. Put the complete question in quer
                 ),
             })
             .superRefine((value, context) => {
-              if (value.library && value.libraryId) {
-                context.addIssue({ code: "custom", message: "Use library or libraryId, not both" });
+              const fuzzyHintCount = value.libraries?.length ?? 0;
+              const exactHintCount = value.libraryIds?.length ?? 0;
+              if (fuzzyHintCount > 0 && exactHintCount > 0) {
+                context.addIssue({ code: "custom", message: "Use library names or library IDs, not both" });
               }
-              if (value.version && !value.library && !value.libraryId) {
+              if (value.version && fuzzyHintCount + exactHintCount !== 1) {
                 context.addIssue({
                   code: "custom",
-                  message: "Version requires a library or libraryId hint",
+                  message: "Version requires exactly one library or libraryId hint",
                 });
               }
             })
@@ -268,16 +290,21 @@ Call this tool exactly once per user question. Put the complete question in quer
       async (
         {
           query,
-          library,
-          libraryId,
+          libraries,
+          libraryIds,
           version,
-        }: { query: string; library?: string; libraryId?: string; version?: string },
+        }: {
+          query: string;
+          libraries?: string[];
+          libraryIds?: string[];
+          version?: string;
+        },
         toolCtx
       ) => {
         const ctx = getClientContext(toolCtx);
         const response = await fetchAutoLibraryContext(query, ctx, {
-          library,
-          libraryId,
+          libraries,
+          libraryIds,
           version,
         });
         maybeElicitAuthSignIn(server, ctx);

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -4,7 +4,7 @@ import { toNodeHandler } from "@modelcontextprotocol/node";
 import { serveStdio } from "@modelcontextprotocol/server/stdio";
 import { McpServer, createMcpHandler, type ServerContext } from "@modelcontextprotocol/server";
 import { z } from "zod";
-import { searchLibraries, fetchLibraryContext } from "./lib/api.js";
+import { searchLibraries, fetchLibraryContext, fetchAutoLibraryContext } from "./lib/api.js";
 import type { ClientContext } from "./lib/types.js";
 import {
   formatSearchResults,
@@ -46,6 +46,11 @@ const program = new Command()
   .option("--transport <stdio|http>", "transport type", "stdio")
   .option("--port <number>", "port for HTTP transport", DEFAULT_PORT.toString())
   .option("--api-key <key>", "API key for authentication (or set CONTEXT7_API_KEY env var)")
+  .option(
+    "--tool-mode <two-step|single>",
+    "MCP tool surface (experimental)",
+    process.env.CONTEXT7_MCP_TOOL_MODE || "two-step"
+  )
   .allowUnknownOption() // let MCP Inspector / other wrappers pass through extra flags
   .parse(process.argv);
 
@@ -53,6 +58,7 @@ const cliOptions = program.opts<{
   transport: string;
   port: string;
   apiKey?: string;
+  toolMode: string;
 }>();
 
 // Validate transport option
@@ -66,6 +72,15 @@ if (!allowedTransports.includes(cliOptions.transport)) {
 
 // Transport configuration
 const TRANSPORT_TYPE = (cliOptions.transport || "stdio") as "stdio" | "http";
+
+const allowedToolModes = ["two-step", "single"] as const;
+if (!allowedToolModes.includes(cliOptions.toolMode as (typeof allowedToolModes)[number])) {
+  console.error(
+    `Invalid --tool-mode value: '${cliOptions.toolMode}'. Must be one of: ${allowedToolModes.join(", ")}`
+  );
+  process.exit(1);
+}
+const TOOL_MODE = cliOptions.toolMode as (typeof allowedToolModes)[number];
 
 // Disallow incompatible flags based on transport
 const passedPortFlag = process.argv.includes("--port");
@@ -127,6 +142,12 @@ const GLOBAL_ALIASES: AliasMap = {
   query: ["userQuery", "question"],
 };
 
+const AUTO_QUERY_ALIASES: AliasMap = {
+  ...GLOBAL_ALIASES,
+  library: ["libraryName", "repository", "domain"],
+  libraryId: ["context7CompatibleLibraryID", "libraryID"],
+};
+
 // Tool-scoped aliases, for keys that are canonical on one tool but a
 // hallucination on another (e.g. `libraryName` is canonical for
 // `resolve-library-id`, so we only rewrite it on `query-docs` calls).
@@ -182,6 +203,110 @@ function createMcpServer() {
 Do not use for: refactoring, writing scripts from scratch, debugging business logic, code review, or general programming concepts.`,
     }
   );
+
+  if (TOOL_MODE === "single") {
+    server.registerTool(
+      "query-docs",
+      {
+        title: "Query Documentation",
+        description: `Retrieves up-to-date documentation and code examples for a natural-language implementation question in one call.
+
+Context7 selects up to four relevant documentation libraries, searches their namespaces in parallel, deduplicates the evidence, and reranks the combined snippets. Explicit Context7 IDs are used directly within the response safety cap.
+
+Call this tool exactly once per user question. Put the complete question in query, including product names, versions, languages, and all concepts needed to answer. Optional library and version fields are routing hints only: pass them when the user supplied that information, but do not guess a Context7 library ID. Use the returned context to answer without calling this tool again.`,
+        inputSchema: z.preprocess(
+          aliasArgs(AUTO_QUERY_ALIASES),
+          z
+            .object({
+              query: z
+                .string()
+                .describe(
+                  "The user's complete implementation question, including the exact library or product name, version, language, and all requested concepts. Do not shorten or split it. Do not include secrets, personal data, or proprietary code."
+                ),
+              library: z
+                .string()
+                .min(1)
+                .max(120)
+                .optional()
+                .describe(
+                  "Optional fuzzy package, product, repository, or documentation-domain hint supplied by the user. The name does not need to be exact."
+                ),
+              libraryId: z
+                .string()
+                .regex(/^\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+(?:[\/@][A-Za-z0-9_.-]+)?$/)
+                .optional()
+                .describe(
+                  "Optional exact Context7 library ID supplied by the user or a trusted source. Never guess this value."
+                ),
+              version: z
+                .string()
+                .regex(/^v?\d+(?:[._]\d+){0,2}(?:[-+][a-z0-9.-]+)?$/i)
+                .optional()
+                .describe(
+                  "Optional library version supplied by the user. Requires one library or libraryId hint."
+                ),
+            })
+            .superRefine((value, context) => {
+              if (value.library && value.libraryId) {
+                context.addIssue({ code: "custom", message: "Use library or libraryId, not both" });
+              }
+              if (value.version && !value.library && !value.libraryId) {
+                context.addIssue({
+                  code: "custom",
+                  message: "Version requires a library or libraryId hint",
+                });
+              }
+            })
+        ),
+        annotations: {
+          readOnlyHint: true,
+          destructiveHint: false,
+          openWorldHint: true,
+          idempotentHint: true,
+        },
+      },
+      async (
+        {
+          query,
+          library,
+          libraryId,
+          version,
+        }: { query: string; library?: string; libraryId?: string; version?: string },
+        toolCtx
+      ) => {
+        const ctx = getClientContext(toolCtx);
+        const response = await fetchAutoLibraryContext(query, ctx, {
+          library,
+          libraryId,
+          version,
+        });
+        maybeElicitAuthSignIn(server, ctx);
+        const selectedLibraries = response.libraryIds?.length
+          ? `Selected ${response.libraryIds.length === 1 ? "library" : "libraries"}: ${response.libraryIds.join(", ")}\n\n`
+          : "";
+        const retryGuidance = response.error
+          ? response.retryable
+            ? "\n\nThis was a transient search failure. Retry the same request later."
+            : `\n\nDo not repeat the identical request. ${
+                response.retryReason === "no-relevant-documentation"
+                  ? "Refine the question or add a library hint."
+                  : "Check the library or version hint."
+              }`
+          : "";
+        return {
+          isError: response.retryable === true,
+          content: [
+            {
+              type: "text",
+              text: `${selectedLibraries}${response.data}${retryGuidance}`,
+            },
+          ],
+        };
+      }
+    );
+
+    return server;
+  }
 
   server.registerTool(
     "resolve-library-id",

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -228,7 +228,7 @@ Do not use for: refactoring, writing scripts from scratch, debugging business lo
 
 Context7 selects up to four relevant documentation libraries, searches their namespaces in parallel, deduplicates the evidence, and reranks the combined snippets. Explicit Context7 IDs are used directly within the response safety cap.
 
-Make one initial call per user question. For comparisons, integrations, and migrations, keep every named product in that one complete query and, when useful, put the user-supplied names in libraries; never fan one question out into parallel query-docs calls. Put the complete question in query, including product names, versions, languages, and all concepts needed to answer. Optional library/libraries and version fields are routing hints only; do not guess a Context7 library ID.
+Make one initial call per user question. For comparisons, integrations, and migrations, keep every named product in that one complete query and put every user-supplied product name in libraries; omitting one product is incorrect. Never fan one question out into parallel query-docs calls. Put the complete question in query, including product names, versions, languages, and all concepts needed to answer. Optional library/libraries and version fields are routing hints only; do not guess a Context7 library ID.
 
 Retry policy: when a failure explicitly says it is transient/retryable, retry the same request at most once later. For a non-retryable documentation miss, never repeat the identical request. Make at most one refined call only when you can add genuinely new routing information from the user, such as an explicit library name, Context7 ID, version, or a materially more specific question. Do not retry a successful response.`,
         inputSchema: z.preprocess(
@@ -238,7 +238,7 @@ Retry policy: when a failure explicitly says it is transient/retryable, retry th
               query: z
                 .string()
                 .describe(
-                  "The user's complete implementation question, including every named library or product, version, language, and all requested concepts. For comparisons, integrations, and migrations, put all products here and make one tool call. Do not shorten or split it. Do not include secrets, personal data, or proprietary code."
+                  "The user's complete implementation question, including every named library or product, version, language, and all requested concepts. For comparisons, integrations, and migrations, every product must remain here and in libraries; omitting one is incorrect. Make one tool call. Do not shorten or split it. Do not include secrets, personal data, or proprietary code."
                 ),
               libraries: z
                 .array(z.string().min(1).max(120))
@@ -246,7 +246,7 @@ Retry policy: when a failure explicitly says it is transient/retryable, retry th
                 .max(4)
                 .optional()
                 .describe(
-                  "Optional fuzzy product names supplied by the user for a comparison, integration, or migration. Keep the complete multi-product question in query and make only one tool call."
+                  "Fuzzy product names supplied by the user. When the question names two or more products for a comparison, integration, or migration, include every named product here and keep all of them in query. Make only one tool call."
                 ),
               libraryIds: z
                 .array(

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -228,7 +228,9 @@ Do not use for: refactoring, writing scripts from scratch, debugging business lo
 
 Context7 selects up to four relevant documentation libraries, searches their namespaces in parallel, deduplicates the evidence, and reranks the combined snippets. Explicit Context7 IDs are used directly within the response safety cap.
 
-Call this tool exactly once per user question. This still means one invocation when the question compares, integrates, or migrates between multiple libraries: keep every named product in the single complete query and, when useful, put the user-supplied names in libraries. Never split one user question into parallel or sequential query-docs calls. Put the complete question in query, including product names, versions, languages, and all concepts needed to answer. Optional library/libraries and version fields are routing hints only; do not guess a Context7 library ID. Use the returned context to answer without calling this tool again.`,
+Make one initial call per user question. For comparisons, integrations, and migrations, keep every named product in that one complete query and, when useful, put the user-supplied names in libraries; never fan one question out into parallel query-docs calls. Put the complete question in query, including product names, versions, languages, and all concepts needed to answer. Optional library/libraries and version fields are routing hints only; do not guess a Context7 library ID.
+
+Retry policy: when a failure explicitly says it is transient/retryable, retry the same request at most once later. For a non-retryable documentation miss, never repeat the identical request. Make at most one refined call only when you can add genuinely new routing information from the user, such as an explicit library name, Context7 ID, version, or a materially more specific question. Do not retry a successful response.`,
         inputSchema: z.preprocess(
           normalizeAutoQueryArgs,
           z

--- a/packages/mcp/src/lib/api.ts
+++ b/packages/mcp/src/lib/api.ts
@@ -220,8 +220,12 @@ export async function fetchAutoLibraryContext(
     const url = new URL(`${CONTEXT7_API_BASE_URL}/v2/context/search`);
     url.searchParams.set("query", query);
     url.searchParams.set("type", "txt");
-    if (options.library) url.searchParams.set("library", options.library);
-    if (options.libraryId) url.searchParams.set("libraryId", options.libraryId);
+    for (const library of options.libraries ?? (options.library ? [options.library] : [])) {
+      url.searchParams.append("library", library);
+    }
+    for (const libraryId of options.libraryIds ?? (options.libraryId ? [options.libraryId] : [])) {
+      url.searchParams.append("libraryId", libraryId);
+    }
     if (options.version) url.searchParams.set("version", options.version);
 
     const response = await fetch(url, {

--- a/packages/mcp/src/lib/api.ts
+++ b/packages/mcp/src/lib/api.ts
@@ -1,4 +1,11 @@
-import { SearchResponse, ContextRequest, ContextResponse, ClientContext } from "./types.js";
+import {
+  SearchResponse,
+  ContextRequest,
+  ContextResponse,
+  AutoContextOptions,
+  AutoContextResponse,
+  ClientContext,
+} from "./types.js";
 import { generateHeaders } from "./encryption.js";
 import { Agent, ProxyAgent, setGlobalDispatcher } from "undici";
 import { CONTEXT7_API_BASE_URL } from "./constants.js";
@@ -12,6 +19,27 @@ import tls from "tls";
  * day of production traffic.
  */
 const API_TIMEOUT_MS = 60_000;
+export const MAX_AUTO_CONTEXT_ROUTES = 6;
+export const MAX_AUTO_CONTEXT_CHARACTERS = 32_000;
+const LIBRARY_ID_PATTERN = /^\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+(?:[\/@][A-Za-z0-9_.-]+)?$/;
+
+export function truncateDocumentationContext(data: string, characterBudget: number): string {
+  if (data.length <= characterBudget) return data;
+  const marker = "\n\n[Context truncated to keep the combined response bounded.]";
+  const target = Math.max(0, characterBudget - marker.length - 5);
+  const candidate = data.slice(0, target);
+  const lastSnippetSeparator = candidate.lastIndexOf("\n\n--------------------------------");
+  const lastLineBreak = candidate.lastIndexOf("\n");
+  const safeEnd =
+    lastSnippetSeparator >= target * 0.2
+      ? lastSnippetSeparator
+      : lastLineBreak >= target * 0.8
+        ? lastLineBreak
+        : target;
+  const prefix = candidate.slice(0, safeEnd).trimEnd();
+  const closesCodeFence = (prefix.match(/```/g)?.length ?? 0) % 2 === 1 ? "\n```" : "";
+  return `${prefix}${closesCodeFence}${marker}`;
+}
 
 /**
  * Parses error response from the Context7 API
@@ -179,5 +207,82 @@ export async function fetchLibraryContext(
     const errorMessage = `Error fetching library context. Please try again later. ${error}`;
     console.error(errorMessage);
     return { data: errorMessage };
+  }
+}
+
+/** Fetches selection and bounded documentation context in one Search API request. */
+export async function fetchAutoLibraryContext(
+  query: string,
+  context: ClientContext = {},
+  options: AutoContextOptions = {}
+): Promise<AutoContextResponse> {
+  try {
+    const url = new URL(`${CONTEXT7_API_BASE_URL}/v2/context/search`);
+    url.searchParams.set("query", query);
+    url.searchParams.set("type", "txt");
+    if (options.library) url.searchParams.set("library", options.library);
+    if (options.libraryId) url.searchParams.set("libraryId", options.libraryId);
+    if (options.version) url.searchParams.set("version", options.version);
+
+    const response = await fetch(url, {
+      headers: generateHeaders(context),
+      signal: AbortSignal.timeout(API_TIMEOUT_MS),
+    });
+    readPromptSignal(response, context);
+    const status = response.headers.get("x-context7-search-status") ?? undefined;
+    const retryHeader = response.headers.get("x-context7-retryable");
+    const retryable = retryHeader
+      ? retryHeader === "true"
+      : response.status === 429 || response.status >= 500;
+    const retryReason = response.headers.get("x-context7-retry-reason") ?? undefined;
+    const suggestedActionHeader = response.headers.get("x-context7-suggested-action");
+    const suggestedAction = suggestedActionHeader
+      ? suggestedActionHeader.replace(/-([a-z])/g, (_, character: string) =>
+          character.toUpperCase()
+        )
+      : undefined;
+    const metadata = {
+      status: status as AutoContextResponse["status"],
+      retryable,
+      retryReason,
+      suggestedAction: suggestedAction as AutoContextResponse["suggestedAction"],
+    };
+
+    if (!response.ok) {
+      const errorMessage = await parseErrorResponse(response, context.apiKey);
+      return { data: errorMessage, error: errorMessage, ...metadata };
+    }
+    const data = await response.text();
+    if (!data.trim()) {
+      return {
+        data: "No relevant documentation was found. Include the exact product or library name and try again.",
+        error: "No relevant documentation was found.",
+        ...metadata,
+        retryable: false,
+        retryReason: "no-relevant-documentation",
+        suggestedAction: "refineQuery",
+      };
+    }
+    const libraryIds = (response.headers.get("x-context7-library-ids") ?? "")
+      .split(",")
+      .map((value) => value.trim())
+      .filter((value, index, all) => LIBRARY_ID_PATTERN.test(value) && all.indexOf(value) === index)
+      .slice(0, MAX_AUTO_CONTEXT_ROUTES);
+    return {
+      data: truncateDocumentationContext(data, MAX_AUTO_CONTEXT_CHARACTERS),
+      libraryIds,
+      ...metadata,
+    };
+  } catch (error) {
+    const errorMessage = `Error searching documentation. Please try again later. ${error}`;
+    console.error(errorMessage);
+    return {
+      data: errorMessage,
+      error: errorMessage,
+      status: "failed",
+      retryable: true,
+      retryReason: "transport-failure",
+      suggestedAction: "retryLater",
+    };
   }
 }

--- a/packages/mcp/src/lib/types.ts
+++ b/packages/mcp/src/lib/types.ts
@@ -32,6 +32,25 @@ export type ContextResponse = {
   data: string;
 };
 
+export type AutoContextOptions = {
+  /** Fuzzy package, product, repository, or documentation-domain hint. */
+  library?: string;
+  /** Exact Context7 ID supplied by the user or another trusted source. */
+  libraryId?: string;
+  /** Version paired with exactly one library or libraryId hint. */
+  version?: string;
+};
+
+export type AutoContextResponse = {
+  data: string;
+  error?: string;
+  libraryIds?: string[];
+  status?: "complete" | "partial" | "not-found" | "failed";
+  retryable?: boolean;
+  retryReason?: string;
+  suggestedAction?: "none" | "retryLater" | "refineQuery" | "checkLibraryOrVersion";
+};
+
 export interface ClientContext {
   clientIp?: string;
   apiKey?: string;

--- a/packages/mcp/src/lib/types.ts
+++ b/packages/mcp/src/lib/types.ts
@@ -35,8 +35,12 @@ export type ContextResponse = {
 export type AutoContextOptions = {
   /** Fuzzy package, product, repository, or documentation-domain hint. */
   library?: string;
+  /** Multiple fuzzy hints for comparison, integration, or migration questions. */
+  libraries?: string[];
   /** Exact Context7 ID supplied by the user or another trusted source. */
   libraryId?: string;
+  /** Multiple exact Context7 IDs supplied by the user or another trusted source. */
+  libraryIds?: string[];
   /** Version paired with exactly one library or libraryId hint. */
   version?: string;
 };

--- a/packages/mcp/test/auto-context.test.ts
+++ b/packages/mcp/test/auto-context.test.ts
@@ -88,6 +88,19 @@ describe("automatic context response controls", () => {
     expect(url.searchParams.has("libraryId")).toBe(false);
   });
 
+  it("forwards multiple library hints in one Search API request", async () => {
+    const fetchMock = vi.fn(async () => new Response("## Documentation"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchAutoLibraryContext("Compare esbuild and Bun bundling commands", {}, {
+      libraries: ["esbuild", "Bun"],
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const url = new URL(String(fetchMock.mock.calls[0]?.[0]));
+    expect(url.searchParams.getAll("library")).toEqual(["esbuild", "Bun"]);
+  });
+
   it("preserves terminal miss metadata so agents do not retry the same call", async () => {
     vi.stubGlobal(
       "fetch",

--- a/packages/mcp/test/auto-context.test.ts
+++ b/packages/mcp/test/auto-context.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  fetchAutoLibraryContext,
+  MAX_AUTO_CONTEXT_CHARACTERS,
+  truncateDocumentationContext,
+} from "../src/lib/api.js";
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("automatic context response controls", () => {
+  it("keeps short context intact and truncates oversized context within budget", () => {
+    expect(truncateDocumentationContext("short", 100)).toBe("short");
+    const output = truncateDocumentationContext(`${"a".repeat(90)}\n${"b".repeat(90)}`, 120);
+    expect(output.length).toBeLessThanOrEqual(120);
+    expect(output).toContain("Context truncated");
+    expect(
+      truncateDocumentationContext(
+        "x".repeat(MAX_AUTO_CONTEXT_CHARACTERS + 1_000),
+        MAX_AUTO_CONTEXT_CHARACTERS
+      ).length
+    ).toBeLessThanOrEqual(MAX_AUTO_CONTEXT_CHARACTERS);
+  });
+
+  it("truncates at a complete snippet and closes an open code fence", () => {
+    const firstSnippet = `### First\n\n\`\`\`ts\n${"a".repeat(40)}\n\`\`\``;
+    const secondSnippet = `### Second\n\n\`\`\`ts\n${"b".repeat(200)}\n\`\`\``;
+    const output = truncateDocumentationContext(
+      `${firstSnippet}\n\n--------------------------------\n\n${secondSnippet}`,
+      170
+    );
+    expect(output).toContain("### First");
+    expect(output).not.toContain("### Second");
+    expect((output.match(/```/g)?.length ?? 0) % 2).toBe(0);
+  });
+
+  it("uses one Search API request and reads selected-library metadata", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response("## Documentation", {
+          headers: {
+            "X-Context7-Library-Ids": "/vercel/next.js,/colinhacks/zod",
+            "X-Context7-Search-Status": "complete",
+            "X-Context7-Retryable": "false",
+            "X-Context7-Retry-Reason": "none",
+            "X-Context7-Suggested-Action": "none",
+          },
+        })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchAutoLibraryContext("Next.js with Zod")).resolves.toEqual({
+      data: "## Documentation",
+      libraryIds: ["/vercel/next.js", "/colinhacks/zod"],
+      status: "complete",
+      retryable: false,
+      retryReason: "none",
+      suggestedAction: "none",
+    });
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain(
+      "/v2/context/search?query=Next.js+with+Zod&type=txt"
+    );
+  });
+
+  it("forwards optional routing hints without adding a second request", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response("## Documentation", {
+          headers: {
+            "X-Context7-Library-Ids": "/vercel/next.js/v15",
+            "X-Context7-Search-Status": "complete",
+            "X-Context7-Retryable": "false",
+          },
+        })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchAutoLibraryContext(
+      "How does caching work?",
+      {},
+      { library: "nextjs", version: "15" }
+    );
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const url = new URL(String(fetchMock.mock.calls[0]?.[0]));
+    expect(url.searchParams.get("library")).toBe("nextjs");
+    expect(url.searchParams.get("version")).toBe("15");
+    expect(url.searchParams.has("libraryId")).toBe(false);
+  });
+
+  it("preserves terminal miss metadata so agents do not retry the same call", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json(
+          { message: "No documentation matched the request." },
+          {
+            status: 404,
+            headers: {
+              "X-Context7-Search-Status": "not-found",
+              "X-Context7-Retryable": "false",
+              "X-Context7-Retry-Reason": "no-relevant-documentation",
+              "X-Context7-Suggested-Action": "refine-query",
+            },
+          }
+        )
+      )
+    );
+
+    await expect(fetchAutoLibraryContext("unknown symbol")).resolves.toMatchObject({
+      error: "No documentation matched the request.",
+      status: "not-found",
+      retryable: false,
+      retryReason: "no-relevant-documentation",
+      suggestedAction: "refineQuery",
+    });
+  });
+
+  it("keeps gateway rate limits retryable when metadata headers are unavailable", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json({}, { status: 429 }))
+    );
+
+    await expect(fetchAutoLibraryContext("Next.js caching")).resolves.toMatchObject({
+      retryable: true,
+    });
+  });
+});

--- a/packages/mcp/test/auto-context.test.ts
+++ b/packages/mcp/test/auto-context.test.ts
@@ -92,9 +92,13 @@ describe("automatic context response controls", () => {
     const fetchMock = vi.fn(async () => new Response("## Documentation"));
     vi.stubGlobal("fetch", fetchMock);
 
-    await fetchAutoLibraryContext("Compare esbuild and Bun bundling commands", {}, {
-      libraries: ["esbuild", "Bun"],
-    });
+    await fetchAutoLibraryContext(
+      "Compare esbuild and Bun bundling commands",
+      {},
+      {
+        libraries: ["esbuild", "Bun"],
+      }
+    );
 
     expect(fetchMock).toHaveBeenCalledOnce();
     const url = new URL(String(fetchMock.mock.calls[0]?.[0]));

--- a/packages/mcp/test/integration.test.ts
+++ b/packages/mcp/test/integration.test.ts
@@ -55,7 +55,42 @@ function startStubApi(): Promise<string> {
     const url = new URL(req.url!, "http://stub.local");
     const apiPath = url.pathname.replace(/^\/api/, "");
     requests.push({ path: apiPath, query: url.searchParams, headers: req.headers });
-    if (apiPath === "/v2/libs/search") {
+    if (apiPath === "/v2/context/search") {
+      const query = url.searchParams.get("query") ?? "";
+      if (query.includes("temporary search failure")) {
+        res.statusCode = 503;
+        res.setHeader("Content-Type", "application/json");
+        res.setHeader("X-Context7-Search-Status", "failed");
+        res.setHeader("X-Context7-Retryable", "true");
+        res.setHeader("X-Context7-Retry-Reason", "transient-search-failure");
+        res.setHeader("X-Context7-Suggested-Action", "retry-later");
+        res.end(JSON.stringify({ message: "The documentation search could not be completed." }));
+        return;
+      }
+      if (query.includes("Acme Quantum Router")) {
+        res.statusCode = 404;
+        res.setHeader("Content-Type", "application/json");
+        res.setHeader("X-Context7-Search-Status", "not-found");
+        res.setHeader("X-Context7-Retryable", "false");
+        res.setHeader("X-Context7-Retry-Reason", "no-matching-library");
+        res.setHeader("X-Context7-Suggested-Action", "check-library-or-version");
+        res.end(JSON.stringify({ message: "No documentation library matched the request." }));
+        return;
+      }
+      const explicitIds = query.includes("/vercel/next.js") && query.includes("/facebook/react");
+      const libraryIds = explicitIds
+        ? "/vercel/next.js,/facebook/react"
+        : url.searchParams.get("version")
+          ? "/vercel/next.js/v15"
+          : "/vercel/next.js";
+      res.setHeader("Content-Type", "text/plain");
+      res.setHeader("X-Context7-Library-Ids", libraryIds);
+      res.setHeader("X-Context7-Search-Status", "complete");
+      res.setHeader("X-Context7-Retryable", "false");
+      res.setHeader("X-Context7-Retry-Reason", "none");
+      res.setHeader("X-Context7-Suggested-Action", "none");
+      res.end(`## Documentation for ${libraryIds.split(",")[0]}\n\n${STUB_DOCS}`);
+    } else if (apiPath === "/v2/libs/search") {
       res.setHeader("Content-Type", "application/json");
       res.end(
         JSON.stringify({
@@ -414,6 +449,92 @@ describe.each([
         : { ide: "test-harness", version: "1.0.0" };
     expect(apiCall.headers["x-context7-client-ide"]).toBe(expected.ide);
     expect(apiCall.headers["x-context7-client-version"]).toBe(expected.version);
+  });
+});
+
+describe("single Search API tool mode", () => {
+  let client: Client;
+
+  beforeAll(async () => {
+    client = new Client({ name: "single-tool-test", version: "1.0.0" });
+    await client.connect(
+      new StdioClientTransport({
+        command: process.execPath,
+        args: [DIST, "--tool-mode", "single"],
+        env: childEnv,
+      })
+    );
+  }, 15_000);
+
+  afterAll(async () => {
+    await client.close();
+  });
+
+  beforeEach(() => {
+    requests.length = 0;
+  });
+
+  test("exposes one tool with optional routing hints", async () => {
+    const { tools } = await client.listTools();
+    expect(tools.map((tool) => tool.name)).toEqual(["query-docs"]);
+    expect(Object.keys(tools[0].inputSchema.properties ?? {})).toEqual([
+      "query",
+      "library",
+      "libraryId",
+      "version",
+    ]);
+    expect(tools[0].inputSchema.required).toEqual(["query"]);
+  });
+
+  test("selects and retrieves documentation in one backend request", async () => {
+    const query = "How does the Next.js app router work?";
+    const result = await client.callTool({ name: "query-docs", arguments: { query } });
+
+    expect(result.isError).toBeFalsy();
+    expect((result.content as Array<{ type: string; text: string }>)[0].text).toContain(
+      "Selected library: /vercel/next.js"
+    );
+    expect(requests.map((request) => request.path)).toEqual(["/v2/context/search"]);
+    expect(requests[0].query.get("query")).toBe(query);
+  });
+
+  test("forwards fuzzy library and version hints in the same request", async () => {
+    const result = await client.callTool({
+      name: "query-docs",
+      arguments: { query: "How does caching work?", library: "nextjs", version: "15" },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(requests.map((request) => request.path)).toEqual(["/v2/context/search"]);
+    expect(requests[0].query.get("library")).toBe("nextjs");
+    expect(requests[0].query.get("version")).toBe("15");
+    expect((result.content as Array<{ type: string; text: string }>)[0].text).toContain(
+      "Selected library: /vercel/next.js/v15"
+    );
+  });
+
+  test("does not turn terminal misses into retry loops", async () => {
+    const result = await client.callTool({
+      name: "query-docs",
+      arguments: { query: "Configure the Acme Quantum Router flux capacitor" },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain("No documentation library matched the request");
+    expect(text).toContain("Do not repeat the identical request");
+  });
+
+  test("marks transient failures as retryable MCP tool errors", async () => {
+    const result = await client.callTool({
+      name: "query-docs",
+      arguments: { query: "temporary search failure" },
+    });
+
+    expect(result.isError).toBe(true);
+    expect((result.content as Array<{ type: string; text: string }>)[0].text).toContain(
+      "Retry the same request later"
+    );
   });
 });
 

--- a/packages/mcp/test/integration.test.ts
+++ b/packages/mcp/test/integration.test.ts
@@ -479,8 +479,8 @@ describe("single Search API tool mode", () => {
     expect(tools.map((tool) => tool.name)).toEqual(["query-docs"]);
     expect(Object.keys(tools[0].inputSchema.properties ?? {})).toEqual([
       "query",
-      "library",
-      "libraryId",
+      "libraries",
+      "libraryIds",
       "version",
     ]);
     expect(tools[0].inputSchema.required).toEqual(["query"]);
@@ -501,7 +501,7 @@ describe("single Search API tool mode", () => {
   test("forwards fuzzy library and version hints in the same request", async () => {
     const result = await client.callTool({
       name: "query-docs",
-      arguments: { query: "How does caching work?", library: "nextjs", version: "15" },
+      arguments: { query: "How does caching work?", libraries: ["nextjs"], version: "15" },
     });
 
     expect(result.isError).toBeFalsy();

--- a/packages/mcp/test/integration.test.ts
+++ b/packages/mcp/test/integration.test.ts
@@ -513,6 +513,23 @@ describe("single Search API tool mode", () => {
     );
   });
 
+  test("accepts multiple fuzzy package hints with shared version context", async () => {
+    const query = "In Prisma ORM 7, configure prisma-client with @prisma/adapter-pg";
+    const result = await client.callTool({
+      name: "query-docs",
+      arguments: {
+        query,
+        libraries: ["Prisma ORM", "@prisma/adapter-pg"],
+        version: "7",
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(requests.map((request) => request.path)).toEqual(["/v2/context/search"]);
+    expect(requests[0].query.getAll("library")).toEqual(["Prisma ORM", "@prisma/adapter-pg"]);
+    expect(requests[0].query.get("version")).toBe("7");
+  });
+
   test("does not turn terminal misses into retry loops", async () => {
     const result = await client.callTool({
       name: "query-docs",


### PR DESCRIPTION
## Summary

- adds an opt-in `single` MCP tool mode backed by `GET /api/v2/context/search`
- exposes one `query-docs` tool with `query`, optional `libraries: string[]`, and optional `version`
- keeps the existing two-tool mode as the default
- preserves fuzzy names and exact Context7 IDs in one non-duplicated library list

## Tool flow

1. The agent sends the complete question once, retaining every named product, version, and concept.
2. Optional library hints are forwarded together in one backend request; they are not split into parallel public tool calls.
3. The backend selects and searches bounded library namespaces, merges their evidence, and returns the chosen library IDs with the documentation.
4. Terminal misses remain successful MCP responses with guidance not to repeat the same request. Explicit transient failures are MCP errors and may be retried once later.

The endpoint algorithm and benchmark rationale are documented in:

- https://github.com/upstash/context7app/pull/1163
- https://github.com/upstash/context7benchmark/pull/19

## Verification

- merged current `master` and resolved the telemetry overlap without removing either feature
- type-check passed
- lint passed
- build passed
- 137/137 tests passed locally
- GitHub test check passed

Closes CTX7-2712
