### PR TITLE
fix(cli): keep unrelated AGENTS.md content intact on remove

### DIFF
--- a/.changeset/remove-rule-section-seam.md
+++ b/.changeset/remove-rule-section-seam.md
@@ -1,0 +1,5 @@
+---
+"ctx7": patch
+---
+
+Keep the rest of AGENTS.md / GEMINI.md untouched when `ctx7 remove` deletes the Context7 rule section; only the seam left by the removed section is normalized.

--- a/packages/cli/src/__tests__/remove.test.ts
+++ b/packages/cli/src/__tests__/remove.test.ts
@@ -91,6 +91,36 @@ describe("remove command", () => {
     });
   });
 
+  test("removing the AGENTS.md section leaves the rest of the file untouched", async () => {
+    const agentsPath = join(tempDir, "AGENTS.md");
+    const own = "# Project rules\n\n```text\nline a\n\n\nline b\n```\n\n\n## Team notes\n\n";
+    const tail = "## Tail section\n";
+    await writeFile(
+      agentsPath,
+      `${own}<!-- context7 -->\nrule body\n<!-- context7 -->\n\n${tail}`,
+      "utf-8"
+    );
+
+    await runCommand("remove", "--codex", "--cli", "--project");
+
+    // Blank lines inside the fenced block and between the user's own sections
+    // are not ours to normalize; only the seam of the removed section is.
+    expect(await readFile(agentsPath, "utf-8")).toBe(`${own}${tail}`);
+  });
+
+  test("removing a trailing AGENTS.md section keeps the preceding content", async () => {
+    const agentsPath = join(tempDir, "AGENTS.md");
+    await writeFile(
+      agentsPath,
+      "# Before\n\nkeep   \n\n<!-- context7 -->\nrule body\n<!-- context7 -->\n",
+      "utf-8"
+    );
+
+    await runCommand("remove", "--codex", "--cli", "--project");
+
+    expect(await readFile(agentsPath, "utf-8")).toBe("# Before\n\nkeep   \n");
+  });
+
   test("removes only MCP artifacts for codex project setup", async () => {
     const agentsPath = join(tempDir, "AGENTS.md");
     const tomlPath = join(tempDir, ".codex", "config.toml");

--- a/packages/cli/src/commands/remove.ts
+++ b/packages/cli/src/commands/remove.ts
@@ -368,11 +368,20 @@ async function uninstallRule(agentName: SetupAgent, scope: Scope): Promise<Clean
     }
 
     const escapedMarker = CONTEXT7_SECTION_MARKER.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    const updated = existing
-      .replace(new RegExp(`\\n?${escapedMarker}\\n[\\s\\S]*?${escapedMarker}\\n?`, "m"), "")
-      .replace(/\n{3,}/g, "\n\n")
-      .replace(/^\n+/, "")
-      .trimEnd();
+    const section = new RegExp(`${escapedMarker}\\n[\\s\\S]*?${escapedMarker}`).exec(existing);
+    if (!section) {
+      return { status: "not found", path: filePath };
+    }
+
+    // Only the seam left by the removed section is normalized; everything else in
+    // the file is the user's own content and must stay byte-for-byte identical
+    // (blank lines inside fenced code blocks, spacing between their sections).
+    const before = existing.slice(0, section.index).replace(/\n+$/, "");
+    const after = existing.slice(section.index + section[0].length).replace(/^\n+/, "");
+    const updated = (before && after ? `${before}\n\n${after}` : before || after).replace(
+      /\n*$/,
+      ""
+    );
 
     if (updated.length === 0) {
       await rm(filePath);


### PR DESCRIPTION
## Summary

`ctx7 remove` for the append-style rule files (`AGENTS.md`, `GEMINI.md`) cut the `<!-- context7 -->` section and then ran `.replace(/\n{3,}/g, "\n\n").replace(/^\n+/, "")` on the **whole file**. That silently rewrote content the CLI never added: two blank lines inside a fenced code block were collapsed, and the spacing between the user's own sections changed.

This PR normalizes only the seam left by the removed section (at most one blank line between the surrounding content, a single trailing newline) and leaves everything else byte for byte as it was. The section lookup itself is unchanged.

Before / after for

````
# Project rules

```text
line a


line b
```


## Team notes

<!-- context7 -->
…
<!-- context7 -->

## Tail section
````

- before this PR: the blank lines inside the code block and before `## Team notes` are collapsed
- after this PR: only the Context7 section is gone, the rest is identical

## Tests

Two cases added to `packages/cli/src/__tests__/remove.test.ts`: the file above is compared with `toBe` against the expected byte-identical result, and a trailing section removal keeps the preceding content (including trailing spaces on the user's lines).

```
pnpm --filter ./packages/cli test    # 19 files, 370 tests
pnpm lint:check / typecheck          # clean
```

Changeset: `ctx7` patch.
