### PR TITLE
fix(cli): honor --output for skills generate inside the home directory

### DIFF
--- a/.changeset/generate-output-dir.md
+++ b/.changeset/generate-output-dir.md
@@ -1,0 +1,5 @@
+---
+"ctx7": patch
+---
+
+Honor `ctx7 skills generate --output <dir>` for projects inside the home directory; the option was silently ignored there and the skill was written into the project instead.

--- a/packages/cli/src/__tests__/target-dirs.test.ts
+++ b/packages/cli/src/__tests__/target-dirs.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "vitest";
+import { homedir } from "os";
+import { join } from "path";
+import { getTargetDirs } from "../utils/ide.js";
+
+describe("getTargetDirs", () => {
+  test("project directories default to the current working directory", () => {
+    const dirs = getTargetDirs({ ides: ["claude", "universal"], scopes: ["project"] });
+
+    expect(dirs).toEqual([
+      join(process.cwd(), ".agents/skills"),
+      join(process.cwd(), ".claude/skills"),
+    ]);
+  });
+
+  test("an explicit project directory replaces the cwd, also when cwd is under $HOME", () => {
+    const out = join(homedir(), "some", "other", "place");
+
+    const dirs = getTargetDirs({ ides: ["claude", "universal"], scopes: ["project"] }, out);
+
+    expect(dirs).toEqual([join(out, ".agents/skills"), join(out, ".claude/skills")]);
+  });
+
+  test("global directories stay under the home directory regardless of the project directory", () => {
+    const dirs = getTargetDirs({ ides: ["cursor"], scopes: ["global", "project"] }, "/srv/app");
+
+    expect(dirs).toEqual([join(homedir(), ".cursor/skills"), join("/srv/app", ".cursor/skills")]);
+  });
+});

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -2,8 +2,7 @@ import { Command } from "commander";
 import pc from "picocolors";
 import ora from "ora";
 import { mkdir, writeFile, readFile, unlink } from "fs/promises";
-import { join } from "path";
-import { homedir } from "os";
+import { join, resolve } from "path";
 import { spawn } from "child_process";
 import { input, select } from "@inquirer/prompts";
 
@@ -506,7 +505,9 @@ async function generateCommand(options: GenerateOptions): Promise<void> {
     return;
   }
 
-  const targetDirs = getTargetDirs(targets);
+  // --output replaces the project as the base of project-scoped skill
+  // directories; global ones stay under the home directory.
+  const targetDirs = getTargetDirs(targets, options.output ? resolve(options.output) : undefined);
 
   const writeSpinner = ora("Writing skill files...").start();
 
@@ -514,11 +515,7 @@ async function generateCommand(options: GenerateOptions): Promise<void> {
   const failedDirs: Set<string> = new Set();
 
   for (const targetDir of targetDirs) {
-    let finalDir = targetDir;
-    if (options.output && !targetDir.includes("/.config/") && !targetDir.startsWith(homedir())) {
-      finalDir = targetDir.replace(process.cwd(), options.output);
-    }
-    const skillDir = join(finalDir, skillName);
+    const skillDir = join(targetDir, skillName);
     const skillPath = join(skillDir, "SKILL.md");
 
     try {

--- a/packages/cli/src/utils/ide.ts
+++ b/packages/cli/src/utils/ide.ts
@@ -256,12 +256,22 @@ export async function promptForSingleTarget(
   return { ide: selectedIde, scope: selectedScope };
 }
 
-export function getTargetDirs(targets: InstallTargets): string[] {
+/**
+ * Resolve the skill directories for the selected agents and scopes.
+ *
+ * `projectDir` is the base for project-scoped directories (defaults to the
+ * current working directory); global directories always live under the home
+ * directory, wherever the project is.
+ */
+export function getTargetDirs(
+  targets: InstallTargets,
+  projectDir: string = process.cwd()
+): string[] {
   const hasUniversal = targets.ides.some((ide) => ide === "universal");
   const dirs: string[] = [];
 
   for (const scope of targets.scopes) {
-    const baseDir = scope === "global" ? homedir() : process.cwd();
+    const baseDir = scope === "global" ? homedir() : projectDir;
 
     if (hasUniversal) {
       const uniPath = scope === "global" ? UNIVERSAL_SKILLS_GLOBAL_PATH : UNIVERSAL_SKILLS_PATH;


### PR DESCRIPTION
## Summary

`ctx7 skills generate --output <dir>` was silently ignored for any project located under the home directory, which is the usual case. The redirect in `generate.ts` skipped every target directory that starts with `homedir()` to leave global skill directories alone, but project directories come from `process.cwd()`, so `/Users/me/dev/app/.claude/skills` was skipped too and the skill landed in the project instead of the requested directory. The option only worked for projects outside `$HOME` (for example `/srv/app`).

Change:

- `getTargetDirs(targets, projectDir = process.cwd())` takes the base for project-scoped directories; global directories always stay under the home directory
- `generate.ts` passes `resolve(options.output)` as that base when `--output` is given, and no longer rewrites paths with `String.replace` (which also treated `$&` style patterns in the option value specially)
- the "Skill saved successfully" summary now lists the directories that were actually written; before it printed the unredirected ones

## Tests

New `packages/cli/src/__tests__/target-dirs.test.ts` covers the default base, an explicit project directory under `$HOME`, and that global directories are unaffected by the project directory.

```
pnpm --filter ./packages/cli test    # 20 files, 371 tests
pnpm lint:check / typecheck          # clean
```

Changeset: `ctx7` patch.
