### PR TITLE
fix(mcp): gate every spelling of the OAuth endpoint

### DIFF
--- a/.changeset/oauth-route-spelling.md
+++ b/.changeset/oauth-route-spelling.md
@@ -1,0 +1,5 @@
+---
+"@upstash/context7-mcp": patch
+---
+
+Apply the OAuth endpoint's authentication requirement to every spelling Express routes to it (`/mcp/oauth/`, `/MCP/OAUTH`), not only the exact `/mcp/oauth`.

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -54,7 +54,10 @@ function getPluginFromRequest(req: express.Request): typeof CLAUDE_CODE_PLUGIN |
 
 function requiresAuthentication(req: express.Request, plugin?: typeof CLAUDE_CODE_PLUGIN): boolean {
   // The MCP routes live on a router mounted at /mcp, so req.path is relative to it.
-  const isOAuthEndpoint = `${req.baseUrl}${req.path}` === "/mcp/oauth";
+  // Express routes "/mcp/oauth/" and "/MCP/OAUTH" to the same handler but keeps the
+  // request's spelling here, so compare the canonical form (as mcpRouteFromUrl does).
+  const isOAuthEndpoint =
+    `${req.baseUrl}${req.path}`.replace(/\/+$/, "").toLowerCase() === "/mcp/oauth";
   // The current official Claude plugin expands an unset API key to an empty header.
   const hasEmptyPluginAuthorization =
     plugin === CLAUDE_CODE_PLUGIN && req.headers.authorization === "";

--- a/packages/mcp/test/integration.test.ts
+++ b/packages/mcp/test/integration.test.ts
@@ -756,6 +756,15 @@ describe("plugin authentication", () => {
     expect(emptyHeaderRes.status).toBe(401);
   });
 
+  test("protects every spelling Express routes to the OAuth endpoint", async () => {
+    // Express matches routes case-insensitively and with an optional trailing
+    // slash; the gate must not depend on the request's spelling.
+    for (const spelling of ["/mcp/oauth/", "/MCP/OAUTH", "/Mcp/OAuth/"]) {
+      const url = httpUrl.replace(/\/mcp$/, spelling);
+      expect((await postMcp(url)).status, spelling).toBe(401);
+    }
+  });
+
   test("tracks authenticated plugin requests separately", async () => {
     const client = new Client(
       { name: "claude-code", version: "1.0.0" },


### PR DESCRIPTION
## Summary

`requiresAuthentication` in `packages/mcp/src/index.ts` decides whether a request hits the protected OAuth endpoint with an exact string compare against `/mcp/oauth`. Express 5 routes case-insensitively and with an optional trailing slash, but `req.baseUrl` and `req.path` keep the request's spelling. So `/mcp/oauth/`, `/MCP/OAUTH` or `/Mcp/OAuth/` reach the same `mcpRouter.all("/oauth")` handler while the gate says "not the OAuth endpoint", and those requests are served like the anonymous `/mcp` route instead of getting the 401 challenge.

The telemetry layer already treats both spellings as the OAuth route (`mcpRouteFromUrl` strips trailing slashes and lowercases, see the test "labels both protected Express route spellings as OAuth"), so the two layers disagreed. This PR applies the same normalization in the gate:

```ts
const isOAuthEndpoint =
  `${req.baseUrl}${req.path}`.replace(/\/+$/, "").toLowerCase() === "/mcp/oauth";
```

No routing changes, no behaviour change for `/mcp` or for the exact `/mcp/oauth` spelling.

## Tests

New integration test "protects every spelling Express routes to the OAuth endpoint" posts an `initialize` request without credentials to `/mcp/oauth/`, `/MCP/OAUTH` and `/Mcp/OAuth/` against the built server and expects 401 for each. It fails on `master` (`/mcp/oauth/: expected 200 to be 401`) and passes with the fix.

```
pnpm --filter @upstash/context7-mcp build && pnpm --filter @upstash/context7-mcp test
Test Files 11 passed, Tests 127 passed
lint / typecheck clean
```

Changeset: `@upstash/context7-mcp` patch.
