### PR TITLE
fix(mcp): strip the bearer auth-scheme case-insensitively

### DIFF
--- a/.changeset/bearer-scheme-case.md
+++ b/.changeset/bearer-scheme-case.md
@@ -1,0 +1,5 @@
+---
+"@upstash/context7-mcp": patch
+---
+
+Accept the `Authorization` auth-scheme in any casing (`bearer`, `BEARER`); the lowercase spelling was forwarded as part of the credential and rejected upstream.

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -394,8 +394,12 @@ async function main() {
       const header = extractHeaderValue(authHeader);
       if (!header) return undefined;
 
-      if (header.startsWith("Bearer ")) {
-        return header.substring(7).trim();
+      // The auth-scheme is case-insensitive (RFC 9110 section 11.1): some clients
+      // and proxies send "bearer" or "BEARER". Strip it in any casing, otherwise
+      // the scheme ends up inside the forwarded credential.
+      const bearer = /^bearer\s+(.*)$/i.exec(header);
+      if (bearer) {
+        return bearer[1].trim();
       }
 
       return header;

--- a/packages/mcp/test/integration.test.ts
+++ b/packages/mcp/test/integration.test.ts
@@ -358,6 +358,33 @@ describe("HTTP API key headers", () => {
       await client.close();
     }
   });
+
+  test.each(["bearer", "BEARER"])(
+    "accepts the %s auth-scheme spelling without forwarding it as part of the key",
+    async (scheme) => {
+      const apiKey = "ctx7sk-scheme-case-test";
+      const client = new Client({ name: "auth-scheme-case-test", version: "1.0.0" });
+
+      await client.connect(
+        new StreamableHTTPClientTransport(new URL(httpUrl), {
+          requestInit: { headers: { Authorization: `${scheme} ${apiKey}` } },
+        })
+      );
+
+      try {
+        requests.length = 0;
+        await client.callTool({
+          name: "query-docs",
+          arguments: { libraryId: "/vercel/next.js", query: "app router" },
+        });
+
+        const apiCall = requests.find((request) => request.path === "/v2/context");
+        expect(apiCall?.headers.authorization).toBe(`Bearer ${apiKey}`);
+      } finally {
+        await client.close();
+      }
+    }
+  );
 });
 
 describe.each([


### PR DESCRIPTION
## Summary

`extractBearerToken` in `packages/mcp/src/index.ts` only recognized the exact `Bearer ` prefix and otherwise returned the whole header value as the credential. The HTTP auth-scheme is case-insensitive (RFC 9110, section 11.1), and some clients and proxies send `bearer <key>` or `BEARER <key>`. Two things went wrong for them:

- API key path: the upstream request to the Context7 API carried `Authorization: Bearer bearer ctx7sk-…`, so the user got an "invalid API key" from the backend with no hint why
- OAuth path: `isJWT("bearer eyJ…")` is still true, so `validateJWT` received the scheme plus token and a valid JWT was rejected as "Invalid token"

The scheme is now matched case-insensitively and stripped in any casing; everything else about header handling is unchanged (the raw-header fallback stays for clients that send a bare key).

```ts
const bearer = /^bearer\s+(.*)$/i.exec(header);
if (bearer) return bearer[1].trim();
```

## Tests

Added to the "HTTP API key headers" block in `test/integration.test.ts`: a client connects with `Authorization: bearer <key>` and `BEARER <key>`, calls `query-docs`, and the recorded upstream request must carry `Bearer <key>`. On `master` both cases fail with `expected 'Bearer bearer ctx7sk-…' to be 'Bearer ctx7sk-…'`.

```
pnpm --filter @upstash/context7-mcp build && pnpm --filter @upstash/context7-mcp test
Test Files 11 passed, Tests 127 passed
lint / typecheck clean
```

Changeset: `@upstash/context7-mcp` patch.
